### PR TITLE
Finish up missing hyperloglog features

### DIFF
--- a/docs/hyperloglog.md
+++ b/docs/hyperloglog.md
@@ -131,3 +131,56 @@ FROM generate_series(1, 100) data
 -------------------
                114
 ```
+
+## **hyperloglog_count** <a id="hyperloglog_stderror"></a>
+
+```SQL ,ignore
+toolkit_experimental.stderror(hyperloglog Hyperloglog) RETURNS DOUBLE PRECISION
+```
+
+Returns an estimate of the relative stderror of the hyperloglog based on the
+hyperloglog error formula. Approximate result are:
+```
+ precision ┃ registers ┃  error ┃  bytes
+━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━╋━━━━━━━━
+         4 ┃        16 ┃ 0.2600 ┃     12
+         5 ┃        32 ┃ 0.1838 ┃     24
+         6 ┃        64 ┃ 0.1300 ┃     48
+         7 ┃       128 ┃ 0.0919 ┃     96
+         8 ┃       256 ┃ 0.0650 ┃    192
+         9 ┃       512 ┃ 0.0460 ┃    384
+        10 ┃      1024 ┃ 0.0325 ┃    768
+        11 ┃      2048 ┃ 0.0230 ┃   1536
+        12 ┃      4096 ┃ 0.0163 ┃   3072
+        13 ┃      8192 ┃ 0.0115 ┃   6144
+        14 ┃     16384 ┃ 0.0081 ┃  12288
+        15 ┃     32768 ┃ 0.0057 ┃  24576
+        16 ┃     65536 ┃ 0.0041 ┃  49152
+        17 ┃    131072 ┃ 0.0029 ┃  98304
+        18 ┃    262144 ┃ 0.0020 ┃ 196608
+```
+
+### Required Arguments <a id="hyperloglog_stderror-required-arguments"></a>
+|Name|Type|Description|
+|---|---|---|
+| `hyperloglog` | `Hyperloglog` | The hyperloglog to extract the count from. |
+<br>
+
+### Returns
+
+|Column|Type|Description|
+|---|---|---|
+| `stderror` | `BIGINT` | The number of distinct elements counted by the hyperloglog. |
+<br>
+
+### Sample Usages <a id="hyperloglog_stderror-examples"></a>
+
+```SQL
+SELECT toolkit_experimental.stderror(toolkit_experimental.hyperloglog(64, data))
+FROM generate_series(1, 100) data
+```
+```output
+ stderror
+----------
+     0.13
+```

--- a/docs/hyperloglog.md
+++ b/docs/hyperloglog.md
@@ -15,7 +15,7 @@ Timescale's HyperLogLog is implemented as an aggregate function in PostgreSQL.  
 
 ## Command List (A-Z) <a id="hyperloglog-api"></a>
 > - [hyperloglog](#hyperloglog)
-> - [hyperloglog_count](#hyperloglog_count)
+> - [distinct_count](#distinct_count)
 
 ---
 ## **hyperloglog** <a id="hyperloglog"></a>
@@ -84,7 +84,7 @@ Returns a Hyperloglog by aggregating over the union of the input elements.
 ### Sample Usages <a id="summary-form-examples"></a>
 
 ```SQL
-SELECT toolkit_experimental.hyperloglog_count(toolkit_experimental.rollup(logs))
+SELECT toolkit_experimental.distinct_count(toolkit_experimental.rollup(logs))
 FROM (
     (SELECT toolkit_experimental.hyperloglog(32, v::text) logs FROM generate_series(1, 100) v)
     UNION ALL
@@ -99,15 +99,14 @@ FROM (
 
 ---
 
-## **hyperloglog_count** <a id="hyperloglog_count"></a>
-
+## **distinct_count** <a id="distinct_count
 ```SQL ,ignore
-toolkit_experimental.hyperloglog_count(hyperloglog Hyperloglog) RETURNS BIGINT
+toolkit_experimental.distinct_count(hyperloglog Hyperloglog) RETURNS BIGINT
 ```
 
 Get the number of distinct values from a hyperloglog.
 
-### Required Arguments <a id="hyperloglog_count-required-arguments"></a>
+### Required Arguments <a id="distinct_count-required-arguments"></a>
 |Name|Type|Description|
 |---|---|---|
 | `hyperloglog` | `Hyperloglog` | The hyperloglog to extract the count from. |
@@ -117,22 +116,22 @@ Get the number of distinct values from a hyperloglog.
 
 |Column|Type|Description|
 |---|---|---|
-| `hyperloglog_count` | `BIGINT` | The number of distinct elements counted by the hyperloglog. |
+| `distinct_count` | `BIGINT` | The number of distinct elements counted by the hyperloglog. |
 <br>
 
-### Sample Usages <a id="hyperloglog_count-examples"></a>
+### Sample Usages <a id="distinct_count-examples"></a>
 
 ```SQL
-SELECT toolkit_experimental.hyperloglog_count(toolkit_experimental.hyperloglog(64, data))
+SELECT toolkit_experimental.distinct_count(toolkit_experimental.hyperloglog(64, data))
 FROM generate_series(1, 100) data
 ```
 ```output
- hyperloglog_count
--------------------
-               114
+ distinct_count
+----------------
+            114
 ```
 
-## **hyperloglog_count** <a id="hyperloglog_stderror"></a>
+## **stderror** <a id="hyperloglog_stderror"></a>
 
 ```SQL ,ignore
 toolkit_experimental.stderror(hyperloglog Hyperloglog) RETURNS DOUBLE PRECISION

--- a/extension/src/hyperloglog.rs
+++ b/extension/src/hyperloglog.rs
@@ -227,7 +227,7 @@ CREATE AGGREGATE toolkit_experimental.rollup(hyperloglog toolkit_experimental.Hy
 
 
 
-#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+#[pg_extern(name="distinct_count", schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn hyperloglog_count<'input>(
     hyperloglog: toolkit_experimental::HyperLogLog<'input>
 ) -> i64 {
@@ -496,7 +496,7 @@ mod tests {
 
             let count = client
                 .select("SELECT \
-                    toolkit_experimental.hyperloglog_count(\
+                    toolkit_experimental.distinct_count(\
                         toolkit_experimental.hyperloglog(32, v::float)\
                     ) \
                     FROM generate_series(1, 100) v", None, None)
@@ -506,7 +506,7 @@ mod tests {
 
             let count2 = client
                 .select(
-                    &format!("SELECT toolkit_experimental.hyperloglog_count('{}')", expected),
+                    &format!("SELECT toolkit_experimental.distinct_count('{}')", expected),
                     None,
                     None,
                 )
@@ -547,7 +547,7 @@ mod tests {
 
             let count = client
                 .select("SELECT \
-                toolkit_experimental.hyperloglog_count(\
+                toolkit_experimental.distinct_count(\
                     toolkit_experimental.hyperloglog(32, v::int)\
                 ) FROM generate_series(1, 100) v", None, None)
                 .first()
@@ -556,7 +556,7 @@ mod tests {
 
             let count2 = client
                 .select(
-                    &format!("SELECT toolkit_experimental.hyperloglog_count('{}')", expected),
+                    &format!("SELECT toolkit_experimental.distinct_count('{}')", expected),
                     None,
                     None,
                 )
@@ -599,7 +599,7 @@ mod tests {
             assert_eq!(text.unwrap(), expected);
 
             let count = client
-                .select("SELECT toolkit_experimental.hyperloglog_count(\
+                .select("SELECT toolkit_experimental.distinct_count(\
                     toolkit_experimental.hyperloglog(32, v::text)\
                 ) FROM generate_series(1, 100) v", None, None)
                 .first()
@@ -608,7 +608,7 @@ mod tests {
 
             let count2 = client
                 .select(
-                    &format!("SELECT toolkit_experimental.hyperloglog_count('{}')", expected),
+                    &format!("SELECT toolkit_experimental.distinct_count('{}')", expected),
                     None,
                     None,
                 )
@@ -657,7 +657,7 @@ mod tests {
             {
                 // differing unions should be a sum of the distinct counts
                 let query =
-                    "SELECT toolkit_experimental.hyperloglog_count(toolkit_experimental.rollup(logs)) \
+                    "SELECT toolkit_experimental.distinct_count(toolkit_experimental.rollup(logs)) \
                     FROM (\
                         (SELECT toolkit_experimental.hyperloglog(32, v::text) logs \
                          FROM generate_series(1, 100) v) \


### PR DESCRIPTION
1. Add a `stderror(hyperloglog)` function which returns the relative stderror that a hyperloglog has.
2. Rename `hyperloglog_count()` to `distinct_count()`.