### PR TITLE
Update load-order

### DIFF
--- a/extension/sql/load-order.txt
+++ b/extension/sql/load-order.txt
@@ -11,3 +11,7 @@ utilities.generated.sql
 stats_agg.generated.sql
 time_series_pipeline.generated.sql
 triggers.generated.sql
+time_series_pipeline_delta.generated.sql
+time_series_pipeline_fill_holes.generated.sql
+time_series_pipeline_resample_to_rate.generated.sql
+time_series_pipeline_sort.generated.sql


### PR DESCRIPTION
For the cloud release we have commands that need to run strictly after all others. Therefor we should attempt top keep `load-order.txt` reasonably up-to-date to minimize the possibilities for error.