### PR TITLE
Mark functions immutable / parallel safe

### DIFF
--- a/extension/src/asap.rs
+++ b/extension/src/asap.rs
@@ -12,7 +12,7 @@ use time_series::{TSPoint, TimeSeries as InternalTimeSeries, ExplicitTimeSeries,
 use crate::time_series::TimeSeries;
 
 // This is included for debug purposes and probably should not leave experimental
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn asap_smooth_raw(
     data: Vec<f64>,
     resolution: i32,
@@ -31,7 +31,7 @@ pub struct ASAPTransState {
     resolution: i32,
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn asap_trans(
     state: Option<Internal<ASAPTransState>>,
     ts: Option<pg_sys::TimestampTz>,
@@ -88,7 +88,7 @@ fn find_downsample_interval(series: &ExplicitTimeSeries, resolution: i64) -> i64
     candidate / median * median  // Truncate candidate to a multiple of median
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 fn asap_final(
     state: Option<Internal<ASAPTransState>>,
     fcinfo: pg_sys::FunctionCallInfo,
@@ -137,7 +137,7 @@ fn asap_final(
     }
 }
 
-#[pg_extern(name="asap_smooth", schema = "toolkit_experimental")]
+#[pg_extern(name="asap_smooth", schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn asap_on_timeseries(
     series: crate::time_series::toolkit_experimental::TimeSeries<'static>,
     resolution: i32

--- a/extension/src/counter_agg.rs
+++ b/extension/src/counter_agg.rs
@@ -157,7 +157,7 @@ impl CounterSummaryTransState {
     }
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn counter_summary_trans_serialize(
     mut state: Internal<CounterSummaryTransState>,
 ) -> bytea {
@@ -165,7 +165,7 @@ pub fn counter_summary_trans_serialize(
     crate::do_serialize!(state)
 }
 
-#[pg_extern(schema = "toolkit_experimental", strict)]
+#[pg_extern(schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 pub fn counter_summary_trans_deserialize(
     bytes: bytea,
     _internal: Option<Internal<()>>,
@@ -173,7 +173,7 @@ pub fn counter_summary_trans_deserialize(
     crate::do_deserialize!(bytes, CounterSummaryTransState)
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn counter_agg_trans(
     state: Option<Internal<CounterSummaryTransState>>,
     ts: Option<pg_sys::TimestampTz>,
@@ -203,7 +203,7 @@ pub fn counter_agg_trans(
     }
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn counter_agg_trans_no_bounds(
     state: Option<Internal<CounterSummaryTransState>>,
     ts: Option<pg_sys::TimestampTz>,
@@ -214,7 +214,7 @@ pub fn counter_agg_trans_no_bounds(
 }
 
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn counter_agg_summary_trans(
     state: Option<Internal<CounterSummaryTransState>>,
     value: Option<toolkit_experimental::CounterSummary>,
@@ -235,7 +235,7 @@ pub fn counter_agg_summary_trans(
     }
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn counter_agg_combine(
     state1: Option<Internal<CounterSummaryTransState>>,
     state2: Option<Internal<CounterSummaryTransState>>,
@@ -260,7 +260,7 @@ pub fn counter_agg_combine(
     }
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 fn counter_agg_final(
     state: Option<Internal<CounterSummaryTransState>>,
     fcinfo: pg_sys::FunctionCallInfo,
@@ -328,7 +328,7 @@ CREATE AGGREGATE toolkit_experimental.rollup(cs toolkit_experimental.CounterSumm
 );
 "#);
 
-#[pg_extern(name="delta", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="delta", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn counter_agg_delta(
     summary: toolkit_experimental::CounterSummary,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -336,7 +336,7 @@ fn counter_agg_delta(
     summary.to_internal_counter_summary().delta()
 }
 
-#[pg_extern(name="rate", schema = "toolkit_experimental", strict, immutable )]
+#[pg_extern(name="rate", schema = "toolkit_experimental", strict, immutable, parallel_safe )]
 fn counter_agg_rate(
     summary: toolkit_experimental::CounterSummary,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -344,7 +344,7 @@ fn counter_agg_rate(
     summary.to_internal_counter_summary().rate()
 }
 
-#[pg_extern(name="time_delta", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="time_delta", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn counter_agg_time_delta(
     summary: toolkit_experimental::CounterSummary,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -352,7 +352,7 @@ fn counter_agg_time_delta(
     summary.to_internal_counter_summary().time_delta()
 }
 
-#[pg_extern(name="irate_left", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="irate_left", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn counter_agg_irate_left(
     summary: toolkit_experimental::CounterSummary,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -360,7 +360,7 @@ fn counter_agg_irate_left(
     summary.to_internal_counter_summary().irate_left()
 }
 
-#[pg_extern(name="irate_right", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="irate_right", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn counter_agg_irate_right(
     summary: toolkit_experimental::CounterSummary,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -368,7 +368,7 @@ fn counter_agg_irate_right(
     summary.to_internal_counter_summary().irate_right()
 }
 
-#[pg_extern(name="idelta_left", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="idelta_left", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn counter_agg_idelta_left(
     summary: toolkit_experimental::CounterSummary,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -376,7 +376,7 @@ fn counter_agg_idelta_left(
     summary.to_internal_counter_summary().idelta_left()
 }
 
-#[pg_extern(name="idelta_right", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="idelta_right", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn counter_agg_idelta_right(
     summary: toolkit_experimental::CounterSummary,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -384,7 +384,7 @@ fn counter_agg_idelta_right(
     summary.to_internal_counter_summary().idelta_right()
 }
 
-#[pg_extern(name="with_bounds", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="with_bounds", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn counter_agg_with_bounds(
     summary: toolkit_experimental::CounterSummary,
     bounds: tstzrange,
@@ -398,7 +398,7 @@ fn counter_agg_with_bounds(
     }
 }
 
-#[pg_extern(name="extrapolated_delta", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="extrapolated_delta", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn counter_agg_extrapolated_delta(
     summary: toolkit_experimental::CounterSummary,
     method: String,
@@ -412,7 +412,7 @@ fn counter_agg_extrapolated_delta(
     }
 }
 
-#[pg_extern(name="extrapolated_rate", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="extrapolated_rate", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn counter_agg_extrapolated_rate(
     summary: toolkit_experimental::CounterSummary,
     method: String,
@@ -426,7 +426,7 @@ fn counter_agg_extrapolated_rate(
     }
 }
 
-#[pg_extern(name="num_elements", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="num_elements", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn counter_agg_num_elements(
     summary: toolkit_experimental::CounterSummary,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -434,7 +434,7 @@ fn counter_agg_num_elements(
     summary.to_internal_counter_summary().stats.n as i64
 }
 
-#[pg_extern(name="num_changes", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="num_changes", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn counter_agg_num_changes(
     summary: toolkit_experimental::CounterSummary,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -442,7 +442,7 @@ fn counter_agg_num_changes(
     summary.to_internal_counter_summary().num_changes as i64
 }
 
-#[pg_extern(name="num_resets", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="num_resets", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn counter_agg_num_resets(
     summary: toolkit_experimental::CounterSummary,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -450,7 +450,7 @@ fn counter_agg_num_resets(
     summary.to_internal_counter_summary().num_resets as i64
 }
 
-#[pg_extern(name="slope", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="slope", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn counter_agg_slope(
     summary: toolkit_experimental::CounterSummary,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -458,7 +458,7 @@ fn counter_agg_slope(
     summary.to_internal_counter_summary().stats.slope()
 }
 
-#[pg_extern(name="intercept", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="intercept", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn counter_agg_intercept(
     summary: toolkit_experimental::CounterSummary,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -466,7 +466,7 @@ fn counter_agg_intercept(
     summary.to_internal_counter_summary().stats.intercept()
 }
 
-#[pg_extern(name="corr", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="corr", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn counter_agg_corr(
     summary: toolkit_experimental::CounterSummary,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -474,7 +474,7 @@ fn counter_agg_corr(
     summary.to_internal_counter_summary().stats.corr()
 }
 
-#[pg_extern(name="counter_zero_time", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="counter_zero_time", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn counter_agg_counter_zero_time(
     summary: toolkit_experimental::CounterSummary,
     _fcinfo: pg_sys::FunctionCallInfo,

--- a/extension/src/hyperloglog.rs
+++ b/extension/src/hyperloglog.rs
@@ -31,7 +31,7 @@ pub struct HyperLogLogTrans {
 type int = i32;
 type AnyElement = Datum;
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn hyperloglog_trans(
     state: Option<Internal<HyperLogLogTrans>>,
     size: int,
@@ -67,7 +67,7 @@ pub fn hyperloglog_trans(
     }
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn hyperloglog_combine(
     state1: Option<Internal<HyperLogLogTrans>>,
     state2: Option<Internal<HyperLogLogTrans>>,
@@ -90,12 +90,12 @@ pub fn hyperloglog_combine(
 #[allow(non_camel_case_types)]
 type bytea = pg_sys::Datum;
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn hyperloglog_serialize(state: Internal<HyperLogLogTrans>) -> bytea {
     crate::do_serialize!(state)
 }
 
-#[pg_extern(schema = "toolkit_experimental", strict)]
+#[pg_extern(schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 pub fn hyperloglog_deserialize(
     bytes: bytea,
     _internal: Option<Internal<()>>,
@@ -152,7 +152,7 @@ mod toolkit_experimental {
 
 json_inout_funcs!(HyperLogLog);
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 fn hyperloglog_final(
     state: Option<Internal<HyperLogLogTrans>>,
     fcinfo: pg_sys::FunctionCallInfo,
@@ -178,12 +178,13 @@ CREATE AGGREGATE toolkit_experimental.hyperloglog(size int, value AnyElement)
     finalfunc = toolkit_experimental.hyperloglog_final,
     combinefunc = toolkit_experimental.hyperloglog_combine,
     serialfunc = toolkit_experimental.hyperloglog_serialize,
-    deserialfunc = toolkit_experimental.hyperloglog_deserialize
+    deserialfunc = toolkit_experimental.hyperloglog_deserialize, 
+    parallel = safe
 );
 "#
 );
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn hyperloglog_union<'input>(
     state: Option<Internal<HyperLogLogTrans>>,
     other: toolkit_experimental::HyperLogLog<'input>,
@@ -220,7 +221,8 @@ CREATE AGGREGATE toolkit_experimental.rollup(hyperloglog toolkit_experimental.Hy
     finalfunc = toolkit_experimental.hyperloglog_final,
     combinefunc = toolkit_experimental.hyperloglog_combine,
     serialfunc = toolkit_experimental.hyperloglog_serialize,
-    deserialfunc = toolkit_experimental.hyperloglog_deserialize
+    deserialfunc = toolkit_experimental.hyperloglog_deserialize, 
+    parallel = safe
 );
 "#
 );

--- a/extension/src/lttb.rs
+++ b/extension/src/lttb.rs
@@ -20,7 +20,7 @@ pub struct LttbTrans {
     resolution: usize,
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn lttb_trans(
     state: Option<Internal<LttbTrans>>,
     time: pg_sys::TimestampTz,
@@ -56,7 +56,7 @@ pub fn lttb_trans(
     }
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn lttb_final(
     state: Option<Internal<LttbTrans>>,
     fcinfo: pg_sys::FunctionCallInfo,
@@ -166,7 +166,7 @@ pub fn lttb(data: &[TSPoint], threshold: usize) -> Cow<'_, [TSPoint]> {
     Cow::Owned(sampled)
 }
 
-#[pg_extern(name="lttb", schema = "toolkit_experimental")]
+#[pg_extern(name="lttb", schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn lttb_on_timeseries(
     series: crate::time_series::toolkit_experimental::TimeSeries<'static>,
     threshold: i32,

--- a/extension/src/stats_agg.rs
+++ b/extension/src/stats_agg.rs
@@ -105,7 +105,7 @@ impl<'input> StatsSummary2D<'input> {
 
 
 
-#[pg_extern(schema = "toolkit_experimental", strict)]
+#[pg_extern(schema = "toolkit_experimental",immutable, parallel_safe, strict)]
 pub fn stats1d_trans_serialize<'s>(
     state: Internal<StatsSummary1D<'s>>,
 ) -> bytea {
@@ -113,7 +113,7 @@ pub fn stats1d_trans_serialize<'s>(
     crate::do_serialize!(ser)
 }
 
-#[pg_extern(schema = "toolkit_experimental", strict)]
+#[pg_extern(schema = "toolkit_experimental",immutable, parallel_safe, strict)]
 pub fn stats1d_trans_deserialize(
     bytes: bytea,
     _internal: Option<Internal<()>>,
@@ -122,7 +122,7 @@ pub fn stats1d_trans_deserialize(
     de.into()
 }
 
-#[pg_extern(schema = "toolkit_experimental", strict)]
+#[pg_extern(schema = "toolkit_experimental",immutable, parallel_safe, strict)]
 pub fn stats2d_trans_serialize<'s>(
     state: Internal<StatsSummary2D<'s>>,
 ) -> bytea {
@@ -130,7 +130,7 @@ pub fn stats2d_trans_serialize<'s>(
     crate::do_serialize!(ser)
 }
 
-#[pg_extern(schema = "toolkit_experimental", strict)]
+#[pg_extern(schema = "toolkit_experimental",immutable, parallel_safe, strict)]
 pub fn stats2d_trans_deserialize(
     bytes: bytea,
     _internal: Option<Internal<()>>,
@@ -139,7 +139,7 @@ pub fn stats2d_trans_deserialize(
     de.into()
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental",immutable, parallel_safe)]
 pub fn stats1d_trans<'s>(
     state: Option<Internal<StatsSummary1D<'s>>>,
     val: Option<f64>,
@@ -167,7 +167,7 @@ pub fn stats1d_trans<'s>(
 }
 // Note that in general, for all stats2d cases, if either the y or x value is missing, we disregard the entire point as the n is shared between them
 // if the user wants us to treat nulls as a particular value (ie zero), they can use COALESCE to do so
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental",immutable, parallel_safe)]
 pub fn stats2d_trans<'s>(
     state: Option<Internal<StatsSummary2D<'s>>>,
     y: Option<f64>,
@@ -201,7 +201,7 @@ pub fn stats2d_trans<'s>(
 }
 
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental",immutable)]
 pub fn stats1d_inv_trans<'s>(
     state: Option<Internal<StatsSummary1D<'s>>>,
     val: Option<f64>,
@@ -225,7 +225,7 @@ pub fn stats1d_inv_trans<'s>(
     }
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental",immutable)]
 pub fn stats2d_inv_trans<'s>(
     state: Option<Internal<StatsSummary2D<'s>>>,
     y: Option<f64>,
@@ -256,7 +256,7 @@ pub fn stats2d_inv_trans<'s>(
 }
 
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental",immutable, parallel_safe)]
 pub fn stats1d_summary_trans<'s, 'v>(
     state: Option<Internal<StatsSummary1D<'s>>>,
     value: Option<toolkit_experimental::StatsSummary1D<'v>>,
@@ -281,7 +281,7 @@ pub fn stats1d_summary_trans<'s, 'v>(
 
 
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental",immutable, parallel_safe)]
 pub fn stats2d_summary_trans<'s, 'v>(
     state: Option<Internal<StatsSummary2D<'s>>>,
     value: Option<toolkit_experimental::StatsSummary2D<'v>>,
@@ -304,7 +304,7 @@ pub fn stats2d_summary_trans<'s, 'v>(
     }
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental",immutable, parallel_safe)]
 pub fn stats1d_summary_inv_trans<'s, 'v>(
     state: Option<Internal<StatsSummary1D<'s>>>,
     value: Option<toolkit_experimental::StatsSummary1D<'v>>,
@@ -329,7 +329,7 @@ pub fn stats1d_summary_inv_trans<'s, 'v>(
     }
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental",immutable, parallel_safe)]
 pub fn stats2d_summary_inv_trans<'s, 'v>(
     state: Option<Internal<StatsSummary2D<'s>>>,
     value: Option<toolkit_experimental::StatsSummary2D<'v>>,
@@ -354,7 +354,7 @@ pub fn stats2d_summary_inv_trans<'s, 'v>(
     }
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental",immutable, parallel_safe)]
 pub fn stats1d_combine<'s, 'v>(
     state1: Option<Internal<StatsSummary1D<'s>>>,
     state2: Option<Internal<StatsSummary1D<'v>>>,
@@ -383,7 +383,7 @@ pub fn stats1d_combine<'s, 'v>(
     }
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental",immutable, parallel_safe)]
 pub fn stats2d_combine<'s, 'v>(
     state1: Option<Internal<StatsSummary2D<'s>>>,
     state2: Option<Internal<StatsSummary2D<'v>>>,
@@ -412,7 +412,7 @@ pub fn stats2d_combine<'s, 'v>(
     }
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental",immutable, parallel_safe)]
 fn stats1d_final<'s>(
     state: Option<Internal<StatsSummary1D<'s>>>,
     fcinfo: pg_sys::FunctionCallInfo,
@@ -427,7 +427,7 @@ fn stats1d_final<'s>(
     }
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental",immutable, parallel_safe)]
 fn stats2d_final<'s>(
     state: Option<Internal<StatsSummary2D<'s>>>,
     fcinfo: pg_sys::FunctionCallInfo,
@@ -577,7 +577,7 @@ CREATE AGGREGATE toolkit_experimental.rolling(ss toolkit_experimental.statssumma
 
 
 
-#[pg_extern(name="average", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="average", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn stats1d_average(
     summary: toolkit_experimental::StatsSummary1D,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -585,7 +585,7 @@ fn stats1d_average(
     summary.to_internal().avg()
 }
 
-#[pg_extern(name="sum", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="sum", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn stats1d_sum(
     summary: toolkit_experimental::StatsSummary1D,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -593,7 +593,7 @@ fn stats1d_sum(
     summary.to_internal().sum()
 }
 
-#[pg_extern(name="stddev", schema = "toolkit_experimental", immutable)]
+#[pg_extern(name="stddev", schema = "toolkit_experimental", immutable, parallel_safe)]
 fn stats1d_stddev(
     summary: Option<toolkit_experimental::StatsSummary1D>,
     method: default!(String, "sample"),
@@ -606,7 +606,7 @@ fn stats1d_stddev(
     }
 }
 
-#[pg_extern(name="variance", schema = "toolkit_experimental", immutable)]
+#[pg_extern(name="variance", schema = "toolkit_experimental", immutable, parallel_safe)]
 fn stats1d_variance(
     summary: Option<toolkit_experimental::StatsSummary1D>,
     method: default!(String, "sample"),
@@ -619,7 +619,7 @@ fn stats1d_variance(
     }
 }
 
-#[pg_extern(name="num_vals", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="num_vals", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn stats1d_num_vals(
     summary: toolkit_experimental::StatsSummary1D,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -627,7 +627,7 @@ fn stats1d_num_vals(
     summary.to_internal().count()
 }
 
-#[pg_extern(name="average_x", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="average_x", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn stats2d_average_x(
     summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -635,7 +635,7 @@ fn stats2d_average_x(
     Some(summary.to_internal().avg()?.x)
 }
 
-#[pg_extern(name="average_y", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="average_y", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn stats2d_average_y(
     summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -643,7 +643,7 @@ fn stats2d_average_y(
     Some(summary.to_internal().avg()?.y)
 }
 
-#[pg_extern(name="sum_x", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="sum_x", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn stats2d_sum_x(
     summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -651,7 +651,7 @@ fn stats2d_sum_x(
     Some(summary.to_internal().sum()?.x)
 }
 
-#[pg_extern(name="sum_y", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="sum_y", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn stats2d_sum_y(
     summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -659,7 +659,7 @@ fn stats2d_sum_y(
     Some(summary.to_internal().sum()?.y)
 }
 
-#[pg_extern(name="stddev_x", schema = "toolkit_experimental", immutable)]
+#[pg_extern(name="stddev_x", schema = "toolkit_experimental", immutable, parallel_safe)]
 fn stats2d_stddev_x(
     summary: Option<toolkit_experimental::StatsSummary2D>,
     method: default!(String, "sample"),
@@ -672,7 +672,7 @@ fn stats2d_stddev_x(
     }
 }
 
-#[pg_extern(name="stddev_y", schema = "toolkit_experimental", immutable)]
+#[pg_extern(name="stddev_y", schema = "toolkit_experimental", immutable, parallel_safe)]
 fn stats2d_stddev_y(
     summary: Option<toolkit_experimental::StatsSummary2D>,
     method: default!(String, "sample"),
@@ -685,7 +685,7 @@ fn stats2d_stddev_y(
     }
 }
 
-#[pg_extern(name="variance_x", schema = "toolkit_experimental", immutable)]
+#[pg_extern(name="variance_x", schema = "toolkit_experimental", immutable, parallel_safe)]
 fn stats2d_variance_x(
     summary: Option<toolkit_experimental::StatsSummary2D>,
     method: default!(String, "sample"),
@@ -698,7 +698,7 @@ fn stats2d_variance_x(
     }
 }
 
-#[pg_extern(name="variance_y", schema = "toolkit_experimental", immutable)]
+#[pg_extern(name="variance_y", schema = "toolkit_experimental", immutable, parallel_safe)]
 fn stats2d_variance_y(
     summary: Option<toolkit_experimental::StatsSummary2D>,
     method: default!(String, "sample"),
@@ -711,7 +711,7 @@ fn stats2d_variance_y(
     }
 }
 
-#[pg_extern(name="num_vals", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="num_vals", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn stats2d_num_vals(
     summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -719,7 +719,7 @@ fn stats2d_num_vals(
     summary.to_internal().count()
 }
 
-#[pg_extern(name="slope", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="slope", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn stats2d_slope(
     summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -727,7 +727,7 @@ fn stats2d_slope(
     summary.to_internal().slope()
 }
 
-#[pg_extern(name="corr", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="corr", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn stats2d_corr(
     summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -735,7 +735,7 @@ fn stats2d_corr(
     summary.to_internal().corr()
 }
 
-#[pg_extern(name="intercept", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="intercept", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn stats2d_intercept(
     summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -743,7 +743,7 @@ fn stats2d_intercept(
     summary.to_internal().intercept()
 }
 
-#[pg_extern(name="x_intercept", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="x_intercept", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn stats2d_x_intercept(
     summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -751,7 +751,7 @@ fn stats2d_x_intercept(
     summary.to_internal().x_intercept()
 }
 
-#[pg_extern(name="determination_coeff", schema = "toolkit_experimental", strict, immutable)]
+#[pg_extern(name="determination_coeff", schema = "toolkit_experimental", strict, immutable, parallel_safe)]
 fn stats2d_determination_coeff(
     summary: toolkit_experimental::StatsSummary2D,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -759,7 +759,7 @@ fn stats2d_determination_coeff(
     summary.to_internal().determination_coeff()
 }
 
-#[pg_extern(name="covariance", schema = "toolkit_experimental", immutable)]
+#[pg_extern(name="covariance", schema = "toolkit_experimental", immutable, parallel_safe)]
 fn stats2d_covar(
     summary: Option<toolkit_experimental::StatsSummary2D>,
     method: default!(String, "sample"),

--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -53,7 +53,7 @@ type int = u32;
 
 // PG function for adding values to a digest.
 // Null values are ignored.
-#[pg_extern]
+#[pg_extern(immutable, parallel_safe)]
 pub fn tdigest_trans(
     state: Option<Internal<TDigestTransState>>,
     size: int,
@@ -81,7 +81,7 @@ pub fn tdigest_trans(
 }
 
 // PG function for merging digests.
-#[pg_extern]
+#[pg_extern(immutable, parallel_safe)]
 pub fn tdigest_combine(
     state1: Option<Internal<TDigestTransState>>,
     state2: Option<Internal<TDigestTransState>>,
@@ -117,7 +117,7 @@ pub fn tdigest_combine(
 #[allow(non_camel_case_types)]
 type bytea = pg_sys::Datum;
 
-#[pg_extern]
+#[pg_extern(immutable, parallel_safe)]
 pub fn tdigest_serialize(
     mut state: Internal<TDigestTransState>,
 ) -> bytea {
@@ -125,7 +125,7 @@ pub fn tdigest_serialize(
     crate::do_serialize!(state)
 }
 
-#[pg_extern(strict)]
+#[pg_extern(strict, immutable, parallel_safe)]
 pub fn tdigest_deserialize(
     bytes: bytea,
     _internal: Option<Internal<()>>,
@@ -186,7 +186,7 @@ impl<'input> TDigest<'input> {
 }
 
 // PG function to generate a user-facing TDigest object from an internal TDigestTransState.
-#[pg_extern]
+#[pg_extern(immutable, parallel_safe)]
 fn tdigest_final(
     state: Option<Internal<TDigestTransState>>,
     fcinfo: pg_sys::FunctionCallInfo,
@@ -218,7 +218,7 @@ CREATE AGGREGATE tdigest(size int, value DOUBLE PRECISION)
 );
 "#);
 
-#[pg_extern]
+#[pg_extern(immutable, parallel_safe)]
 pub fn tdigest_compound_trans(
     state: Option<Internal<InternalTDigest>>,
     value: Option<TDigest<'static>>,
@@ -240,7 +240,7 @@ pub fn tdigest_compound_trans(
     }
 }
 
-#[pg_extern]
+#[pg_extern(immutable, parallel_safe)]
 pub fn tdigest_compound_combine(
     state1: Option<Internal<InternalTDigest>>,
     state2: Option<Internal<InternalTDigest>>,
@@ -263,7 +263,7 @@ pub fn tdigest_compound_combine(
     }
 }
 
-#[pg_extern]
+#[pg_extern(immutable, parallel_safe)]
 fn tdigest_compound_final(
     state: Option<Internal<InternalTDigest>>,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -274,7 +274,7 @@ fn tdigest_compound_final(
     }
 }
 
-#[pg_extern]
+#[pg_extern(immutable, parallel_safe)]
 fn tdigest_compound_serialize(
     state: Internal<InternalTDigest>,
     _fcinfo: pg_sys::FunctionCallInfo,
@@ -282,7 +282,7 @@ fn tdigest_compound_serialize(
     crate::do_serialize!(state)
 }
 
-#[pg_extern]
+#[pg_extern(immutable, parallel_safe)]
 pub fn tdigest_compound_deserialize(
     bytes: bytea,
     _internal: Option<Internal<()>>,

--- a/extension/src/time_series.rs
+++ b/extension/src/time_series.rs
@@ -333,21 +333,21 @@ impl<'a> TimeSeries<'a> {
     }
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn unnest_series(
     series: toolkit_experimental::TimeSeries,
 ) -> impl std::iter::Iterator<Item = (name!(time,pg_sys::TimestampTz),name!(value,f64))> + '_ {
     Box::new(series.iter().map(|points| (points.ts, points.val)))
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn timeseries_serialize(
     state: Internal<InternalTimeSeries>,
 ) -> bytea {
     crate::do_serialize!(state)
 }
 
-#[pg_extern(schema = "toolkit_experimental",strict)]
+#[pg_extern(schema = "toolkit_experimental",strict, immutable, parallel_safe)]
 pub fn timeseries_deserialize(
     bytes: bytea,
     _internal: Option<Internal<()>>,
@@ -355,7 +355,7 @@ pub fn timeseries_deserialize(
     crate::do_deserialize!(bytes, InternalTimeSeries)
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn timeseries_trans(
     state: Option<Internal<InternalTimeSeries>>,
     time: Option<pg_sys::TimestampTz>,
@@ -382,7 +382,7 @@ pub fn timeseries_trans(
     }
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn timeseries_compound_trans(
     state: Option<Internal<InternalTimeSeries>>,
     series: Option<crate::time_series::toolkit_experimental::TimeSeries<'static>>,
@@ -401,7 +401,7 @@ pub fn timeseries_compound_trans(
     }
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn timeseries_combine (
     state1: Option<Internal<InternalTimeSeries>>,
     state2: Option<Internal<InternalTimeSeries>>,
@@ -420,7 +420,7 @@ pub fn timeseries_combine (
     }
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn timeseries_final(
     state: Option<Internal<InternalTimeSeries>>,
     fcinfo: pg_sys::FunctionCallInfo,
@@ -443,7 +443,8 @@ CREATE AGGREGATE toolkit_experimental.timeseries(ts TIMESTAMPTZ, value DOUBLE PR
     finalfunc = toolkit_experimental.timeseries_final,
     combinefunc = toolkit_experimental.timeseries_combine,
     serialfunc = toolkit_experimental.timeseries_serialize,
-    deserialfunc = toolkit_experimental.timeseries_deserialize
+    deserialfunc = toolkit_experimental.timeseries_deserialize,
+    parallel = safe
 );
 "#);
 
@@ -456,13 +457,14 @@ CREATE AGGREGATE toolkit_experimental.rollup(
     finalfunc = toolkit_experimental.timeseries_final,
     combinefunc = toolkit_experimental.timeseries_combine,
     serialfunc = toolkit_experimental.timeseries_serialize,
-    deserialfunc = toolkit_experimental.timeseries_deserialize
+    deserialfunc = toolkit_experimental.timeseries_deserialize,
+    parallel = safe
 );
 "#);
 
 type Interval = pg_sys::Datum;
 
-#[pg_extern(schema = "toolkit_experimental", name="normalize")]
+#[pg_extern(schema = "toolkit_experimental", name="normalize", immutable, parallel_safe)]
 pub fn normalize_default_range (
     series: crate::time_series::toolkit_experimental::TimeSeries<'static>,
     interval: Interval,
@@ -473,7 +475,7 @@ pub fn normalize_default_range (
     normalize(series, interval, method, truncate, None, None, _fcinfo)
 }
 
-#[pg_extern(schema = "toolkit_experimental")]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
 pub fn normalize (
     series: crate::time_series::toolkit_experimental::TimeSeries<'static>,
     interval: Interval,

--- a/extension/src/time_weighted_average.rs
+++ b/extension/src/time_weighted_average.rs
@@ -86,21 +86,21 @@ impl TimeWeightTransState {
     }
 }
 
-#[pg_extern()]
+#[pg_extern(immutable, parallel_safe)]
 pub fn time_weight_trans_serialize(mut state: Internal<TimeWeightTransState>) -> bytea {
     state.combine_summaries();
     crate::do_serialize!(state)
 }
 
-#[pg_extern(strict)]
+#[pg_extern(strict, immutable, parallel_safe)]
 pub fn time_weight_trans_deserialize(
     bytes: bytea,
     _internal: Option<Internal<()>>,
 ) -> Internal<TimeWeightTransState> {
     crate::do_deserialize!(bytes, TimeWeightTransState)
 }
-
-#[pg_extern()]
+// these are technically parallel_safe (as in they can be called in a parallel context) even though the aggregate itself is parallel restricted.
+#[pg_extern(immutable, parallel_safe)]
 pub fn time_weight_trans(
     state: Option<Internal<TimeWeightTransState>>,
     method: String,
@@ -140,7 +140,7 @@ pub fn time_weight_trans(
     }
 }
 
-#[pg_extern()]
+#[pg_extern(immutable, parallel_safe)]
 pub fn time_weight_summary_trans<'b>(
     state: Option<Internal<TimeWeightTransState>>,
     next: Option<TimeWeightSummary<'b>>,
@@ -171,7 +171,7 @@ pub fn time_weight_summary_trans<'b>(
     }
 }
 
-#[pg_extern()]
+#[pg_extern(immutable, parallel_safe)]
 pub fn time_weight_combine(
     state1: Option<Internal<TimeWeightTransState>>,
     state2: Option<Internal<TimeWeightTransState>>,
@@ -204,7 +204,7 @@ pub fn time_weight_combine(
     }
 }
 
-#[pg_extern()]
+#[pg_extern(immutable, parallel_safe)]
 fn time_weight_final(
     state: Option<Internal<TimeWeightTransState>>,
     fcinfo: pg_sys::FunctionCallInfo,

--- a/extension/src/uddsketch.rs
+++ b/extension/src/uddsketch.rs
@@ -22,7 +22,7 @@ type int = u32;
 
 // PG function for adding values to a sketch.
 // Null values are ignored.
-#[pg_extern()]
+#[pg_extern(immutable, parallel_safe)]
 pub fn uddsketch_trans(
     state: Option<Internal<UddSketchInternal>>,
     size: int,
@@ -48,7 +48,7 @@ pub fn uddsketch_trans(
 
 // transition function for the simpler percentile_agg aggregate, which doesn't
 // take parameters for the size and error, but uses a default
-#[pg_extern()]
+#[pg_extern(immutable, parallel_safe)]
 pub fn percentile_agg_trans(
     state: Option<Internal<UddSketchInternal>>,
     value: Option<f64>,
@@ -60,7 +60,7 @@ pub fn percentile_agg_trans(
 }
 
 // PG function for merging sketches.
-#[pg_extern()]
+#[pg_extern(immutable, parallel_safe)]
 pub fn uddsketch_combine(
     state1: Option<Internal<UddSketchInternal>>,
     state2: Option<Internal<UddSketchInternal>>,
@@ -85,7 +85,7 @@ pub fn uddsketch_combine(
 #[allow(non_camel_case_types)]
 type bytea = pg_sys::Datum;
 
-#[pg_extern()]
+#[pg_extern(immutable, parallel_safe)]
 pub fn uddsketch_serialize(
     state: Internal<UddSketchInternal>,
 ) -> bytea {
@@ -93,7 +93,7 @@ pub fn uddsketch_serialize(
     crate::do_serialize!(serializable)
 }
 
-#[pg_extern(strict)]
+#[pg_extern(strict, immutable, parallel_safe)]
 pub fn uddsketch_deserialize(
     bytes: bytea,
     _internal: Option<Internal<()>>,
@@ -269,7 +269,7 @@ impl<'input> UddSketch<'input> {
 }
 
 // PG function to generate a user-facing UddSketch object from a UddSketchInternal.
-#[pg_extern()]
+#[pg_extern(immutable, parallel_safe)]
 fn uddsketch_final(
     state: Option<Internal<UddSketchInternal>>,
     fcinfo: pg_sys::FunctionCallInfo,
@@ -418,7 +418,7 @@ CREATE AGGREGATE percentile_agg(value DOUBLE PRECISION)
 );
 "#);
 
-#[pg_extern()]
+#[pg_extern(immutable, parallel_safe)]
 pub fn uddsketch_compound_trans(
     state: Option<Internal<UddSketchInternal>>,
     value: Option<UddSketch>,


### PR DESCRIPTION
Many functions were left with default properties, which are
volatile, parallel unsafe. In addition several aggregates were
left with default parallel safety (unsafe) when they were, in fact,
safe, as they had all the components but weren't marked as such.