### PR TITLE
Switch Hyperloglog rollup to an aggregate

### DIFF
--- a/crates/hyperloglogplusplus/src/dense.rs
+++ b/crates/hyperloglogplusplus/src/dense.rs
@@ -42,6 +42,15 @@ impl<'s> Storage<'s> {
         }
     }
 
+    pub fn into_owned(&self) -> Storage<'static> {
+        Storage {
+            registers: self.registers.into_owned(),
+            index_shift: self.index_shift,
+            precision: self.precision,
+            hash_mask: self.hash_mask,
+        }
+    }
+
     pub fn add_hash(&mut self, hash: u64) {
         let (idx, count) = self.idx_count_from_hash(hash);
         self.registers.set_max(idx as usize, count as u8);

--- a/crates/hyperloglogplusplus/src/lib.rs
+++ b/crates/hyperloglogplusplus/src/lib.rs
@@ -110,6 +110,20 @@ impl<'s, T, B> HyperLogLog<'s, T, B> {
             HyperLogLogStorage::Dense(_) => {},
         }
     }
+
+    pub fn into_owned(&self) -> HyperLogLog<'static, T, B>
+    where B: Clone {
+        use HyperLogLogStorage::*;
+        let storage = match &self.storage {
+            Sparse(s) => Sparse(s.into_owned()),
+            Dense(s) => Dense(s.into_owned()),
+        };
+        HyperLogLog {
+            storage,
+            buildhasher: self.buildhasher.clone(),
+            _pd: PhantomData
+        }
+    }
 }
 
 impl<'s, T, B> HyperLogLog<'s, T, B>

--- a/crates/hyperloglogplusplus/src/registers.rs
+++ b/crates/hyperloglogplusplus/src/registers.rs
@@ -141,6 +141,10 @@ impl<'s> Registers<'s> {
 
         merged
     }
+
+    pub fn into_owned(&self) -> Registers<'static> {
+        Registers(Cow::from(self.0.clone().into_owned()))
+    }
 }
 
 #[cfg(test)]

--- a/crates/hyperloglogplusplus/src/sparse.rs
+++ b/crates/hyperloglogplusplus/src/sparse.rs
@@ -60,6 +60,15 @@ impl<'s> Storage<'s> {
         }
     }
 
+    pub fn into_owned(&self) -> Storage<'static> {
+        Storage {
+            to_merge: self.to_merge.clone(),
+            compressed: self.compressed.into_owned(),
+            num_compressed: self.num_compressed,
+            precision: self.precision,
+        }
+    }
+
     pub fn add_hash(&mut self, hash: u64) -> Overflowing {
         let encoded = Encoded::from_hash(hash, self.precision);
         self.add_encoded(encoded)

--- a/crates/hyperloglogplusplus/src/sparse/varint.rs
+++ b/crates/hyperloglogplusplus/src/sparse/varint.rs
@@ -33,6 +33,10 @@ impl<'c> Compressed<'c> {
     pub fn cap(&self) -> usize {
         self.0.len()
     }
+
+    pub fn into_owned(&self) -> Compressed<'static> {
+        Compressed(Cow::from(self.0.clone().into_owned()))
+    }
 }
 
 

--- a/docs/hyperloglog.md
+++ b/docs/hyperloglog.md
@@ -66,7 +66,7 @@ rollup(
 ) RETURNS Hyperloglog
 ```
 
-Returns a Hyperloglog over the union of the input elements.
+Returns a Hyperloglog by aggregating over the union of the input elements.
 
 ### Required Arguments <a id="hyperloglog-required-arguments"></a>
 |Name| Type |Description|
@@ -84,12 +84,12 @@ Returns a Hyperloglog over the union of the input elements.
 ### Sample Usages <a id="summary-form-examples"></a>
 
 ```SQL
-SELECT toolkit_experimental.hyperloglog_count(
-    toolkit_experimental.rollup(
-        (SELECT toolkit_experimental.hyperloglog(32, v::text) FROM generate_series(1, 100) v),
-        (SELECT toolkit_experimental.hyperloglog(32, v::text) FROM generate_series(50, 150) v)
-    )
-)
+SELECT toolkit_experimental.hyperloglog_count(toolkit_experimental.rollup(logs))
+FROM (
+    (SELECT toolkit_experimental.hyperloglog(32, v::text) logs FROM generate_series(1, 100) v)
+    UNION ALL
+    (SELECT toolkit_experimental.hyperloglog(32, v::text) FROM generate_series(50, 150) v)
+) hll;
 ```
 ```output
  count


### PR DESCRIPTION
This commit changes the hyperloglog `rollup()` function from taking a pair of logs to union, `rollup(Hyperloglog, Hyperloglog)`, to taking a column of hyperloglogs to aggregate over `rollup(Hyperloglog)`. This was always the intended signature, and it's unknown why it was not implemented like this initially.

The example from https://github.com/timescale/timescaledb-toolkit/pull/203 would look like
```SQL
select
  time_bucket('1 day', bucket), 
  toolkit_experimental.hyperloglog_count(toolkit_experimental.rollup(val)) 
from test_hll_mv_devices_hourly
group by 1
order by time_bucket asc;
```

fixes https://github.com/timescale/timescaledb-toolkit/issues/202
intended to supercede https://github.com/timescale/timescaledb-toolkit/pull/203