### PR TITLE
Fix potential memory leaks

### DIFF
--- a/extension/src/palloc.rs
+++ b/extension/src/palloc.rs
@@ -1,52 +1,9 @@
 
 use std::{
-    alloc::{GlobalAlloc, Layout},
-    convert::TryInto,
     ptr::NonNull,
 };
 
 use pgx::*;
-
-struct PallocAllocator;
-
-/// There is an uncomfortable mismatch between rust's memory allocation and
-/// postgres's; rust tries to clean memory by using stack-based destructors,
-/// while postgres does so using arenas. The issue we encounter is that postgres
-/// implements exception-handling using setjmp/longjmp, which will can jump over
-/// stack frames containing rust destructors. To avoid needing to register a
-/// setjmp handler at every call to a postgres function, we use postgres's
-/// MemoryContexts to manage memory, even though this is not strictly speaking
-/// safe. Though it is tempting to try to get more control over which
-/// MemoryContext we allocate in, there doesn't seem to be way to do so that is
-/// safe in the context of postgres exceptions and doesn't incur the cost of
-/// setjmp
-// NOTE some code, for instance the JSON deserialization code in
-//      serde_reference_adaptor assumes it's ok to leak memory as postgres will
-//      clean it up
-unsafe impl GlobalAlloc for PallocAllocator {
-    //FIXME allow for switching the memory context allocated in
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        pg_sys::MemoryContextAlloc(
-            pg_sys::CurrentMemoryContext,
-            layout.size().try_into().unwrap()
-        )  as *mut _
-    }
-
-    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
-        pg_sys::pfree(ptr as *mut _)
-    }
-
-    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
-        pg_sys::MemoryContextAllocZero(
-            pg_sys::CurrentMemoryContext,
-            layout.size().try_into().unwrap()
-        ) as *mut _
-    }
-
-    unsafe fn realloc(&self, ptr: *mut u8, _layout: Layout, new_size: usize) -> *mut u8 {
-        pg_sys::repalloc(ptr as *mut _, new_size.try_into().unwrap()) as *mut _
-    }
-}
 
 pub unsafe fn in_memory_context<T, F: FnOnce() -> T>(
     mctx: pg_sys::MemoryContext,
@@ -98,7 +55,8 @@ impl<T> IntoDatum for Internal<T> {
 
 impl<T> From<T> for Internal<T> {
     fn from(t: T) -> Self {
-        Self(Box::leak(Box::new(t)).into())
+        let ptr = PgMemoryContexts::CurrentMemoryContext.leak_and_drop_on_delete(t);
+        Self(NonNull::new(ptr).unwrap())
     }
 }
 


### PR DESCRIPTION
Our old strategy of forwarding rust allocations to `palloc()` ended up being too complicated to be worth keeping; rust expects more alignment than `palloc()` can provide, and the forwarding was deactivated for a while without anyone noticing. This commit removes all of that code, and instead changes the types that cross boundaries–`Internal` and `flat_serialize!`–to use the postgres allocator.