### PR TITLE
Add status badges

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,3 +1,6 @@
+[![CI](https://github.com/timescale/timescaledb-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/timescale/timescaledb-toolkit/actions/workflows/ci.yml) [![nightly](https://github.com/timescale/timescaledb-toolkit/actions/workflows/nightly_build.yml/badge.svg)](https://github.com/timescale/timescaledb-toolkit/actions/workflows/nightly_build.yml)
+
+
 # TimescaleDB Toolkit #
 
 This repository is the home of the TimescaleDB Toolkit team. Our mission is to


### PR DESCRIPTION
This PR adds status badges for our nightly CI and nightly image builds. Merges are gated on CI so the CI one should always be green. The nightly image build has been flakier in the past due to issues in the action's script, but that should be sorted now.