### PR TITLE
Create pipeline scafolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ version = "0.1.0"
 dependencies = [
  "flat_serialize_macro",
  "ordered-float",
+ "serde",
 ]
 
 [[package]]

--- a/crates/flat_serialize/example_generated.rs
+++ b/crates/flat_serialize/example_generated.rs
@@ -1,4 +1,6 @@
-#[derive(Copy, Clone, Debug)]
+#![allow(unused_imports)]
+use crate as flat_serialize;
+#[derive(Clone, Debug)]
 pub struct Basic<'input> {
     pub header: u64,
     pub data_len: u32,
@@ -286,7 +288,7 @@ unsafe impl<'input> flat_serialize::FlatSerializable<'input> for Basic<'input> {
     ) -> &'out mut [std::mem::MaybeUninit<u8>] {
         let total_len = self.len();
         let (mut input, rem) = input.split_at_mut(total_len);
-        let &Basic {
+        let Basic {
             header,
             data_len,
             array,
@@ -303,12 +305,12 @@ unsafe impl<'input> flat_serialize::FlatSerializable<'input> for Basic<'input> {
             input = array.fill_slice(input);
         };
         unsafe {
-            let count = (data_len) as usize;
-            input = <_ as flat_serialize::Slice<'_>>::fill_slice(&data, count, input);
+            let count = (*data_len) as usize;
+            input = <_ as flat_serialize::Slice<'_>>::fill_slice(data, count, input);
         };
         unsafe {
-            let count = ((data_len) / 3) as usize;
-            input = <_ as flat_serialize::Slice<'_>>::fill_slice(&data2, count, input);
+            let count = ((*data_len) / 3) as usize;
+            input = <_ as flat_serialize::Slice<'_>>::fill_slice(data2, count, input);
         }
         debug_assert_eq!(input.len(), 0);
         rem
@@ -316,7 +318,7 @@ unsafe impl<'input> flat_serialize::FlatSerializable<'input> for Basic<'input> {
     #[allow(unused_assignments, unused_variables)]
     #[inline(always)]
     fn len(&self) -> usize {
-        let &Basic {
+        let Basic {
             header,
             data_len,
             array,
@@ -324,14 +326,14 @@ unsafe impl<'input> flat_serialize::FlatSerializable<'input> for Basic<'input> {
             data2,
         } = self;
         0usize
-            + <u64 as flat_serialize::FlatSerializable>::len(&header)
-            + <u32 as flat_serialize::FlatSerializable>::len(&data_len)
-            + <[u16; 3] as flat_serialize::FlatSerializable>::len(&array)
-            + (<_ as flat_serialize::Slice<'_>>::len(&data, (data_len) as usize))
-            + (<_ as flat_serialize::Slice<'_>>::len(&data2, ((data_len) / 3) as usize))
+            + <u64 as flat_serialize::FlatSerializable>::len(header)
+            + <u32 as flat_serialize::FlatSerializable>::len(data_len)
+            + <[u16; 3] as flat_serialize::FlatSerializable>::len(array)
+            + (<_ as flat_serialize::Slice<'_>>::len(data, (*data_len) as usize))
+            + (<_ as flat_serialize::Slice<'_>>::len(data2, ((*data_len) / 3) as usize))
     }
 }
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Optional {
     pub header: u64,
     pub optional_field: Option<u32>,
@@ -535,7 +537,7 @@ unsafe impl<'a> flat_serialize::FlatSerializable<'a> for Optional {
     ) -> &'out mut [std::mem::MaybeUninit<u8>] {
         let total_len = self.len();
         let (mut input, rem) = input.split_at_mut(total_len);
-        let &Optional {
+        let Optional {
             header,
             optional_field,
             non_optional_field,
@@ -544,7 +546,7 @@ unsafe impl<'a> flat_serialize::FlatSerializable<'a> for Optional {
             input = header.fill_slice(input);
         };
         unsafe {
-            if (header) != 1 {
+            if (*header) != 1 {
                 let optional_field: &u32 = optional_field.as_ref().unwrap();
                 input = optional_field.fill_slice(input);
             }
@@ -558,22 +560,22 @@ unsafe impl<'a> flat_serialize::FlatSerializable<'a> for Optional {
     #[allow(unused_assignments, unused_variables)]
     #[inline(always)]
     fn len(&self) -> usize {
-        let &Optional {
+        let Optional {
             header,
             optional_field,
             non_optional_field,
         } = self;
         0usize
-            + <u64 as flat_serialize::FlatSerializable>::len(&header)
-            + (if (header) != 1 {
+            + <u64 as flat_serialize::FlatSerializable>::len(header)
+            + (if (*header) != 1 {
                 <u32 as flat_serialize::FlatSerializable>::len(optional_field.as_ref().unwrap())
             } else {
                 0
             })
-            + <u16 as flat_serialize::FlatSerializable>::len(&non_optional_field)
+            + <u16 as flat_serialize::FlatSerializable>::len(non_optional_field)
     }
 }
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct Nested<'a> {
     pub prefix: u64,
     pub basic: Basic<'a>,
@@ -719,7 +721,7 @@ unsafe impl<'a> flat_serialize::FlatSerializable<'a> for Nested<'a> {
     ) -> &'out mut [std::mem::MaybeUninit<u8>] {
         let total_len = self.len();
         let (mut input, rem) = input.split_at_mut(total_len);
-        let &Nested { prefix, basic } = self;
+        let Nested { prefix, basic } = self;
         unsafe {
             input = prefix.fill_slice(input);
         };
@@ -732,13 +734,13 @@ unsafe impl<'a> flat_serialize::FlatSerializable<'a> for Nested<'a> {
     #[allow(unused_assignments, unused_variables)]
     #[inline(always)]
     fn len(&self) -> usize {
-        let &Nested { prefix, basic } = self;
+        let Nested { prefix, basic } = self;
         0usize
-            + <u64 as flat_serialize::FlatSerializable>::len(&prefix)
-            + <Basic as flat_serialize::FlatSerializable>::len(&basic)
+            + <u64 as flat_serialize::FlatSerializable>::len(prefix)
+            + <Basic as flat_serialize::FlatSerializable>::len(basic)
     }
 }
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct NestedOptional {
     pub present: u64,
     pub val: Option<Optional>,
@@ -903,12 +905,12 @@ unsafe impl<'a> flat_serialize::FlatSerializable<'a> for NestedOptional {
     ) -> &'out mut [std::mem::MaybeUninit<u8>] {
         let total_len = self.len();
         let (mut input, rem) = input.split_at_mut(total_len);
-        let &NestedOptional { present, val } = self;
+        let NestedOptional { present, val } = self;
         unsafe {
             input = present.fill_slice(input);
         };
         unsafe {
-            if (present) > 2 {
+            if (*present) > 2 {
                 let val: &Optional = val.as_ref().unwrap();
                 input = val.fill_slice(input);
             }
@@ -919,17 +921,17 @@ unsafe impl<'a> flat_serialize::FlatSerializable<'a> for NestedOptional {
     #[allow(unused_assignments, unused_variables)]
     #[inline(always)]
     fn len(&self) -> usize {
-        let &NestedOptional { present, val } = self;
+        let NestedOptional { present, val } = self;
         0usize
-            + <u64 as flat_serialize::FlatSerializable>::len(&present)
-            + (if (present) > 2 {
+            + <u64 as flat_serialize::FlatSerializable>::len(present)
+            + (if (*present) > 2 {
                 <Optional as flat_serialize::FlatSerializable>::len(val.as_ref().unwrap())
             } else {
                 0
             })
     }
 }
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct NestedSlice<'b> {
     pub num_vals: u64,
     pub vals: <Optional as flat_serialize::FlatSerializable<'b>>::SLICE,
@@ -1085,13 +1087,13 @@ unsafe impl<'b> flat_serialize::FlatSerializable<'b> for NestedSlice<'b> {
     ) -> &'out mut [std::mem::MaybeUninit<u8>] {
         let total_len = self.len();
         let (mut input, rem) = input.split_at_mut(total_len);
-        let &NestedSlice { num_vals, vals } = self;
+        let NestedSlice { num_vals, vals } = self;
         unsafe {
             input = num_vals.fill_slice(input);
         };
         unsafe {
-            let count = (num_vals) as usize;
-            input = <_ as flat_serialize::Slice<'_>>::fill_slice(&vals, count, input);
+            let count = (*num_vals) as usize;
+            input = <_ as flat_serialize::Slice<'_>>::fill_slice(vals, count, input);
         }
         debug_assert_eq!(input.len(), 0);
         rem
@@ -1099,13 +1101,13 @@ unsafe impl<'b> flat_serialize::FlatSerializable<'b> for NestedSlice<'b> {
     #[allow(unused_assignments, unused_variables)]
     #[inline(always)]
     fn len(&self) -> usize {
-        let &NestedSlice { num_vals, vals } = self;
+        let NestedSlice { num_vals, vals } = self;
         0usize
-            + <u64 as flat_serialize::FlatSerializable>::len(&num_vals)
-            + (<_ as flat_serialize::Slice<'_>>::len(&vals, (num_vals) as usize))
+            + <u64 as flat_serialize::FlatSerializable>::len(num_vals)
+            + (<_ as flat_serialize::Slice<'_>>::len(vals, (*num_vals) as usize))
     }
 }
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub enum BasicEnum<'input> {
     First {
         data_len: u32,
@@ -1469,7 +1471,7 @@ unsafe impl<'input> flat_serialize::FlatSerializable<'input> for BasicEnum<'inpu
         let total_len = self.len();
         let (mut input, rem) = input.split_at_mut(total_len);
         match self {
-            &BasicEnum::First { data_len, data } => {
+            BasicEnum::First { data_len, data } => {
                 let k: &u64 = &2;
                 unsafe {
                     input = k.fill_slice(input);
@@ -1478,11 +1480,11 @@ unsafe impl<'input> flat_serialize::FlatSerializable<'input> for BasicEnum<'inpu
                     input = data_len.fill_slice(input);
                 };
                 unsafe {
-                    let count = (data_len) as usize;
-                    input = <_ as flat_serialize::Slice<'_>>::fill_slice(&data, count, input);
+                    let count = (*data_len) as usize;
+                    input = <_ as flat_serialize::Slice<'_>>::fill_slice(data, count, input);
                 }
             }
-            &BasicEnum::Fixed { array } => {
+            BasicEnum::Fixed { array } => {
                 let k: &u64 = &3;
                 unsafe {
                     input = k.fill_slice(input);
@@ -1498,19 +1500,19 @@ unsafe impl<'input> flat_serialize::FlatSerializable<'input> for BasicEnum<'inpu
     #[allow(unused_assignments, unused_variables)]
     fn len(&self) -> usize {
         match self {
-            &BasicEnum::First { data_len, data } => {
+            BasicEnum::First { data_len, data } => {
                 ::std::mem::size_of::<u64>()
-                    + <u32 as flat_serialize::FlatSerializable>::len(&data_len)
-                    + (<_ as flat_serialize::Slice<'_>>::len(&data, (data_len) as usize))
+                    + <u32 as flat_serialize::FlatSerializable>::len(data_len)
+                    + (<_ as flat_serialize::Slice<'_>>::len(data, (*data_len) as usize))
             }
-            &BasicEnum::Fixed { array } => {
+            BasicEnum::Fixed { array } => {
                 ::std::mem::size_of::<u64>()
-                    + <[u16; 3] as flat_serialize::FlatSerializable>::len(&array)
+                    + <[u16; 3] as flat_serialize::FlatSerializable>::len(array)
             }
         }
     }
 }
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub enum PaddedEnum<'input> {
     First {
         padding: [u8; 3],
@@ -1957,7 +1959,7 @@ unsafe impl<'input> flat_serialize::FlatSerializable<'input> for PaddedEnum<'inp
         let total_len = self.len();
         let (mut input, rem) = input.split_at_mut(total_len);
         match self {
-            &PaddedEnum::First {
+            PaddedEnum::First {
                 padding,
                 data_len,
                 data,
@@ -1973,11 +1975,11 @@ unsafe impl<'input> flat_serialize::FlatSerializable<'input> for PaddedEnum<'inp
                     input = data_len.fill_slice(input);
                 };
                 unsafe {
-                    let count = (data_len) as usize;
-                    input = <_ as flat_serialize::Slice<'_>>::fill_slice(&data, count, input);
+                    let count = (*data_len) as usize;
+                    input = <_ as flat_serialize::Slice<'_>>::fill_slice(data, count, input);
                 }
             }
-            &PaddedEnum::Fixed { padding, array } => {
+            PaddedEnum::Fixed { padding, array } => {
                 let k: &u8 = &3;
                 unsafe {
                     input = k.fill_slice(input);
@@ -1996,20 +1998,20 @@ unsafe impl<'input> flat_serialize::FlatSerializable<'input> for PaddedEnum<'inp
     #[allow(unused_assignments, unused_variables)]
     fn len(&self) -> usize {
         match self {
-            &PaddedEnum::First {
+            PaddedEnum::First {
                 padding,
                 data_len,
                 data,
             } => {
                 ::std::mem::size_of::<u8>()
-                    + <[u8; 3] as flat_serialize::FlatSerializable>::len(&padding)
-                    + <u32 as flat_serialize::FlatSerializable>::len(&data_len)
-                    + (<_ as flat_serialize::Slice<'_>>::len(&data, (data_len) as usize))
+                    + <[u8; 3] as flat_serialize::FlatSerializable>::len(padding)
+                    + <u32 as flat_serialize::FlatSerializable>::len(data_len)
+                    + (<_ as flat_serialize::Slice<'_>>::len(data, (*data_len) as usize))
             }
-            &PaddedEnum::Fixed { padding, array } => {
+            PaddedEnum::Fixed { padding, array } => {
                 ::std::mem::size_of::<u8>()
-                    + <u8 as flat_serialize::FlatSerializable>::len(&padding)
-                    + <[u16; 3] as flat_serialize::FlatSerializable>::len(&array)
+                    + <u8 as flat_serialize::FlatSerializable>::len(padding)
+                    + <[u16; 3] as flat_serialize::FlatSerializable>::len(array)
             }
         }
     }

--- a/crates/flat_serialize/flat_serialize/Cargo.toml
+++ b/crates/flat_serialize/flat_serialize/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 ordered-float = "1.0"
+serde = "1.0"
 
 [dev-dependencies]
 flat_serialize_macro = {path="../flat_serialize_macro"}

--- a/extension/sql/load-order.txt
+++ b/extension/sql/load-order.txt
@@ -2,7 +2,6 @@ range.generated.sql
 tdigest.generated.sql
 hyperloglog.generated.sql
 uddsketch.generated.sql
-triggers.generated.sql
 time_weighted_average.generated.sql
 time_series.generated.sql
 lttb.generated.sql
@@ -10,6 +9,5 @@ asap.generated.sql
 counter_agg.generated.sql
 utilities.generated.sql
 stats_agg.generated.sql
-schema_test.generated.sql
-serialization_collations.generated.sql
-serialization_types.generated.sql
+time_series_pipeline.generated.sql
+triggers.generated.sql

--- a/extension/src/lttb.rs
+++ b/extension/src/lttb.rs
@@ -175,7 +175,10 @@ pub fn lttb_on_timeseries(
 }
 
 // based on https://github.com/jeromefroe/lttb-rs version 0.2.0
-pub fn lttb_ts (data: crate::time_series::toolkit_experimental::TimeSeries<'static>, threshold: usize)
+pub fn lttb_ts<'s>(
+    data: crate::time_series::toolkit_experimental::TimeSeries<'s>,
+    threshold: usize
+)
 -> crate::time_series::toolkit_experimental::TimeSeries<'static>
 {
     if !data.is_sorted() {
@@ -184,7 +187,7 @@ pub fn lttb_ts (data: crate::time_series::toolkit_experimental::TimeSeries<'stat
 
     if threshold >= data.num_points() || threshold == 0 {
         // Nothing to do.
-        return data.clone();  // can we avoid this copy???
+        return data.in_current_context();  // can we avoid this copy???
     }
 
     // let mut sampled = Vec::with_capacity(threshold);

--- a/extension/src/schema_test.rs
+++ b/extension/src/schema_test.rs
@@ -63,6 +63,12 @@ mod tests {
                             return None
                     }
 
+                    let operator_prefix = "operator toolkit_experimental.";
+                    if val.starts_with(operator_prefix)
+                        && val.strip_prefix(operator_prefix).is_some() {
+                            return None
+                    }
+
                     // ignore the pgx test schema
                     let test_prefix = "function tests.";
                     if val.starts_with(test_prefix)
@@ -143,5 +149,9 @@ mod tests {
         "function timeweightsummary_in(cstring)",
         "function timeweightsummary_out(timeweightsummary)",
         "type timeweightsummary",
+        "operator |>(toolkit_experimental.timeseries,toolkit_experimental.unstabletimeseriespipeline)",
+        "operator |>(toolkit_experimental.timeseries,toolkit_experimental.unstabletimeseriespipelineelement)",
+        "operator |>(toolkit_experimental.unstabletimeseriespipeline,toolkit_experimental.unstabletimeseriespipelineelement)",
+        "operator |>(toolkit_experimental.unstabletimeseriespipelineelement,toolkit_experimental.unstabletimeseriespipelineelement)",
     ];
 }

--- a/extension/src/serialization.rs
+++ b/extension/src/serialization.rs
@@ -131,10 +131,31 @@ pub(crate) mod serde_reference_adaptor {
         T::deserialize(deserializer)
     }
 
-    pub(crate) fn deserialize_slice<'de, D, T>(deserializer: D) -> Result<&'static [T], D::Error>
-    where D: Deserializer<'de>, T: Deserialize<'de> {
-        let boxed = <Box<[T]>>::deserialize(deserializer)?.into();
-        Ok(Box::leak(boxed))
+    pub(crate) fn deserialize_slice<'de, D, S>(deserializer: D) -> Result<S, D::Error>
+    where D: Deserializer<'de>, S: LeakableSlice<'de> {
+        S::deserialize_slice(deserializer)
+    }
+
+    pub(crate) trait LeakableSlice<'de>: Sized {
+        fn deserialize_slice<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de>;
+    }
+
+    impl<'de, T> LeakableSlice<'de> for &'static [T]
+    where T: Deserialize<'de> {
+        fn deserialize_slice<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de> {
+            let boxed = <Box<[T]>>::deserialize(deserializer)?.into();
+            Ok(Box::leak(boxed))
+        }
+    }
+
+    impl<'de, T> LeakableSlice<'de> for flat_serialize::Iterable<'static, T>
+    where T: Deserialize<'de> {
+        fn deserialize_slice<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de> {
+            Self::deserialize(deserializer)
+        }
     }
 
     pub(crate) fn default_padding() -> [u8; 3] {

--- a/extension/src/time_series/pipeline.rs
+++ b/extension/src/time_series/pipeline.rs
@@ -1,0 +1,297 @@
+
+use std::convert::TryInto;
+
+use pgx::*;
+
+use super::*;
+
+use crate::{
+    json_inout_funcs, pg_type, flatten,
+};
+
+// TODO once we start stabilizing elements, create a type
+//      `TimeseriesPipelineElement` and move stable variants to that.
+pg_type! {
+    #[derive(Debug)]
+    struct UnstableTimeseriesPipelineElement {
+        element: enum Element {
+            kind: u64,
+            LTTB: 1 {
+                resolution: u64,
+            },
+        },
+    }
+}
+
+json_inout_funcs!(UnstableTimeseriesPipelineElement);
+
+// TODO once we start stabilizing elements, create a type TimeseriesPipeline
+//      stable elements will create a stable pipeline, but adding an unstable
+//      element to a stable pipeline will create an unstable pipeline
+type USPED = UnstableTimeseriesPipelineElementData;
+pg_type! {
+    #[derive(Debug)]
+    struct UnstableTimeseriesPipeline<'input> {
+        num_elements: u64,
+        elements: [USPED; self.num_elements],
+    }
+}
+
+json_inout_funcs!(UnstableTimeseriesPipeline);
+
+// hack to allow us to qualify names with "toolkit_experimental"
+// so that pgx generates the correct SQL
+pub mod toolkit_experimental {
+    pub(crate) use super::*;
+    varlena_type!(UnstableTimeseriesPipeline);
+    varlena_type!(UnstableTimeseriesPipelineElement);
+}
+
+pub enum MaybeOwnedTs<'s> {
+    Borrowed(TimeSeries<'s>),
+    Owned(TimeSeries<'static>),
+}
+
+#[pg_extern(immutable, parallel_safe, schema="toolkit_experimental")]
+pub fn run_pipeline<'s, 'p>(
+    timeseries: toolkit_experimental::TimeSeries<'s>,
+    pipeline: toolkit_experimental::UnstableTimeseriesPipeline<'p>,
+) -> toolkit_experimental::TimeSeries<'static> {
+    let mut timeseries = MaybeOwnedTs::Borrowed(timeseries);
+    for element in pipeline.elements.iter() {
+        let element = element.element;
+        let new_timeseries = execute_pipeline_element(&mut timeseries, &element);
+        if let Some(series) = new_timeseries {
+            timeseries = MaybeOwnedTs::Owned(series)
+        }
+    }
+    match timeseries {
+        MaybeOwnedTs::Borrowed(series) => series.in_current_context(),
+        MaybeOwnedTs::Owned(series) => series,
+    }
+}
+
+#[pg_extern(immutable, parallel_safe, schema="toolkit_experimental")]
+pub fn run_pipeline_element<'s, 'p>(
+    timeseries: toolkit_experimental::TimeSeries<'s>,
+    element: toolkit_experimental::UnstableTimeseriesPipelineElement<'p>,
+) -> toolkit_experimental::TimeSeries<'static> {
+    let owned_timeseries = execute_pipeline_element(&mut MaybeOwnedTs::Borrowed(timeseries), &element.element);
+    if let Some(timeseries) = owned_timeseries {
+        return timeseries
+    }
+    return timeseries.in_current_context()
+}
+
+// TODO need cow-like for timeseries input
+pub fn execute_pipeline_element<'s, 'e>(
+    timeseries: &mut MaybeOwnedTs<'s>,
+    element: &Element
+) -> Option<toolkit_experimental::TimeSeries<'static>> {
+    use MaybeOwnedTs::{Borrowed, Owned};
+    match (element, timeseries) {
+        (Element::LTTB{resolution}, Borrowed(timeseries)) => {
+            return Some(crate::lttb::lttb_ts(*timeseries, *resolution as _))
+        }
+        (Element::LTTB{resolution}, Owned(timeseries)) => {
+            return Some(crate::lttb::lttb_ts(*timeseries, *resolution as _))
+        }
+    }
+}
+
+#[pg_extern(immutable, parallel_safe, schema="toolkit_experimental")]
+pub fn build_unstable_pipepine<'s, 'p>(
+    first: toolkit_experimental::UnstableTimeseriesPipelineElement<'s>,
+    second: toolkit_experimental::UnstableTimeseriesPipelineElement<'p>,
+) -> toolkit_experimental::UnstableTimeseriesPipeline<'static> {
+    unsafe {
+        let elements: Vec<_> = vec!(first.flatten().0, second.flatten().0);
+        flatten! {
+            UnstableTimeseriesPipeline {
+                num_elements: 2,
+                elements: (&*elements).into(),
+            }
+        }
+    }
+}
+
+// TODO is (immutable, parallel_safe) correct?
+#[pg_extern(immutable, parallel_safe, schema="toolkit_experimental")]
+pub fn add_unstable_element<'p, 'e>(
+    pipeline: toolkit_experimental::UnstableTimeseriesPipeline<'p>,
+    element: toolkit_experimental::UnstableTimeseriesPipelineElement<'e>,
+) -> toolkit_experimental::UnstableTimeseriesPipeline<'p> {
+    unsafe {
+        let elements: Vec<_> = pipeline.elements.iter().chain(Some(element.flatten().0)).collect();
+        flatten! {
+            UnstableTimeseriesPipeline {
+                num_elements: elements.len().try_into().unwrap(),
+                elements: (&*elements).into(),
+            }
+        }
+    }
+}
+
+// using this instead of pg_operator since the latter doesn't support schemas yet
+// FIXME there is no CREATE OR REPLACE OPERATOR need to update post-install.rs
+//       need to ensure this works with out unstable warning
+extension_sql!(r#"
+CREATE OPERATOR |> (
+    PROCEDURE=toolkit_experimental."run_pipeline",
+    LEFTARG=toolkit_experimental.TimeSeries,
+    RIGHTARG=toolkit_experimental.UnstableTimeseriesPipeline
+);
+
+CREATE OPERATOR |> (
+    PROCEDURE=toolkit_experimental."run_pipeline_element",
+    LEFTARG=toolkit_experimental.TimeSeries,
+    RIGHTARG=toolkit_experimental.UnstableTimeseriesPipelineElement
+);
+
+CREATE OPERATOR |> (
+    PROCEDURE=toolkit_experimental."build_unstable_pipepine",
+    LEFTARG=toolkit_experimental.UnstableTimeseriesPipelineElement,
+    RIGHTARG=toolkit_experimental.UnstableTimeseriesPipelineElement
+);
+
+CREATE OPERATOR |> (
+    PROCEDURE=toolkit_experimental."add_unstable_element",
+    LEFTARG=toolkit_experimental.UnstableTimeseriesPipeline,
+    RIGHTARG=toolkit_experimental.UnstableTimeseriesPipelineElement
+);
+"#);
+
+// TODO is (immutable, parallel_safe) correct?
+#[pg_extern(
+    immutable,
+    parallel_safe,
+    name="lttb",
+    schema="toolkit_experimental"
+)]
+pub fn lttb_pipeline_element<'p, 'e>(
+    resolution: i32,
+) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
+    unsafe {
+        flatten!(
+            UnstableTimeseriesPipelineElement {
+                element: Element::LTTB {
+                    resolution: resolution.try_into().unwrap(),
+                }
+            }
+        )
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+mod tests {
+    use pgx::*;
+
+    #[pg_test]
+    fn test_pipeline_lttb() {
+        Spi::execute(|client| {
+            // using the search path trick for this test b/c the operator is
+            // difficult to spot otherwise.
+            let sp = client.select("SELECT format(' %s, toolkit_experimental',current_setting('search_path'))", None, None).first().get_one::<String>().unwrap();
+            client.select(&format!("SET LOCAL search_path TO {}", sp), None, None);
+            client.select("SET timescaledb_toolkit_acknowledge_auto_drop TO 'true'", None, None);
+
+            client.select(
+                "CREATE TABLE lttb_pipe (series timeseries)",
+                None,
+                None
+            );
+            client.select(
+                "INSERT INTO lttb_pipe \
+                SELECT timeseries(time, val) FROM ( \
+                    SELECT \
+                        '2020-01-01 UTC'::TIMESTAMPTZ + make_interval(days=>(foo*10)::int) as time, \
+                        TRUNC((10 + 5 * cos(foo))::numeric, 4) as val \
+                    FROM generate_series(1,11,0.1) foo \
+                ) bar",
+                None,
+                None
+            );
+
+            let val = client.select(
+                "SELECT (series |> lttb(17))::TEXT FROM lttb_pipe",
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-11 00:00:00+00\",\"val\":12.7015},\
+                {\"ts\":\"2020-01-13 00:00:00+00\",\"val\":11.8117},\
+                {\"ts\":\"2020-01-22 00:00:00+00\",\"val\":7.4757},\
+                {\"ts\":\"2020-01-28 00:00:00+00\",\"val\":5.4796},\
+                {\"ts\":\"2020-02-03 00:00:00+00\",\"val\":5.0626},\
+                {\"ts\":\"2020-02-09 00:00:00+00\",\"val\":6.3703},\
+                {\"ts\":\"2020-02-14 00:00:00+00\",\"val\":8.4633},\
+                {\"ts\":\"2020-02-24 00:00:00+00\",\"val\":13.1734},\
+                {\"ts\":\"2020-03-01 00:00:00+00\",\"val\":14.8008},\
+                {\"ts\":\"2020-03-07 00:00:00+00\",\"val\":14.7511},\
+                {\"ts\":\"2020-03-13 00:00:00+00\",\"val\":13.0417},\
+                {\"ts\":\"2020-03-23 00:00:00+00\",\"val\":8.3042},\
+                {\"ts\":\"2020-03-29 00:00:00+00\",\"val\":5.9445},\
+                {\"ts\":\"2020-04-04 00:00:00+00\",\"val\":5.0015},\
+                {\"ts\":\"2020-04-10 00:00:00+00\",\"val\":5.8046},\
+                {\"ts\":\"2020-04-14 00:00:00+00\",\"val\":7.195},\
+                {\"ts\":\"2020-04-20 00:00:00+00\",\"val\":10.0221}\
+            ]");
+
+            let val = client.select(
+                "SELECT (series |> lttb(8))::TEXT FROM lttb_pipe",
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-11 00:00:00+00\",\"val\":12.7015},\
+                {\"ts\":\"2020-01-27 00:00:00+00\",\"val\":5.7155},\
+                {\"ts\":\"2020-02-06 00:00:00+00\",\"val\":5.5162},\
+                {\"ts\":\"2020-02-27 00:00:00+00\",\"val\":14.1735},\
+                {\"ts\":\"2020-03-09 00:00:00+00\",\"val\":14.3469},\
+                {\"ts\":\"2020-03-30 00:00:00+00\",\"val\":5.6728},\
+                {\"ts\":\"2020-04-09 00:00:00+00\",\"val\":5.554},\
+                {\"ts\":\"2020-04-20 00:00:00+00\",\"val\":10.0221}\
+            ]");
+
+            let val = client.select(
+                "SELECT (series |> lttb(8) |> lttb(8))::TEXT FROM lttb_pipe",
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-11 00:00:00+00\",\"val\":12.7015},\
+                {\"ts\":\"2020-01-27 00:00:00+00\",\"val\":5.7155},\
+                {\"ts\":\"2020-02-06 00:00:00+00\",\"val\":5.5162},\
+                {\"ts\":\"2020-02-27 00:00:00+00\",\"val\":14.1735},\
+                {\"ts\":\"2020-03-09 00:00:00+00\",\"val\":14.3469},\
+                {\"ts\":\"2020-03-30 00:00:00+00\",\"val\":5.6728},\
+                {\"ts\":\"2020-04-09 00:00:00+00\",\"val\":5.554},\
+                {\"ts\":\"2020-04-20 00:00:00+00\",\"val\":10.0221}\
+            ]");
+
+            let val = client.select(
+                "SELECT (series |> (lttb(8) |> lttb(8) |> lttb(8)))::TEXT FROM lttb_pipe",
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-11 00:00:00+00\",\"val\":12.7015},\
+                {\"ts\":\"2020-01-27 00:00:00+00\",\"val\":5.7155},\
+                {\"ts\":\"2020-02-06 00:00:00+00\",\"val\":5.5162},\
+                {\"ts\":\"2020-02-27 00:00:00+00\",\"val\":14.1735},\
+                {\"ts\":\"2020-03-09 00:00:00+00\",\"val\":14.3469},\
+                {\"ts\":\"2020-03-30 00:00:00+00\",\"val\":5.6728},\
+                {\"ts\":\"2020-04-09 00:00:00+00\",\"val\":5.554},\
+                {\"ts\":\"2020-04-20 00:00:00+00\",\"val\":10.0221}\
+            ]");
+        });
+    }
+}

--- a/extension/src/type_builder.rs
+++ b/extension/src/type_builder.rs
@@ -89,7 +89,7 @@ macro_rules! pg_type_impl {
     ) => {
         ::paste::paste! {
             $(#[$attrs])*
-            #[derive(pgx::PostgresType, Copy, Clone)]
+            #[derive(pgx::PostgresType, Clone)]
             #[inoutfuncs]
             pub struct $name<$lifetemplate>([<$name Data>] $(<$inlife>)?, Option<&$lifetemplate [u8]>);
 
@@ -111,10 +111,10 @@ macro_rules! pg_type_impl {
             }
 
             impl<'input> $name<'input> {
-                pub fn in_current_context(&self) -> $name<'static> {
+                pub fn in_current_context<'foo>(&self) -> $name<'foo> {
                     unsafe { self.0.flatten() }
                 }
-            } 
+            }
 
             impl<$lifetemplate> [<$name Data>] $(<$inlife>)? {
                 pub unsafe fn flatten<'any>(&self) -> $name<'any> {


### PR DESCRIPTION
This commit adds the pipeline scaffolding; the basic code to run pipeline elements like
```SQL
timeseries |> lttb(17)
```
The commit also adds an lttb element to test it.

This commit also switches the timeseries text IO to to use a simple explicit timeseries. I believe this is the most user-friendly default for both human readers, and the simplest for downstream applications to parse. We can always add a transform to send the more optimized layouts if desired.
