### PR TITLE
Add user-defined mapping elements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,6 +1894,7 @@ dependencies = [
  "flat_serialize",
  "flat_serialize_macro",
  "hyperloglogplusplus",
+ "once_cell",
  "paste",
  "pgx",
  "pgx-macros",

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -34,6 +34,7 @@ approx = {version = "0.4.0", optional = true}
 bincode = "1.3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+once_cell = "1.8.0"
 paste = "1.0"
 rand = { version = "0.8.3", features = ["getrandom", "small_rng"] }
 rand_distr = "0.4.0"

--- a/extension/sql/load-order.txt
+++ b/extension/sql/load-order.txt
@@ -13,6 +13,7 @@ time_series_pipeline.generated.sql
 triggers.generated.sql
 time_series_pipeline_delta.generated.sql
 time_series_pipeline_fill_holes.generated.sql
+time_series_pipeline_map.generated.sql
 time_series_pipeline_resample_to_rate.generated.sql
 time_series_pipeline_sort.generated.sql
 schema_test.generated.sql

--- a/extension/src/schema_test.rs
+++ b/extension/src/schema_test.rs
@@ -153,5 +153,10 @@ mod tests {
         "operator |>(toolkit_experimental.timeseries,toolkit_experimental.unstabletimeseriespipelineelement)",
         "operator |>(toolkit_experimental.unstabletimeseriespipeline,toolkit_experimental.unstabletimeseriespipelineelement)",
         "operator |>(toolkit_experimental.unstabletimeseriespipelineelement,toolkit_experimental.unstabletimeseriespipelineelement)",
+        "operator |>>(regproc,regproc)",
+        "operator |>>(regproc,toolkit_experimental.unstabletimeseriespipelineelement)",
+        "operator |>>(toolkit_experimental.timeseries,regproc)",
+        "operator |>>(toolkit_experimental.unstabletimeseriespipeline,regproc)",
+        "operator |>>(toolkit_experimental.unstabletimeseriespipelineelement,regproc)",
     ];
 }

--- a/extension/src/serialization.rs
+++ b/extension/src/serialization.rs
@@ -2,9 +2,11 @@
 use std::{convert::TryInto, ffi::CStr, os::raw::{c_char, c_int}};
 pub use self::types::{PgTypId, ShortTypeId};
 pub use self::collations::PgCollationId;
+pub use self::functions::PgProcId;
 
 use pgx::pg_sys;
 
+mod functions;
 mod types;
 mod collations;
 

--- a/extension/src/serialization/functions.rs
+++ b/extension/src/serialization/functions.rs
@@ -1,0 +1,69 @@
+use std::{
+    ffi::{CStr, CString},
+    mem::{align_of, size_of, MaybeUninit},
+    os::raw::c_char,
+    slice,
+};
+
+use flat_serialize::{impl_flat_serializable, FlatSerializable, WrapErr};
+
+use serde::{Deserialize, Serialize};
+
+use pg_sys::{Datum, Oid};
+use pgx::*;
+
+/// `PgProcId` provides provides the ability to serialize and deserialize
+/// regprocedures as `namespace.name(args)`
+#[derive(Debug, Clone, Copy)]
+#[repr(transparent)]
+pub struct PgProcId(pub Oid);
+
+impl_flat_serializable!(PgProcId);
+
+use super::{pg_server_to_any, PG_UTF8};
+// FIXME upstream to pgx
+// TODO use this or regprocedureout()?
+extern "C" {
+    pub fn format_procedure_qualified(procedure_oid: pg_sys::Oid) -> *const c_char;
+}
+
+impl Serialize for PgProcId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        unsafe {
+            let qualified_name = format_procedure_qualified(self.0);
+            let len = CStr::from_ptr(qualified_name).to_bytes().len();
+            let qualified_name = pg_server_to_any(qualified_name, len as _, PG_UTF8);
+            let qualified_name = CStr::from_ptr(qualified_name);
+            let qualified_name = qualified_name.to_str().unwrap();
+            qualified_name.serialize(serializer)
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for PgProcId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // FIXME pgx wraps all functions in rust wrappers, which makes them
+        //       uncallable with DirectFunctionCall(). Is there a way to
+        //       export both?
+        extern "C" {
+            fn regprocedurein(fcinfo: pg_sys::FunctionCallInfo) -> Datum;
+        }
+        let qualified_name = <&str>::deserialize(deserializer)?;
+        let qualified_name = CString::new(qualified_name).unwrap();
+        let oid = unsafe {
+            pg_sys::DirectFunctionCall1Coll(
+                Some(regprocedurein),
+                pg_sys::InvalidOid,
+                qualified_name.as_ptr() as pg_sys::Datum,
+            )
+        };
+
+        Ok(Self(oid as _))
+    }
+}

--- a/extension/src/serialization/types.rs
+++ b/extension/src/serialization/types.rs
@@ -1,6 +1,5 @@
 use std::{
     ffi::{CStr, CString},
-    os::raw::{c_char, c_int},
     slice,
     mem::{size_of, align_of, MaybeUninit},
 };
@@ -195,12 +194,7 @@ impl ShortTypIdSerializer {
 #[repr(transparent)]
 pub struct PgTypId(pub Oid);
 
-// FIXME upstream to pgx
-const PG_UTF8: i32 = 6;
-extern "C" {
-    fn pg_server_to_any(s: *const c_char, len: c_int, encoding: c_int) -> *const c_char;
-    fn pg_any_to_server(s: *const c_char, len: c_int, encoding: c_int) -> *const c_char;
-}
+use super::{pg_server_to_any, pg_any_to_server, PG_UTF8};
 
 impl Serialize for PgTypId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/extension/src/time_series.rs
+++ b/extension/src/time_series.rs
@@ -90,7 +90,7 @@ impl<'input> InOutFuncs for TimeSeries<'input> {
                 TimeSeries {
                     series: SeriesType::ExplicitSeries {
                         num_points: series.len() as u64,
-                        points: (&*series).into(),
+                        points: series.into(),
                     }
                 }
             }
@@ -192,6 +192,10 @@ impl<'a> TimeSeries<'a> {
         }
     }
 }
+
+pub static TIMESERIES_OID: once_cell::sync::Lazy<pg_sys::Oid> = once_cell::sync::Lazy::new(|| {
+    TimeSeries::type_oid()
+});
 
 #[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn unnest_series(

--- a/extension/src/time_series/pipeline.rs
+++ b/extension/src/time_series/pipeline.rs
@@ -53,6 +53,10 @@ pg_type! {
             MapData: 6 {
                 // FIXME serialize/deserialize as `name(type)`
                 function: pg_sys::regproc,
+            },
+            MapSeries: 7 {
+                // FIXME serialize/deserialize as `name(type)`
+                function: pg_sys::regproc,
             }
         },
     }
@@ -121,6 +125,8 @@ pub fn execute_pipeline_element<'s, 'e>(
             return timeseries_delta(&timeseries),
         Element::MapData { function } =>
             return map::apply_to(timeseries, *function),
+        Element::MapSeries { function } =>
+            return map::apply_to_series(timeseries, *function),
     }
 }
 

--- a/extension/src/time_series/pipeline.rs
+++ b/extension/src/time_series/pipeline.rs
@@ -3,6 +3,7 @@ mod fill_holes;
 mod resample_to_rate;
 mod sort;
 mod delta;
+mod map;
 
 use std::convert::TryInto;
 
@@ -49,6 +50,10 @@ pg_type! {
             },
             Delta: 5 {
             },
+            MapData: 6 {
+                // FIXME serialize/deserialize as `name(type)`
+                function: pg_sys::regproc,
+            }
         },
     }
 }
@@ -114,6 +119,8 @@ pub fn execute_pipeline_element<'s, 'e>(
             return sort_timeseries(timeseries),
         Element::Delta{..} =>
             return timeseries_delta(&timeseries),
+        Element::MapData { function } =>
+            return map::apply_to(timeseries, *function),
     }
 }
 

--- a/extension/src/time_series/pipeline.rs
+++ b/extension/src/time_series/pipeline.rs
@@ -28,6 +28,8 @@ use resample_to_rate::{
 use sort::sort_timeseries;
 use delta::timeseries_delta;
 
+use crate::serialization::PgProcId;
+
 // TODO once we start stabilizing elements, create a type
 //      `TimeseriesPipelineElement` and move stable variants to that.
 pg_type! {
@@ -52,11 +54,11 @@ pg_type! {
             },
             MapData: 6 {
                 // FIXME serialize/deserialize as `name(type)`
-                function: pg_sys::regproc,
+                function: PgProcId,
             },
             MapSeries: 7 {
                 // FIXME serialize/deserialize as `name(type)`
-                function: pg_sys::regproc,
+                function: PgProcId,
             }
         },
     }
@@ -124,9 +126,9 @@ pub fn execute_pipeline_element<'s, 'e>(
         Element::Delta{..} =>
             return timeseries_delta(&timeseries),
         Element::MapData { function } =>
-            return map::apply_to(timeseries, *function),
+            return map::apply_to(timeseries, function.0),
         Element::MapSeries { function } =>
-            return map::apply_to_series(timeseries, *function),
+            return map::apply_to_series(timeseries, function.0),
     }
 }
 

--- a/extension/src/time_series/pipeline/map.rs
+++ b/extension/src/time_series/pipeline/map.rs
@@ -9,6 +9,82 @@ use crate::{
     flatten,
 };
 
+#[pg_extern(
+    stable,
+    parallel_safe,
+    name="map_series",
+    schema="toolkit_experimental"
+)]
+pub fn map_series_pipeline_element<'e>(
+    function: pg_sys::regproc,
+) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
+    let mut argtypes: *mut pg_sys::Oid = ptr::null_mut();
+    let mut nargs: ::std::os::raw::c_int = 0;
+    let rettype = unsafe {
+        pg_sys::get_func_signature(function, &mut argtypes, &mut nargs)
+    };
+
+    if nargs != 1 {
+        error!("invalid number of mapping function arguments, expected fn(timeseries) RETURNS timeseries")
+    }
+
+    if unsafe { *argtypes } != *crate::time_series::TIMESERIES_OID {
+        error!("invalid argument type, expected fn(timeseries) RETURNS timeseries")
+    }
+
+    if rettype != *crate::time_series::TIMESERIES_OID {
+        error!("invalid return type, expected fn(timeseries) RETURNS timeseries")
+    }
+
+    unsafe {
+        flatten!(
+            UnstableTimeseriesPipelineElement {
+                element: Element::MapSeries { function }
+            }
+        )
+    }
+}
+
+pub fn apply_to_series(series: TimeSeries<'_>, func: pg_sys::RegProcedure) -> TimeSeries<'_> {
+    let mut flinfo: pg_sys::FmgrInfo = unsafe {
+        MaybeUninit::zeroed().assume_init()
+    };
+
+    let fn_addr: unsafe extern "C" fn(*mut pg_sys::FunctionCallInfoBaseData) -> usize;
+    let mut fc_info = unsafe {
+        pg_sys::fmgr_info(func, &mut flinfo);
+        fn_addr = flinfo.fn_addr.expect("null function in timeseries map");
+        union FcInfo1 {
+            data: ManuallyDrop<pg_sys::FunctionCallInfoBaseData>,
+            #[allow(dead_code)]
+            bytes: [u8; mem::size_of::<pg_sys::FunctionCallInfoBaseData>()
+                + mem::size_of::<pg_sys::NullableDatum>()]
+        }
+        FcInfo1 {
+            data: ManuallyDrop::new(pg_sys::FunctionCallInfoBaseData {
+                flinfo: &mut flinfo,
+                context: std::ptr::null_mut(),
+                resultinfo: std::ptr::null_mut(),
+                fncollation: pg_sys::InvalidOid,
+                isnull: false,
+                nargs: 1,
+                args: Default::default(),
+            }),
+        }
+    };
+
+    unsafe {
+        let fc_info = &mut *fc_info.data;
+        let args = fc_info.args.as_mut_slice(1);
+        args[0].value = series.into_datum().unwrap();
+        args[0].isnull = false;
+        // FIXME wrap in pg_guard?
+        let res = fn_addr(fc_info);
+        TimeSeries::from_datum(res, fc_info.isnull, pg_sys::InvalidOid)
+            .expect("unexpected NULL in timeseries mapping function")
+    }
+}
+
 // TODO is (stable, parallel_safe) correct?
 #[pg_extern(
     stable,
@@ -194,6 +270,70 @@ mod tests {
                 {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":30.0},\
                 {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":60.0}\
             ]");
+        });
+    }
+
+    #[pg_test]
+    fn test_pipeline_map_series() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            // using the search path trick for this test b/c the operator is
+            // difficult to spot otherwise.
+            let sp = client.select("SELECT format(' %s, toolkit_experimental',current_setting('search_path'))", None, None).first().get_one::<String>().unwrap();
+            client.select(&format!("SET LOCAL search_path TO {}", sp), None, None);
+            client.select("SET timescaledb_toolkit_acknowledge_auto_drop TO 'true'", None, None);
+
+            client.select(
+                "CREATE TABLE series(time timestamptz, value double precision)",
+                None,
+                None
+            );
+            client.select(
+                "INSERT INTO series \
+                    VALUES \
+                    ('2020-01-04 UTC'::TIMESTAMPTZ, 25.0), \
+                    ('2020-01-01 UTC'::TIMESTAMPTZ, 10.0), \
+                    ('2020-01-03 UTC'::TIMESTAMPTZ, 20.0), \
+                    ('2020-01-02 UTC'::TIMESTAMPTZ, 15.0), \
+                    ('2020-01-05 UTC'::TIMESTAMPTZ, 30.0)",
+                None,
+                None
+            );
+
+            let val = client.select(
+                "SELECT (timeseries(time, value))::TEXT FROM series",
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":25.0},\
+                {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":10.0},\
+                {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":20.0},\
+                {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":15.0},\
+                {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":30.0}\
+            ]");
+
+            client.select(
+                "CREATE FUNCTION jan_3_x3(timeseries) RETURNS timeseries AS $$\
+                    SELECT timeseries(time, value * 3) \
+                    FROM (SELECT (unnest_series($1)).*) a \
+                    WHERE time='2020-01-03 00:00:00+00';\
+                $$ LANGUAGE SQL",
+                None,
+                None,
+            );
+
+
+            let val = client.select(
+                "SELECT (timeseries(time, value) |> map_series('jan_3_x3'))::TEXT FROM series",
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[{\"ts\":\"2020-01-03 00:00:00+00\",\"val\":60.0}]");
         });
     }
 }

--- a/extension/src/time_series/pipeline/map.rs
+++ b/extension/src/time_series/pipeline/map.rs
@@ -1,0 +1,199 @@
+
+use std::{mem::{self, ManuallyDrop, MaybeUninit}, ptr};
+
+use pgx::*;
+
+use super::*;
+
+use crate::{
+    flatten,
+};
+
+// TODO is (stable, parallel_safe) correct?
+#[pg_extern(
+    stable,
+    parallel_safe,
+    name="map_data",
+    schema="toolkit_experimental"
+)]
+pub fn map_data_pipeline_element<'e>(
+    function: pg_sys::regproc,
+) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
+    let mut argtypes: *mut pg_sys::Oid = ptr::null_mut();
+    let mut nargs: ::std::os::raw::c_int = 0;
+    let rettype = unsafe {
+        pg_sys::get_func_signature(function, &mut argtypes, &mut nargs)
+    };
+
+    if nargs != 1 {
+        error!("invalid number of mapping function arguments, expected fn(double precision) RETURNS double precision")
+    }
+
+    if unsafe { *argtypes } != pgx::PgBuiltInOids::FLOAT8OID.value() {
+        error!("invalid argument type, expected fn(double precision) RETURNS double precision")
+    }
+
+    if rettype != pgx::PgBuiltInOids::FLOAT8OID.value() {
+        error!("invalid return type, expected fn(double precision) RETURNS double precision")
+    }
+
+    unsafe {
+        flatten!(
+            UnstableTimeseriesPipelineElement {
+                element: Element::MapData { function }
+            }
+        )
+    }
+}
+
+
+pub fn apply_to(mut series: TimeSeries<'_>, func: pg_sys::RegProcedure)
+-> TimeSeries<'_> {
+    let mut flinfo: pg_sys::FmgrInfo = unsafe {
+        MaybeUninit::zeroed().assume_init()
+    };
+
+
+
+    let fn_addr: unsafe extern "C" fn(*mut pg_sys::FunctionCallInfoBaseData) -> usize;
+    let mut fc_info = unsafe {
+        pg_sys::fmgr_info(func, &mut flinfo);
+        fn_addr = flinfo.fn_addr.expect("null function in timeseries map");
+        union FcInfo1 {
+            data: ManuallyDrop<pg_sys::FunctionCallInfoBaseData>,
+            #[allow(dead_code)]
+            bytes: [u8; mem::size_of::<pg_sys::FunctionCallInfoBaseData>()
+                + mem::size_of::<pg_sys::NullableDatum>()]
+        }
+        FcInfo1 {
+            data: ManuallyDrop::new(pg_sys::FunctionCallInfoBaseData {
+                flinfo: &mut flinfo,
+                context: std::ptr::null_mut(),
+                resultinfo: std::ptr::null_mut(),
+                fncollation: pg_sys::InvalidOid,
+                isnull: false,
+                nargs: 1,
+                args: Default::default(),
+            }),
+        }
+    };
+
+
+    let invoke = |val: f64| unsafe {
+        let fc_info = &mut *fc_info.data;
+        let args = fc_info.args.as_mut_slice(1);
+        args[0].value = val.into_datum().unwrap();
+        args[0].isnull = false;
+        let res = fn_addr(fc_info);
+        f64::from_datum(res, false, pg_sys::InvalidOid)
+            .expect("unexpected NULL in timeseries mapping function")
+    };
+
+    //FIXME add setjmp guard around loop
+    map_series(&mut series, invoke);
+    series
+}
+
+fn map_series(series: &mut TimeSeries<'_>, mut func: impl FnMut(f64) -> f64) {
+    use SeriesType::*;
+    //FIXME add setjmp guard around loops
+    match &mut series.series {
+        SortedSeries { points, .. } => {
+            for point in points.as_owned() {
+                *point = TSPoint {
+                    ts: point.ts,
+                    val: func(point.val),
+                }
+            }
+        },
+        NormalSeries { values, .. } => {
+            for value in values.as_owned() {
+                *value = func(*value)
+            }
+        },
+        ExplicitSeries { points, .. } => {
+            for point in points.as_owned() {
+                *point = TSPoint {
+                    ts: point.ts,
+                    val: func(point.val),
+                }
+            }
+        },
+        GappyNormalSeries { values, .. } => {
+                for value in values.as_owned() {
+                    *value = func(*value)
+                }
+        },
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+mod tests {
+    use pgx::*;
+
+    #[pg_test]
+    fn test_pipeline_map_data() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            // using the search path trick for this test b/c the operator is
+            // difficult to spot otherwise.
+            let sp = client.select("SELECT format(' %s, toolkit_experimental',current_setting('search_path'))", None, None).first().get_one::<String>().unwrap();
+            client.select(&format!("SET LOCAL search_path TO {}", sp), None, None);
+            client.select("SET timescaledb_toolkit_acknowledge_auto_drop TO 'true'", None, None);
+
+            client.select(
+                "CREATE TABLE series(time timestamptz, value double precision)",
+                None,
+                None
+            );
+            client.select(
+                "INSERT INTO series \
+                    VALUES \
+                    ('2020-01-04 UTC'::TIMESTAMPTZ, 25.0), \
+                    ('2020-01-01 UTC'::TIMESTAMPTZ, 10.0), \
+                    ('2020-01-03 UTC'::TIMESTAMPTZ, 20.0), \
+                    ('2020-01-02 UTC'::TIMESTAMPTZ, 15.0), \
+                    ('2020-01-05 UTC'::TIMESTAMPTZ, 30.0)",
+                None,
+                None
+            );
+
+            let val = client.select(
+                "SELECT (timeseries(time, value))::TEXT FROM series",
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":25.0},\
+                {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":10.0},\
+                {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":20.0},\
+                {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":15.0},\
+                {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":30.0}\
+            ]");
+
+            client.select(
+                "CREATE FUNCTION x2(double precision) RETURNS DOUBLE PRECISION AS 'SELECT $1 * 2;' LANGUAGE SQL",
+                None,
+                None,
+            );
+
+
+            let val = client.select(
+                "SELECT (timeseries(time, value) |> map_data('x2'))::TEXT FROM series",
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":50.0},\
+                {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":20.0},\
+                {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":40.0},\
+                {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":30.0},\
+                {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":60.0}\
+            ]");
+        });
+    }
+}

--- a/extension/src/time_series/pipeline/map.rs
+++ b/extension/src/time_series/pipeline/map.rs
@@ -7,6 +7,7 @@ use super::*;
 
 use crate::{
     flatten,
+    serialization::PgProcId,
 };
 
 #[pg_extern(
@@ -39,7 +40,7 @@ pub fn map_series_pipeline_element<'e>(
     unsafe {
         flatten!(
             UnstableTimeseriesPipelineElement {
-                element: Element::MapSeries { function }
+                element: Element::MapSeries { function: PgProcId(function) }
             }
         )
     }
@@ -49,39 +50,20 @@ pub fn apply_to_series(series: TimeSeries<'_>, func: pg_sys::RegProcedure) -> Ti
     let mut flinfo: pg_sys::FmgrInfo = unsafe {
         MaybeUninit::zeroed().assume_init()
     };
-
-    let fn_addr: unsafe extern "C" fn(*mut pg_sys::FunctionCallInfoBaseData) -> usize;
-    let mut fc_info = unsafe {
+    unsafe {
         pg_sys::fmgr_info(func, &mut flinfo);
-        fn_addr = flinfo.fn_addr.expect("null function in timeseries map");
-        union FcInfo1 {
-            data: ManuallyDrop<pg_sys::FunctionCallInfoBaseData>,
-            #[allow(dead_code)]
-            bytes: [u8; mem::size_of::<pg_sys::FunctionCallInfoBaseData>()
-                + mem::size_of::<pg_sys::NullableDatum>()]
-        }
-        FcInfo1 {
-            data: ManuallyDrop::new(pg_sys::FunctionCallInfoBaseData {
-                flinfo: &mut flinfo,
-                context: std::ptr::null_mut(),
-                resultinfo: std::ptr::null_mut(),
-                fncollation: pg_sys::InvalidOid,
-                isnull: false,
-                nargs: 1,
-                args: Default::default(),
-            }),
-        }
     };
 
     unsafe {
-        let fc_info = &mut *fc_info.data;
-        let args = fc_info.args.as_mut_slice(1);
-        args[0].value = series.into_datum().unwrap();
-        args[0].isnull = false;
-        // FIXME wrap in pg_guard?
-        let res = fn_addr(fc_info);
-        TimeSeries::from_datum(res, fc_info.isnull, pg_sys::InvalidOid)
+        // use pg_sys::FunctionCall1Coll to get the pg_guard
+        let res = pg_sys::FunctionCall1Coll(
+            &mut flinfo,
+            pg_sys::InvalidOid,
+            series.into_datum().unwrap(),
+        );
+        TimeSeries::from_datum(res, false, pg_sys::InvalidOid)
             .expect("unexpected NULL in timeseries mapping function")
+
     }
 }
 
@@ -116,7 +98,7 @@ pub fn map_data_pipeline_element<'e>(
     unsafe {
         flatten!(
             UnstableTimeseriesPipelineElement {
-                element: Element::MapData { function }
+                element: Element::MapData { function: PgProcId(function) }
             }
         )
     }
@@ -161,21 +143,22 @@ pub fn apply_to(mut series: TimeSeries<'_>, func: pg_sys::RegProcedure)
         args[0].value = val.into_datum().unwrap();
         args[0].isnull = false;
         let res = fn_addr(fc_info);
-        f64::from_datum(res, false, pg_sys::InvalidOid)
+        f64::from_datum(res, fc_info.isnull, pg_sys::InvalidOid)
             .expect("unexpected NULL in timeseries mapping function")
     };
 
-    //FIXME add setjmp guard around loop
     map_series(&mut series, invoke);
     series
 }
 
 fn map_series(series: &mut TimeSeries<'_>, mut func: impl FnMut(f64) -> f64) {
     use SeriesType::*;
-    //FIXME add setjmp guard around loops
+
     match &mut series.series {
         SortedSeries { points, .. } => {
-            for point in points.as_owned() {
+            let points = points.as_owned();
+            //FIXME add setjmp guard around loop
+            for point in points {
                 *point = TSPoint {
                     ts: point.ts,
                     val: func(point.val),
@@ -183,12 +166,16 @@ fn map_series(series: &mut TimeSeries<'_>, mut func: impl FnMut(f64) -> f64) {
             }
         },
         NormalSeries { values, .. } => {
-            for value in values.as_owned() {
+            let values = values.as_owned();
+            //FIXME add setjmp guard around loop
+            for value in values {
                 *value = func(*value)
             }
         },
         ExplicitSeries { points, .. } => {
-            for point in points.as_owned() {
+            let points = points.as_owned();
+            //FIXME add setjmp guard around loop
+            for point in points {
                 *point = TSPoint {
                     ts: point.ts,
                     val: func(point.val),
@@ -196,9 +183,11 @@ fn map_series(series: &mut TimeSeries<'_>, mut func: impl FnMut(f64) -> f64) {
             }
         },
         GappyNormalSeries { values, .. } => {
-                for value in values.as_owned() {
-                    *value = func(*value)
-                }
+            let values = values.as_owned();
+            //FIXME add setjmp guard around loop
+            for value in values {
+                *value = func(*value)
+            }
         },
     }
 }
@@ -334,6 +323,107 @@ mod tests {
                 .first()
                 .get_one::<String>();
             assert_eq!(val.unwrap(), "[{\"ts\":\"2020-01-03 00:00:00+00\",\"val\":60.0}]");
+        });
+    }
+
+    #[pg_test]
+    fn test_map_io() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            // using the search path trick for this test b/c the operator is
+            // difficult to spot otherwise.
+            let sp = client.select("SELECT format(' %s, toolkit_experimental',current_setting('search_path'))", None, None).first().get_one::<String>().unwrap();
+            client.select(&format!("SET LOCAL search_path TO {}", sp), None, None);
+            client.select("SET timescaledb_toolkit_acknowledge_auto_drop TO 'true'", None, None);
+
+            client.select(
+                "CREATE TABLE series(time timestamptz, value double precision)",
+                None,
+                None
+            );
+            client.select(
+                "INSERT INTO series \
+                    VALUES \
+                    ('2020-01-04 UTC'::TIMESTAMPTZ, 25.0), \
+                    ('2020-01-01 UTC'::TIMESTAMPTZ, 10.0), \
+                    ('2020-01-03 UTC'::TIMESTAMPTZ, 20.0), \
+                    ('2020-01-02 UTC'::TIMESTAMPTZ, 15.0), \
+                    ('2020-01-05 UTC'::TIMESTAMPTZ, 30.0)",
+                None,
+                None
+            );
+
+            let val = client.select(
+                "SELECT (timeseries(time, value))::TEXT FROM series",
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":25.0},\
+                {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":10.0},\
+                {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":20.0},\
+                {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":15.0},\
+                {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":30.0}\
+            ]");
+
+            client.select(
+                "CREATE FUNCTION serier(timeseries) RETURNS timeseries AS $$\
+                    SELECT $1;\
+                $$ LANGUAGE SQL",
+                None,
+                None,
+            );
+
+            client.select(
+                "CREATE FUNCTION dater(double precision) RETURNS double precision AS $$\
+                    SELECT $1 * 3;\
+                $$ LANGUAGE SQL",
+                None,
+                None,
+            );
+
+
+            let (a, b) = client.select(
+                "SELECT map_series('serier')::TEXT, map_data('dater')::TEXT FROM series",
+                None,
+                None
+            )
+                .first()
+                .get_two::<String, String>();
+            let one = "\
+            {\
+                \"version\":1,\
+                \"element\":{\
+                    \"MapSeries\":{\
+                        \"function\":\"public.serier(toolkit_experimental.timeseries)\"\
+                    }\
+                }\
+            }";
+            let two = "\
+            {\
+                \"version\":1,\
+                \"element\":{\
+                    \"MapData\":{\
+                        \"function\":\"public.dater(double precision)\"\
+                    }\
+                }\
+            }";
+            assert_eq!((&*a.unwrap(), &*b.unwrap()), (one, two));
+
+            let (a, b) = client.select(
+                &*format!("SELECT \
+                    '{}'::UnstableTimeseriesPipelineElement::Text, \
+                    '{}'::UnstableTimeseriesPipelineElement::Text",
+                    one, two
+                ),
+                None,
+                None
+            )
+                .first()
+                .get_two::<String, String>();
+            assert_eq!((&*a.unwrap(), &*b.unwrap()), (one, two));
         });
     }
 }


### PR DESCRIPTION
This PR adds a number of utilities for user-defined pipeline elements:

1. `map_series()` allows users to use `fn(timeseries) returns timeseries` to create their own pipeline elements
2.  A wildly experimental `|>>` operator allows using custom pipeline elements almost as ergonomically as ones we define.
3. `map_data()` is a convenience function that allows users to apply `fn(double precision) returns double precision` to apply data-local transformations.

-----

**`map_series()`**

This function allows users to write their own pipeline elements by writing a SQL function `fn(timeseries) returns timeseries`. For example

```SQL
CREATE FUNCTION jan_3_x3(timeseries) RETURNS timeseries AS $$
    SELECT timeseries(time, value * 3)
    FROM (SELECT (unnest_series($1)).*) a
    WHERE time='2020-01-03 00:00:00+00';
$$ LANGUAGE SQL;

SELECT series |> map_series('jan_3_x3');
```

This greatly expands the power users have, and should enable them to fill in gaps in the timeseries API if needed.

-----

**`|>>`**

This operator, `|>>` can be used anywhere our other operator can except that right side is a regproc instead of a pipeline element eg. it looks like
```SQL
CREATE FUNCTION yesterday_squared(timeseries) RETURNS timeseries AS $$
    SELECT timeseries(time, value * value) \
    FROM (SELECT (unnest_series($1)).*) a \
    WHERE time>now() - '1 day'::interval;\
$$ LANGUAGE SQL;

SELECT series |>> 'yesterday_squared';
```

It is wildly experimental, even compared to the rest of the pipeline API. This PR creates a new operator instead of reusing the `|>` because if we use `|>` for both this and and the regular timeseries elements trying to do `series |> 'custom_element'` gets an ambiguous operator error `timeseries |> unknown` is not unique. In the future we could consider changing the element input function to fallback to checking if the input is a regproc if it doesn't recognize it; the formats should be different enough that there's no risk of collision.

-----

**`map_data()`**

`map_data()` is a convenience element for users that just want to apply mappings over the data stored in a timesries; it takes a `fn(double precision) returns double precision` and applies it to every datapoint eg.
```SQL
CREATE FUNCTION x2(double precision) RETURNS DOUBLE PRECISION
AS 'SELECT $1 * 2;' LANGUAGE SQL;

SELECT series |> map_data('x2');
```

-----

These functions should add a lot more power to the pipeline API since with the addition of `map_series()` users can create their own timeseries pipeline elements if the find the preexisting set lacking. Though `map_series()` should be "complete" in that any element one wants could be defined in terms of `map_series()` we may want to consider adding other connivence methods for common interactions. In particular, a `map_points(timestamptz, double precision)` seems like a promising candidate.

-----

The PR contains ≈1 commit per function, though note that the first commit is `map_data()` as that was simplest to implement. The PR also contains some refactoring, notably switching our pipeline executor to take in timeseries by-value; this was needed to make user-defined elements work.