### PR TITLE
Up pgx version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -36,12 +36,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,12 +43,12 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "as-slice"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4d1c23475b74e3672afa8c2be22040b8b7783ad9b461021144ed10a46bb0e6"
+checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
 dependencies = [
- "generic-array 0.12.3",
- "generic-array 0.13.2",
+ "generic-array 0.12.4",
+ "generic-array 0.13.3",
  "generic-array 0.14.4",
  "stable_deref_trait",
 ]
@@ -131,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.57.0"
+version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd4865004a46a0aafb2a0a5eb19d3c9fc46ee5f063a6cfc605c69ac9ecf5263d"
+checksum = "0f8523b410d7187a43085e7e064416ea32ded16bd0a4e6fc025e21616d01258f"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -157,17 +151,6 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-
-[[package]]
-name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
 
 [[package]]
 name = "block-buffer"
@@ -283,12 +266,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "counter-agg"
 version = "0.1.0"
 dependencies = [
@@ -383,18 +360,18 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "3.0.1"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
  "libc",
  "redox_users",
@@ -614,18 +591,18 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "generic-array"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
+checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
 dependencies = [
  "typenum",
 ]
@@ -694,12 +671,12 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.5.6"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74911a68a1658cfcfb61bc0ccfbd536e3b6e906f8c2f7883ee50157e3e2184f1"
+checksum = "634bd4d29cbf24424d0a4bfcbf80c6960129dc24424752a7d1d1390607023422"
 dependencies = [
  "as-slice",
- "generic-array 0.13.2",
+ "generic-array 0.14.4",
  "hash32",
  "stable_deref_trait",
 ]
@@ -796,9 +773,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "a1fa8cddc8fbbee11227ef194b5317ed014b8acbf15139bd716a18ad3fe99ec5"
 
 [[package]]
 name = "libloading"
@@ -852,22 +829,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
-name = "md5"
-version = "0.7.0"
+name = "md-5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "opaque-debug",
+]
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
@@ -917,7 +899,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "socket2",
+ "socket2 0.3.19",
  "winapi 0.3.9",
 ]
 
@@ -962,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad167a2f54e832b82dbe003a046280dceffe5227b5f79e08e363a29638cfddd"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
@@ -1002,7 +984,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.2.5",
+ "redox_syscall",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -1027,8 +1009,8 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pgx"
-version = "0.1.19"
-source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#87e0460e6e88d6ffa9b9eb37dce4b71e4336e31e"
+version = "0.1.21"
+source = "git+https://github.com/JLockerman/pgx.git?branch=timescale2#e5b383422200bc0345eba2747cc50e5878d8d19c"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1049,8 +1031,8 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.1.19"
-source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#87e0460e6e88d6ffa9b9eb37dce4b71e4336e31e"
+version = "0.1.21"
+source = "git+https://github.com/JLockerman/pgx.git?branch=timescale2#e5b383422200bc0345eba2747cc50e5878d8d19c"
 dependencies = [
  "pgx-utils",
  "proc-macro2",
@@ -1061,8 +1043,8 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.1.19"
-source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#87e0460e6e88d6ffa9b9eb37dce4b71e4336e31e"
+version = "0.1.21"
+source = "git+https://github.com/JLockerman/pgx.git?branch=timescale2#e5b383422200bc0345eba2747cc50e5878d8d19c"
 dependencies = [
  "bindgen",
  "build-deps",
@@ -1080,8 +1062,8 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.1.19"
-source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#87e0460e6e88d6ffa9b9eb37dce4b71e4336e31e"
+version = "0.1.21"
+source = "git+https://github.com/JLockerman/pgx.git?branch=timescale2#e5b383422200bc0345eba2747cc50e5878d8d19c"
 dependencies = [
  "colored",
  "lazy_static",
@@ -1099,8 +1081,8 @@ dependencies = [
 
 [[package]]
 name = "pgx-utils"
-version = "0.1.19"
-source = "git+https://github.com/JLockerman/pgx.git?branch=timescale#87e0460e6e88d6ffa9b9eb37dce4b71e4336e31e"
+version = "0.1.21"
+source = "git+https://github.com/JLockerman/pgx.git?branch=timescale2#e5b383422200bc0345eba2747cc50e5878d8d19c"
 dependencies = [
  "colored",
  "dirs",
@@ -1158,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "postgres"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f853fba627ed1f21392d329eeb03caf90dce57a65dfbd24274f4c39452ed3bb"
+checksum = "c7871ee579860d8183f542e387b176a25f2656b9fb5211e045397f745a68d1c2"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -1172,16 +1154,16 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e34ad3dc5c56d036b9418185ee97e14b6766d55c8ccf9dc18302ad4e6371d9"
+checksum = "ff3e0f70d32e20923cabf2df02913be7c1842d4c772db8065c00fcfdd1d1bff3"
 dependencies = [
  "base64 0.13.0",
  "byteorder",
  "bytes",
  "fallible-iterator",
  "hmac",
- "md5",
+ "md-5",
  "memchr",
  "rand 0.8.3",
  "sha2",
@@ -1190,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493d9d4613b88b12433aa12890e74e74cd93fdc1e08b7c2aed4768aaae8414c"
+checksum = "430f4131e1b7657b0cd9a2b0c3408d77c9a43a042d300b8c77f981dffcc43a2f"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -1219,9 +1201,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -1387,12 +1369,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
@@ -1402,32 +1378,30 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.1.16",
- "redox_syscall 0.1.57",
- "rust-argon2",
+ "getrandom 0.2.2",
+ "redox_syscall",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rttp_client"
@@ -1444,18 +1418,6 @@ dependencies = [
  "rand 0.7.3",
  "socks",
  "url",
-]
-
-[[package]]
-name = "rust-argon2"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
-dependencies = [
- "base64 0.13.0",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1529,9 +1491,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "d1f72836d2aa753853178eda473a3b9d8e4eefdaf20523b919677e6de489f8f1"
 dependencies = [
  "serde_derive",
 ]
@@ -1560,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.129"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "e57ae87ad533d9a56427558b516d0adac283614e347abf85b0dc0cbbf0a249f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1571,9 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.62"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
@@ -1601,9 +1563,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "0.1.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
 name = "shutdown_hooks"
@@ -1636,6 +1598,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "socket2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
+dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
@@ -1764,9 +1736,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "b7f58f7e8eaa0009c5fec437aabf511bd9933e4b2d7407bd05273c01a8906ea7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1845,19 +1817,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "time"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1195b046942c221454c2539395f85413b33383a067449d78aab2b7b052a142f7"
+checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
 dependencies = [
  "const_fn",
  "libc",
@@ -1969,9 +1932,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc9f82c2bfb06a33dd0dfb44b07ca98fe72df19e681d80c78d05a1bac2138e2"
+checksum = "2d2b1383c7e4fb9a09e292c7c6afb7da54418d53b045f1c1fac7a911411a2b8b"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1985,7 +1948,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "socket2",
+ "socket2 0.4.1",
  "tokio",
  "tokio-util",
 ]

--- a/Readme.md
+++ b/Readme.md
@@ -40,7 +40,7 @@ sudo apt-get install make gcc pkg-config clang postgresql-server-dev-13 libssl-d
 and finally, the toolkit uses a [fork](https://github.com/JLockerman/pgx/tree/timescale)
 of [pgx](https://github.com/zombodb/pgx) while our patches are being upstreamed. It can be installed with
 ```bash
-cargo install --git https://github.com/JLockerman/pgx.git --branch timescale cargo-pgx && \
+cargo install --git https://github.com/JLockerman/pgx.git --branch timescale2 cargo-pgx && \
 cargo pgx init --pg13 pg_config
 ```
 
@@ -74,7 +74,7 @@ The extension is built using a [fork](https://github.com/JLockerman/pgx/tree/tim
 of [pgx](https://github.com/zombodb/pgx). To install pgx use
 
 ```bash
-cargo install --git https://github.com/JLockerman/pgx.git --branch timescale cargo-pgx && \
+cargo install --git https://github.com/JLockerman/pgx.git --branch timescale2 cargo-pgx && \
 cargo pgx init
 ```
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -8,7 +8,7 @@ RUN useradd -ms /bin/bash postgres
 USER postgres
 
 # custom pgx until upstream workspace support is added
-RUN cargo install --git https://github.com/JLockerman/pgx.git --branch timescale cargo-pgx
+RUN cargo install --git https://github.com/JLockerman/pgx.git --branch timescale2 cargo-pgx
 
 # only use pg12 for now timescaledb doesn't support 13
 RUN set -ex \

--- a/docker/nightly/Dockerfile
+++ b/docker/nightly/Dockerfile
@@ -24,7 +24,7 @@ ENV PATH="/build/.cargo/bin:${PATH}"
 RUN set -ex \
     && rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" \
     && chown postgres:postgres -R "${CARGO_HOME}" \
-    && cargo install --git https://github.com/JLockerman/pgx.git --branch timescale cargo-pgx \
+    && cargo install --git https://github.com/JLockerman/pgx.git --branch timescale2 cargo-pgx \
     && cargo pgx init --pg13 /usr/lib/postgresql/13/bin/pg_config
 
 COPY . /rust/timescale-analytics

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -15,8 +15,8 @@ pg13 = ["pgx/pg13", "pgx-tests/pg13"]
 pg_test = ["approx"]
 
 [dependencies]
-pgx = {git="https://github.com/JLockerman/pgx.git", branch="timescale"}
-pgx-macros = {git="https://github.com/JLockerman/pgx.git", branch="timescale"}
+pgx = {git="https://github.com/JLockerman/pgx.git", branch="timescale2"}
+pgx-macros = {git="https://github.com/JLockerman/pgx.git", branch="timescale2"}
 encodings = {path="../crates/encodings"}
 flat_serialize = {path="../crates/flat_serialize/flat_serialize"}
 flat_serialize_macro = {path="../crates/flat_serialize/flat_serialize_macro"}
@@ -39,5 +39,5 @@ rand_distr = "0.4.0"
 rand_chacha = "0.3.0"
 
 [dev-dependencies]
-pgx-tests = {git="https://github.com/JLockerman/pgx.git", branch="timescale"}
+pgx-tests = {git="https://github.com/JLockerman/pgx.git", branch="timescale2"}
 approx = "0.4.0"

--- a/extension/src/asap.rs
+++ b/extension/src/asap.rs
@@ -193,6 +193,7 @@ mod tests {
     #[pg_test]
     fn test_asap() {
         Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
             client.select("CREATE TABLE asap_test (date timestamptz, value DOUBLE PRECISION)", None, None);
 
             // Create a table with some cyclic data

--- a/extension/src/time_series/pipeline.rs
+++ b/extension/src/time_series/pipeline.rs
@@ -244,6 +244,7 @@ mod tests {
     #[pg_test]
     fn test_pipeline_lttb() {
         Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
             // using the search path trick for this test b/c the operator is
             // difficult to spot otherwise.
             let sp = client.select("SELECT format(' %s, toolkit_experimental',current_setting('search_path'))", None, None).first().get_one::<String>().unwrap();

--- a/extension/src/time_series/pipeline/delta.rs
+++ b/extension/src/time_series/pipeline/delta.rs
@@ -60,6 +60,7 @@ mod tests {
     #[pg_test]
     fn test_pipeline_delta() {
         Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
             // using the search path trick for this test b/c the operator is
             // difficult to spot otherwise.
             let sp = client.select("SELECT format(' %s, toolkit_experimental',current_setting('search_path'))", None, None).first().get_one::<String>().unwrap();

--- a/extension/src/time_series/pipeline/fill_holes.rs
+++ b/extension/src/time_series/pipeline/fill_holes.rs
@@ -34,7 +34,7 @@ impl FillMethod {
                                 if present[pidx as usize / 64] & 1 << (pidx % 64) != 0 {
                                     last_val = values[vidx];
                                     vidx += 1;
-                                } 
+                                }
                                 results.push(last_val);
                             }
 
@@ -119,7 +119,7 @@ pub fn holefill_pipeline_element<'e> (
 }
 
 pub fn fill_holes(
-    series: &toolkit_experimental::TimeSeries, 
+    series: &toolkit_experimental::TimeSeries,
     element: &toolkit_experimental::Element
 ) -> toolkit_experimental::TimeSeries<'static> {
     let method = match element {
@@ -141,6 +141,7 @@ mod tests {
     #[pg_test]
     fn test_pipeline_gapfill() {
         Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
             // using the search path trick for this test b/c the operator is
             // difficult to spot otherwise.
             let sp = client.select("SELECT format(' %s, toolkit_experimental',current_setting('search_path'))", None, None).first().get_one::<String>().unwrap();
@@ -172,7 +173,7 @@ mod tests {
                 None,
                 None
             );
-            
+
             client.select(
                 "INSERT INTO gappy_series \
                     SELECT \

--- a/extension/src/time_series/pipeline/resample_to_rate.rs
+++ b/extension/src/time_series/pipeline/resample_to_rate.rs
@@ -116,12 +116,12 @@ fn determine_offset_from_rate(first_timestamp: i64, rate: i64, snap_to_rate: boo
 
     match method {
         ResampleMethod::Average | ResampleMethod::Nearest | ResampleMethod::WeightedAverage => result - rate / 2,
-        ResampleMethod::TrailingAverage => result, 
+        ResampleMethod::TrailingAverage => result,
     }
 }
 
 pub fn resample_to_rate(
-    series: &toolkit_experimental::TimeSeries, 
+    series: &toolkit_experimental::TimeSeries,
     element: &toolkit_experimental::Element
 ) -> toolkit_experimental::TimeSeries<'static> {
     let (interval, method, snap) = match element {
@@ -151,7 +151,7 @@ pub fn resample_to_rate(
                     Some(ref mut series) => series.add_point(new_pt),
                 }
             }
-            
+
             current = Some(target);
             points.clear();
         }
@@ -174,6 +174,7 @@ mod tests {
     #[pg_test]
     fn test_pipeline_resample() {
         Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
             // using the search path trick for this test b/c the operator is
             // difficult to spot otherwise.
             let sp = client.select("SELECT format(' %s, toolkit_experimental',current_setting('search_path'))", None, None).first().get_one::<String>().unwrap();

--- a/extension/src/time_series/pipeline/sort.rs
+++ b/extension/src/time_series/pipeline/sort.rs
@@ -55,6 +55,7 @@ mod tests {
     #[pg_test]
     fn test_pipeline_sort() {
         Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
             // using the search path trick for this test b/c the operator is
             // difficult to spot otherwise.
             let sp = client.select("SELECT format(' %s, toolkit_experimental',current_setting('search_path'))", None, None).first().get_one::<String>().unwrap();

--- a/extension/src/time_weighted_average.rs
+++ b/extension/src/time_weighted_average.rs
@@ -345,6 +345,7 @@ mod tests {
     #[pg_test]
     fn test_time_weight_io() {
         Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
             let stmt = "CREATE TABLE test(ts timestamptz, val DOUBLE PRECISION)";
             client.select(stmt, None, None);
 

--- a/tools/sql-doctester/Cargo.toml
+++ b/tools/sql-doctester/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 bytecount = "0.6.2"
 clap = { version = "2.33", features = ["wrap_help"] }
 colored = "2.0.0"
-postgres = "0.19.0"
+postgres = "0.19.1"
 pulldown-cmark = "0.8.0"
 rayon = "1.5"
 uuid = { version = "0.8", features = ["v4"] }


### PR DESCRIPTION
We're getting closer to being able to work on vanilla upstream. Changes since last sync seem to alter the way the Spi client handles timezones, so explicitly set the timezone on those tests that rely on the old behavior.

Also update the readme and docker images to use the new branch to install `cargo-pgx` even though this _technically_ isn't needed.