### PR TITLE
Br/pipeline downsampling

### DIFF
--- a/extension/src/asap.rs
+++ b/extension/src/asap.rs
@@ -159,7 +159,8 @@ pub fn asap_on_timeseries(
                 Err(_) => unreachable!()
             }
         },
-        InternalTimeSeries::Normal(normal) => normal
+        InternalTimeSeries::Normal(normal) => normal,
+        InternalTimeSeries::GappyNormal(_) => panic!("Series must be gapfilled before running asap smoothing"),
     };
 
     // Drop the last value to match the reference implementation

--- a/extension/src/time_series.rs
+++ b/extension/src/time_series.rs
@@ -306,7 +306,7 @@ impl<'a> Iterator for TimeSeriesIter<'a> {
                 if idx >= count {
                     return None;
                 }
-                while present[(*idx/64) as usize] & (1 >> *idx % 64) == 0 {
+                while present[(*idx/64) as usize] & (1 << (*idx % 64)) == 0 {
                     *idx += 1;
                 }
                 let ts = *start + *idx as i64 * *step;

--- a/extension/src/time_series/pipeline.rs
+++ b/extension/src/time_series/pipeline.rs
@@ -19,6 +19,10 @@ pg_type! {
             LTTB: 1 {
                 resolution: u64,
             },
+            Downsample: 2 {
+                interval: i64,
+                downsample_method: i64,
+            },
         },
     }
 }
@@ -89,12 +93,19 @@ pub fn execute_pipeline_element<'s, 'e>(
     element: &Element
 ) -> Option<toolkit_experimental::TimeSeries<'static>> {
     use MaybeOwnedTs::{Borrowed, Owned};
+
     match (element, timeseries) {
         (Element::LTTB{resolution}, Borrowed(timeseries)) => {
             return Some(crate::lttb::lttb_ts(*timeseries, *resolution as _))
         }
         (Element::LTTB{resolution}, Owned(timeseries)) => {
             return Some(crate::lttb::lttb_ts(*timeseries, *resolution as _))
+        }
+        (Element::Downsample{..}, Borrowed(timeseries)) => {
+            return Some(downsample(timeseries, &element));
+        }
+        (Element::Downsample{..}, Owned(timeseries)) => {
+            return Some(downsample(timeseries, &element));
         }
     }
 }
@@ -180,6 +191,162 @@ pub fn lttb_pipeline_element<'p, 'e>(
             }
         )
     }
+}
+
+type Interval = pg_sys::Datum;
+
+pub enum DownsampleMethod {
+    Average,
+    WeightedAverage,
+    Nearest,
+}
+
+impl From<i64> for DownsampleMethod {
+    fn from(item: i64) -> Self {
+        match item {
+            1 => DownsampleMethod::Average,
+            2 => DownsampleMethod::WeightedAverage,
+            3 => DownsampleMethod::Nearest,
+            _ => panic!("Invalid downsample method")
+        }
+    }
+}
+
+impl Into<i64> for DownsampleMethod {
+    fn into(self) -> i64 {
+        match self {
+            DownsampleMethod::Average => 1,
+            DownsampleMethod::WeightedAverage => 2,
+            DownsampleMethod::Nearest => 3,
+        }
+    }
+}
+
+impl DownsampleMethod {
+    pub fn process(&self, vals: &std::vec::Vec<TSPoint>, target: i64, interval: i64) -> TSPoint {
+        match self {
+            DownsampleMethod::Average => {
+                let mut sum = 0.0;
+                for TSPoint{val, ..} in vals.iter() {
+                    sum += val;
+                }
+                TSPoint{ts: target, val: sum / vals.len() as f64}
+            }
+            DownsampleMethod::WeightedAverage => {
+                let mut sum = 0.0;
+                let mut wsum  = 0.0;
+                for TSPoint{ts, val} in vals.iter() {
+                    let weight = (ts - target).abs() as f64 / interval as f64 / 2.0;
+                    sum += val * weight;
+                    wsum += weight;
+                }
+                TSPoint{ts: target, val: sum / wsum as f64}
+            }
+            DownsampleMethod::Nearest => {
+                let mut closest = i64::MAX;
+                let mut result = 0.0;
+                for TSPoint{ts, val} in vals.iter() {
+                    let distance = (ts - target).abs();
+                    if distance < closest {
+                        closest = distance;
+                        result = *val;
+                    } else if distance == closest {
+                        result = (result + val) / 2.0;
+                    }
+                }
+                TSPoint{ts: target, val: result}
+            }
+        }
+    }
+}
+
+// TODO is (immutable, parallel_safe) correct?
+#[pg_extern(
+    immutable,
+    parallel_safe,
+    name="downsample",
+    schema="toolkit_experimental"
+)]
+pub fn downsample_pipeline_element_default<'p, 'e>(
+    interval: Interval,
+) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
+    downsample_pipeline_element(interval, "average".to_string())
+}
+
+#[pg_extern(
+    immutable,
+    parallel_safe,
+    name="downsample",
+    schema="toolkit_experimental"
+)]
+pub fn downsample_pipeline_element<'p, 'e>(
+    interval: Interval,
+    downsample_method: String,
+) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
+    unsafe {
+        let interval = interval as *const pg_sys::Interval;
+        if (*interval).day > 0 || (*interval).month > 0 {
+            panic!("downsample intervals are currently restricted to stable units (hours or smaller)");
+        }
+        let interval = (*interval).time;
+
+        let downsample_method = match downsample_method.to_lowercase().as_str() {
+            "average" => DownsampleMethod::Average,
+            "weighted_average" => DownsampleMethod::WeightedAverage,
+            "nearest" => DownsampleMethod::Nearest,
+            _ => panic!("Invalid downsample method")
+        };
+
+        flatten!(
+            UnstableTimeseriesPipelineElement {
+                element: Element::Downsample {
+                    interval,
+                    downsample_method: downsample_method.into()
+                }
+            }
+        )
+    }
+}
+
+fn downsample(
+    series: &toolkit_experimental::TimeSeries, 
+    element: &toolkit_experimental::Element
+) -> toolkit_experimental::TimeSeries<'static> {
+    let (interval, method) = match element {
+        Element::Downsample{interval, downsample_method} => (interval, downsample_method),
+        _ => panic!("Downsample evaluator called on incorrect pipeline element")
+    };
+    let interval = *interval;
+    let method = DownsampleMethod::from(*method);
+
+    let mut result = None;
+    let mut current = None;
+    let mut points = Vec::new();
+    for point in series.iter() {
+        let TSPoint{ts, ..} = point;
+        let target = (ts + (interval / 2) as i64 - 1) / interval as i64 * interval as i64;
+        if current != Some(target) {
+            if current != None {
+                let new_pt = method.process(&points, current.unwrap(), interval);
+                match result {
+                    None => result = Some(InternalTimeSeries::new_gappy_normal_series(new_pt, interval)),
+                    Some(ref mut series) => series.add_point(new_pt),
+                }
+            }
+            
+            current = Some(target);
+            points = Vec::new();
+        }
+        points.push(point);
+    }
+
+    let new_pt = method.process(&points, current.unwrap(), interval);
+    match result {
+        None => result = Some(InternalTimeSeries::new_gappy_normal_series(new_pt, interval)),
+        Some(ref mut series) => series.add_point(new_pt),
+    }
+
+    TimeSeries::from_internal_time_series(&result.unwrap())
 }
 
 #[cfg(any(test, feature = "pg_test"))]
@@ -291,6 +458,69 @@ mod tests {
                 {\"ts\":\"2020-03-30 00:00:00+00\",\"val\":5.6728},\
                 {\"ts\":\"2020-04-09 00:00:00+00\",\"val\":5.554},\
                 {\"ts\":\"2020-04-20 00:00:00+00\",\"val\":10.0221}\
+            ]");
+
+            let val = client.select(
+                "SELECT (series |> downsample('240 hours'))::TEXT FROM lttb_pipe",
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-06 00:00:00+00\",\"val\":12.7015},\
+                {\"ts\":\"2020-01-16 00:00:00+00\",\"val\":10.09967},\
+                {\"ts\":\"2020-01-26 00:00:00+00\",\"val\":6.018800000000001},\
+                {\"ts\":\"2020-02-05 00:00:00+00\",\"val\":5.598180000000001},\
+                {\"ts\":\"2020-02-15 00:00:00+00\",\"val\":9.22451},\
+                {\"ts\":\"2020-02-25 00:00:00+00\",\"val\":13.56377},\
+                {\"ts\":\"2020-03-06 00:00:00+00\",\"val\":14.626499999999998},\
+                {\"ts\":\"2020-03-16 00:00:00+00\",\"val\":11.435550000000001},\
+                {\"ts\":\"2020-03-26 00:00:00+00\",\"val\":6.92475},\
+                {\"ts\":\"2020-04-05 00:00:00+00\",\"val\":5.24124},\
+                {\"ts\":\"2020-04-15 00:00:00+00\",\"val\":7.93288}\
+            ]");
+
+            let val = client.select(
+                "SELECT (series |> downsample('240 hours', 'weighted_average'))::TEXT FROM lttb_pipe",
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-06 00:00:00+00\",\"val\":12.7015},\
+                {\"ts\":\"2020-01-16 00:00:00+00\",\"val\":9.852736000000002},\
+                {\"ts\":\"2020-01-26 00:00:00+00\",\"val\":5.963883999999999},\
+                {\"ts\":\"2020-02-05 00:00:00+00\",\"val\":5.785756000000001},\
+                {\"ts\":\"2020-02-15 00:00:00+00\",\"val\":9.482128000000001},\
+                {\"ts\":\"2020-02-25 00:00:00+00\",\"val\":13.654568000000001},\
+                {\"ts\":\"2020-03-06 00:00:00+00\",\"val\":14.467004000000003},\
+                {\"ts\":\"2020-03-16 00:00:00+00\",\"val\":11.172388},\
+                {\"ts\":\"2020-03-26 00:00:00+00\",\"val\":6.79988},\
+                {\"ts\":\"2020-04-05 00:00:00+00\",\"val\":5.369460000000001},\
+                {\"ts\":\"2020-04-15 00:00:00+00\",\"val\":8.196308}\
+            ]");
+
+            let val = client.select(
+                "SELECT (series |> downsample('240 hours', 'NEAREST'))::TEXT FROM lttb_pipe",
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-06 00:00:00+00\",\"val\":12.7015},\
+                {\"ts\":\"2020-01-16 00:00:00+00\",\"val\":10.3536},\
+                {\"ts\":\"2020-01-26 00:00:00+00\",\"val\":5.9942},\
+                {\"ts\":\"2020-02-05 00:00:00+00\",\"val\":5.3177},\
+                {\"ts\":\"2020-02-15 00:00:00+00\",\"val\":8.946},\
+                {\"ts\":\"2020-02-25 00:00:00+00\",\"val\":13.5433},\
+                {\"ts\":\"2020-03-06 00:00:00+00\",\"val\":14.8829},\
+                {\"ts\":\"2020-03-16 00:00:00+00\",\"val\":11.7331},\
+                {\"ts\":\"2020-03-26 00:00:00+00\",\"val\":6.9899},\
+                {\"ts\":\"2020-04-05 00:00:00+00\",\"val\":5.0141},\
+                {\"ts\":\"2020-04-15 00:00:00+00\",\"val\":7.6223}\
             ]");
         });
     }


### PR DESCRIPTION
This change adds a new type of timeseries, GappyNormalTimeseries, and two new pipeline elements: Downsample and Gapfill.  There still needs to be some discussion on the final API for these elements, in particular Gapfill can't currently handle an ExplicitTimeseries, but this PR should serve as a starting point.