### PR TITLE
Add `stats_agg()` pipeline finalizer

### DIFF
--- a/extension/sql/load-order.txt
+++ b/extension/sql/load-order.txt
@@ -16,7 +16,8 @@ time_series_pipeline_fill_holes.generated.sql
 time_series_pipeline_map.generated.sql
 time_series_pipeline_resample_to_rate.generated.sql
 time_series_pipeline_sort.generated.sql
+topn.generated.sql
+time_series_pipeline_arithmetic.generated.sql
 schema_test.generated.sql
 serialization_collations.generated.sql
 serialization_types.generated.sql
-topn.generated.sql

--- a/extension/sql/load-order.txt
+++ b/extension/sql/load-order.txt
@@ -18,6 +18,7 @@ time_series_pipeline_resample_to_rate.generated.sql
 time_series_pipeline_sort.generated.sql
 topn.generated.sql
 time_series_pipeline_arithmetic.generated.sql
+time_series_pipeline_aggregation.generated.sql
 schema_test.generated.sql
 serialization_collations.generated.sql
 serialization_types.generated.sql

--- a/extension/src/schema_test.rs
+++ b/extension/src/schema_test.rs
@@ -150,13 +150,10 @@ mod tests {
         "function timeweightsummary_out(timeweightsummary)",
         "type timeweightsummary",
         "operator |>(toolkit_experimental.timeseries,toolkit_experimental.unstabletimeseriespipeline)",
-        "operator |>(toolkit_experimental.timeseries,toolkit_experimental.unstabletimeseriespipelineelement)",
-        "operator |>(toolkit_experimental.unstabletimeseriespipeline,toolkit_experimental.unstabletimeseriespipelineelement)",
-        "operator |>(toolkit_experimental.unstabletimeseriespipelineelement,toolkit_experimental.unstabletimeseriespipelineelement)",
+        "operator |>(toolkit_experimental.unstabletimeseriespipeline,toolkit_experimental.unstabletimeseriespipeline)",
         "operator |>>(regproc,regproc)",
-        "operator |>>(regproc,toolkit_experimental.unstabletimeseriespipelineelement)",
+        "operator |>>(regproc,toolkit_experimental.unstabletimeseriespipeline)",
         "operator |>>(toolkit_experimental.timeseries,regproc)",
         "operator |>>(toolkit_experimental.unstabletimeseriespipeline,regproc)",
-        "operator |>>(toolkit_experimental.unstabletimeseriespipelineelement,regproc)",
     ];
 }

--- a/extension/src/schema_test.rs
+++ b/extension/src/schema_test.rs
@@ -155,5 +155,7 @@ mod tests {
         "operator |>>(regproc,toolkit_experimental.unstabletimeseriespipeline)",
         "operator |>>(toolkit_experimental.timeseries,regproc)",
         "operator |>>(toolkit_experimental.unstabletimeseriespipeline,regproc)",
+        "operator |>(toolkit_experimental.timeseries,toolkit_experimental.pipelinethenstatsagg)",
+        "operator |>(toolkit_experimental.unstabletimeseriespipeline,toolkit_experimental.pipelinethenstatsagg)",
     ];
 }

--- a/extension/src/stats_agg.rs
+++ b/extension/src/stats_agg.rs
@@ -9,14 +9,14 @@ use flat_serialize::*;
 use crate::{
     aggregate_utils::in_aggregate_context,
     json_inout_funcs,
-    flatten,
+    build,
     palloc::Internal,
     pg_type,
 };
 
 use stats_agg::XYPair;
-use stats_agg::stats1d::StatsSummary1D as InternalStatsSummary1D;
-use stats_agg::stats2d::StatsSummary2D as InternalStatsSummary2D;
+pub use stats_agg::stats1d::StatsSummary1D as InternalStatsSummary1D;
+pub use stats_agg::stats2d::StatsSummary2D as InternalStatsSummary2D;
 
 
 
@@ -66,14 +66,14 @@ impl<'input> StatsSummary1D<'input> {
             sxx: self.sxx,
         }
     }
-    fn from_internal(st: InternalStatsSummary1D) -> Self {
-        unsafe{
-            flatten!(StatsSummary1D {
+    pub fn from_internal(st: InternalStatsSummary1D) -> Self {
+        build!(
+            StatsSummary1D {
                 n: st.n,
                 sx: st.sx,
                 sxx: st.sxx,
-            })
-        }
+            }
+        )
     }
 }
 
@@ -89,8 +89,7 @@ impl<'input> StatsSummary2D<'input> {
         }
     }
     fn from_internal(st: InternalStatsSummary2D) -> Self {
-        unsafe{
-            flatten!(
+        build!(
             StatsSummary2D {
                 n: st.n,
                 sx: st.sx,
@@ -98,8 +97,8 @@ impl<'input> StatsSummary2D<'input> {
                 sy: st.sy,
                 syy: st.syy,
                 sxy: st.sxy,
-            })
-        }
+            }
+        )
     }
 }
 
@@ -882,7 +881,7 @@ mod tests {
                 let mantissa = self.gen.gen_range((1.)..2.);
                 let sign = [-1., 1.].choose(&mut self.gen).unwrap();
                 self.x_values.push(sign * mantissa * exp.exp2());
-                
+
                 let exp = self.gen.gen_range((exp_base - 2.)..=(exp_base + 2.));
                 let mantissa = self.gen.gen_range((1.)..2.);
                 let sign = [-1., 1.].choose(&mut self.gen).unwrap();
@@ -971,8 +970,8 @@ mod tests {
                 None,
                 None
             );
-            
-            client.select(&format!("INSERT INTO test_table VALUES {}", 
+
+            client.select(&format!("INSERT INTO test_table VALUES {}",
                 state.x_values.iter().zip(state.y_values.iter()).map(
                     |(x, y)| "(".to_string() + &x.to_string() + "," + &y.to_string()+ ")" + ","
                 ).collect::<String>().trim_end_matches(",")), None, None);

--- a/extension/src/time_series/pipeline.rs
+++ b/extension/src/time_series/pipeline.rs
@@ -4,6 +4,7 @@ mod resample_to_rate;
 mod sort;
 mod delta;
 mod map;
+mod arithmetic;
 
 use std::convert::TryInto;
 
@@ -65,6 +66,10 @@ pg_type! {
             MapSeries: 7 {
                 // FIXME serialize/deserialize as `name(type)`
                 function: PgProcId,
+            },
+            Arithmetic: 8 {
+                function: arithmetic::Function,
+                rhs: f64,
             }
         },
     }
@@ -135,6 +140,8 @@ pub fn execute_pipeline_element<'s, 'e>(
             return map::apply_to(timeseries, function.0),
         Element::MapSeries { function } =>
             return map::apply_to_series(timeseries, function.0),
+        Element::Arithmetic{ function, rhs } =>
+            return arithmetic::apply(timeseries, *function, *rhs),
     }
 }
 

--- a/extension/src/time_series/pipeline/aggregation.rs
+++ b/extension/src/time_series/pipeline/aggregation.rs
@@ -1,0 +1,135 @@
+
+use std::mem::replace;
+
+use pgx::*;
+
+use super::*;
+
+use crate::{
+    json_inout_funcs, pg_type, build,
+    stats_agg::{InternalStatsSummary1D, StatsSummary1D},
+};
+
+
+pg_type! {
+    #[derive(Debug)]
+    struct PipelineThenStatsAgg<'input> {
+        num_elements: u64,
+        elements: [Element; self.num_elements],
+    }
+}
+
+json_inout_funcs!(PipelineThenStatsAgg);
+
+// hack to allow us to qualify names with "toolkit_experimental"
+// so that pgx generates the correct SQL
+pub mod toolkit_experimental {
+    pub(crate) use super::*;
+    varlena_type!(PipelineThenStatsAgg);
+}
+
+
+
+#[pg_extern(immutable, parallel_safe, schema="toolkit_experimental")]
+pub fn run_pipeline_then_stats_agg<'s, 'p>(
+    mut timeseries: toolkit_experimental::TimeSeries<'s>,
+    pipeline: toolkit_experimental::PipelineThenStatsAgg<'p>,
+) -> toolkit_experimental::StatsSummary1D<'static> {
+    timeseries = run_pipeline_elements(timeseries, pipeline.elements.iter());
+    let mut stats = InternalStatsSummary1D::new();
+    for TSPoint{ val, ..} in timeseries.iter() {
+        stats.accum(val).expect("error while running stats_agg");
+    }
+    StatsSummary1D::from_internal(stats)
+}
+
+#[pg_extern(immutable, parallel_safe, schema="toolkit_experimental")]
+pub fn finalize_with_stats_agg<'p, 'e>(
+    mut pipeline: toolkit_experimental::UnstableTimeseriesPipeline<'p>,
+    then_stats_agg: toolkit_experimental::PipelineThenStatsAgg<'e>,
+) -> toolkit_experimental::PipelineThenStatsAgg<'e> {
+    if then_stats_agg.num_elements == 0 {
+        // flatten immediately so we don't need a temporary allocation for elements
+        return unsafe {flatten! {
+            PipelineThenStatsAgg {
+                num_elements: pipeline.0.num_elements,
+                elements: pipeline.0.elements,
+            }
+        }}
+    }
+
+    let mut elements = replace(pipeline.elements.as_owned(), vec![]);
+    elements.extend(then_stats_agg.elements.iter());
+    build! {
+        PipelineThenStatsAgg {
+            num_elements: elements.len().try_into().unwrap(),
+            elements: elements.into(),
+        }
+    }
+}
+
+#[pg_extern(
+    immutable,
+    parallel_safe,
+    name="stats_agg",
+    schema="toolkit_experimental"
+)]
+pub fn pipeline_stats_agg<'e>() -> toolkit_experimental::PipelineThenStatsAgg<'e> {
+    build! {
+        PipelineThenStatsAgg {
+            num_elements: 0,
+            elements: vec![].into(),
+        }
+    }
+}
+
+// using this instead of pg_operator since the latter doesn't support schemas yet
+// FIXME there is no CREATE OR REPLACE OPERATOR need to update post-install.rs
+//       need to ensure this works with out unstable warning
+extension_sql!(r#"
+CREATE OPERATOR |> (
+    PROCEDURE=toolkit_experimental."run_pipeline_then_stats_agg",
+    LEFTARG=toolkit_experimental.TimeSeries,
+    RIGHTARG=toolkit_experimental.PipelineThenStatsAgg
+);
+
+CREATE OPERATOR |> (
+    PROCEDURE=toolkit_experimental."finalize_with_stats_agg",
+    LEFTARG=toolkit_experimental.UnstableTimeseriesPipeline,
+    RIGHTARG=toolkit_experimental.PipelineThenStatsAgg
+);
+"#);
+
+#[cfg(any(test, feature = "pg_test"))]
+mod tests {
+    use pgx::*;
+
+    #[pg_test]
+    fn test_stats_agg_finalizer() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            // using the search path trick for this test b/c the operator is
+            // difficult to spot otherwise.
+            let sp = client.select("SELECT format(' %s, toolkit_experimental',current_setting('search_path'))", None, None).first().get_one::<String>().unwrap();
+            client.select(&format!("SET LOCAL search_path TO {}", sp), None, None);
+            client.select("SET timescaledb_toolkit_acknowledge_auto_drop TO 'true'", None, None);
+
+            // we use a subselect to guarantee order
+            let create_series = "SELECT timeseries(time, value) as series FROM \
+                (VALUES ('2020-01-04 UTC'::TIMESTAMPTZ, 25.0), \
+                    ('2020-01-01 UTC'::TIMESTAMPTZ, 10.0), \
+                    ('2020-01-03 UTC'::TIMESTAMPTZ, 20.0), \
+                    ('2020-01-02 UTC'::TIMESTAMPTZ, 15.0), \
+                    ('2020-01-05 UTC'::TIMESTAMPTZ, 30.0)) as v(time, value)";
+
+            let val = client.select(
+                &format!("SELECT (series |> stats_agg())::TEXT FROM ({}) s", create_series),
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "{\"version\":1,\"n\":5,\"sx\":100.0,\"sxx\":250.0}");
+        });
+    }
+}

--- a/extension/src/time_series/pipeline/arithmetic.rs
+++ b/extension/src/time_series/pipeline/arithmetic.rs
@@ -1,0 +1,284 @@
+
+use pgx::*;
+
+use super::*;
+
+use super::Element::Arithmetic;
+use Function::*;
+
+#[derive(Debug, Copy, Clone, flat_serialize_macro::FlatSerializable, serde::Serialize, serde::Deserialize)]
+#[repr(u64)]
+//XXX note that the order here _is_ significant
+pub enum Function {
+    // binary functions
+    Add = 1,
+    Sub = 2,
+    Mul = 3,
+    Div = 4,
+    Mod = 5,
+    Power = 6,
+    LogN = 7,
+}
+
+pub fn apply(
+    mut series: TimeSeries<'_>,
+    function: Function,
+    rhs: f64,
+) -> TimeSeries<'_> {
+    let function: fn(f64, f64) -> f64 = match function {
+        Add => |a, b| a + b,
+        Sub => |a, b| a - b,
+        Mul => |a, b| a * b,
+        Div => |a, b| a / b,
+        // TODO is this the right mod?
+        Mod => |a, b| a % b,
+        Power => |a, b| a.powf(b),
+        LogN => |a, b| a.log(b),
+    };
+    map::map_series(&mut series, |lhs| function(lhs, rhs));
+    series
+}
+
+#[pg_extern(
+    immutable,
+    parallel_safe,
+    name="add",
+    schema="toolkit_experimental"
+)]
+pub fn pipeline_add<'e>(
+    rhs: f64,
+) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
+    build!(
+        UnstableTimeseriesPipelineElement {
+            element: Arithmetic { function: Add, rhs: rhs }
+        }
+    )
+}
+
+#[pg_extern(
+    immutable,
+    parallel_safe,
+    name="sub",
+    schema="toolkit_experimental"
+)]
+pub fn pipeline_sub<'e>(
+    rhs: f64,
+) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
+    build!(
+        UnstableTimeseriesPipelineElement {
+            element: Arithmetic { function: Sub, rhs: rhs }
+        }
+    )
+}
+
+#[pg_extern(
+    immutable,
+    parallel_safe,
+    name="mul",
+    schema="toolkit_experimental"
+)]
+pub fn pipeline_mul<'e>(
+    rhs: f64,
+) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
+    build!(
+        UnstableTimeseriesPipelineElement {
+            element: Arithmetic { function: Mul, rhs: rhs }
+        }
+    )
+}
+
+#[pg_extern(
+    immutable,
+    parallel_safe,
+    name="div",
+    schema="toolkit_experimental"
+)]
+pub fn pipeline_div<'e>(
+    rhs: f64,
+) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
+    build!(
+        UnstableTimeseriesPipelineElement {
+            element: Arithmetic { function: Div, rhs: rhs }
+        }
+    )
+}
+
+#[pg_extern(
+    immutable,
+    parallel_safe,
+    name="mod",
+    schema="toolkit_experimental"
+)]
+pub fn pipeline_mod<'e>(
+    rhs: f64,
+) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
+    build!(
+        UnstableTimeseriesPipelineElement {
+            element: Arithmetic { function: Mod, rhs: rhs }
+        }
+    )
+}
+
+#[pg_extern(
+    immutable,
+    parallel_safe,
+    name="power",
+    schema="toolkit_experimental"
+)]
+pub fn pipeline_power<'e>(
+    rhs: f64,
+) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
+    build!(
+        UnstableTimeseriesPipelineElement {
+            element: Arithmetic { function: Power, rhs: rhs }
+        }
+    )
+}
+
+// log(double) already exists as the log base 10 so we need a new name
+#[pg_extern(
+    immutable,
+    parallel_safe,
+    name="logN",
+    schema="toolkit_experimental"
+)]
+pub fn pipeline_log_n<'e>(
+    rhs: f64,
+) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
+    build!(
+        UnstableTimeseriesPipelineElement {
+            element: Arithmetic { function: LogN, rhs: rhs }
+        }
+    )
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+mod tests {
+    use pgx::*;
+
+    #[pg_test]
+    fn test_simple_arith_map() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            // using the search path trick for this test b/c the operator is
+            // difficult to spot otherwise.
+            let sp = client.select("SELECT format(' %s, toolkit_experimental',current_setting('search_path'))", None, None).first().get_one::<String>().unwrap();
+            client.select(&format!("SET LOCAL search_path TO {}", sp), None, None);
+            client.select("SET timescaledb_toolkit_acknowledge_auto_drop TO 'true'", None, None);
+
+            // we use a subselect to guarantee order
+            let create_series = "SELECT timeseries(time, value) as series FROM \
+                (VALUES ('2020-01-04 UTC'::TIMESTAMPTZ, 25.0), \
+                    ('2020-01-01 UTC'::TIMESTAMPTZ, 10.0), \
+                    ('2020-01-03 UTC'::TIMESTAMPTZ, 20.0), \
+                    ('2020-01-02 UTC'::TIMESTAMPTZ, 15.0), \
+                    ('2020-01-05 UTC'::TIMESTAMPTZ, 30.0)) as v(time, value)";
+
+            let val = client.select(
+                &format!("SELECT (series |> add(1.0))::TEXT FROM ({}) s", create_series),
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":26.0},\
+                {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":11.0},\
+                {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":21.0},\
+                {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":16.0},\
+                {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":31.0}\
+            ]");
+
+            let val = client.select(
+                &format!("SELECT (series |> sub(3.0))::TEXT FROM ({}) s", create_series),
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":22.0},\
+                {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":7.0},\
+                {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":17.0},\
+                {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":12.0},\
+                {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":27.0}\
+            ]");
+
+            let val = client.select(
+                &format!("SELECT (series |> mul(2.0))::TEXT FROM ({}) s", create_series),
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":50.0},\
+                {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":20.0},\
+                {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":40.0},\
+                {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":30.0},\
+                {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":60.0}\
+            ]");
+
+            let val = client.select(
+                &format!("SELECT (series |> div(5.0))::TEXT FROM ({}) s", create_series),
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":5.0},\
+                {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":2.0},\
+                {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":4.0},\
+                {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":3.0},\
+                {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":6.0}\
+            ]");
+
+            let val = client.select(
+                &format!("SELECT (series |> mod(5.0))::TEXT FROM ({}) s", create_series),
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":0.0},\
+                {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":0.0},\
+                {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":0.0},\
+                {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":0.0},\
+                {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":0.0}\
+            ]");
+
+            let val = client.select(
+                &format!("SELECT (series |> power(2.0))::TEXT FROM ({}) s", create_series),
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":625.0},\
+                {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":100.0},\
+                {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":400.0},\
+                {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":225.0},\
+                {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":900.0}\
+            ]");
+
+
+            let val = client.select(
+                &format!("SELECT (series |> logN(10.0))::TEXT FROM ({}) s", create_series),
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":1.3979400086720375},\
+                {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":1.0},\
+                {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":1.301029995663981},\
+                {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":1.1760912590556811},\
+                {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":1.4771212547196624}\
+            ]");
+        });
+    }
+}

--- a/extension/src/time_series/pipeline/arithmetic.rs
+++ b/extension/src/time_series/pipeline/arithmetic.rs
@@ -74,12 +74,8 @@ pub fn apply(
 )]
 pub fn pipeline_add<'e>(
     rhs: f64,
-) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    build!(
-        UnstableTimeseriesPipelineElement {
-            element: Arithmetic { function: Add, rhs: rhs }
-        }
-    )
+) -> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Arithmetic { function: Add, rhs: rhs }.flatten()
 }
 
 #[pg_extern(
@@ -90,12 +86,8 @@ pub fn pipeline_add<'e>(
 )]
 pub fn pipeline_sub<'e>(
     rhs: f64,
-) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    build!(
-        UnstableTimeseriesPipelineElement {
-            element: Arithmetic { function: Sub, rhs: rhs }
-        }
-    )
+) -> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Arithmetic { function: Sub, rhs: rhs }.flatten()
 }
 
 #[pg_extern(
@@ -106,12 +98,8 @@ pub fn pipeline_sub<'e>(
 )]
 pub fn pipeline_mul<'e>(
     rhs: f64,
-) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    build!(
-        UnstableTimeseriesPipelineElement {
-            element: Arithmetic { function: Mul, rhs: rhs }
-        }
-    )
+) -> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Arithmetic { function: Mul, rhs: rhs }.flatten()
 }
 
 #[pg_extern(
@@ -122,12 +110,8 @@ pub fn pipeline_mul<'e>(
 )]
 pub fn pipeline_div<'e>(
     rhs: f64,
-) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    build!(
-        UnstableTimeseriesPipelineElement {
-            element: Arithmetic { function: Div, rhs: rhs }
-        }
-    )
+) -> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Arithmetic { function: Div, rhs: rhs }.flatten()
 }
 
 #[pg_extern(
@@ -138,12 +122,8 @@ pub fn pipeline_div<'e>(
 )]
 pub fn pipeline_mod<'e>(
     rhs: f64,
-) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    build!(
-        UnstableTimeseriesPipelineElement {
-            element: Arithmetic { function: Mod, rhs: rhs }
-        }
-    )
+) -> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Arithmetic { function: Mod, rhs: rhs }.flatten()
 }
 
 #[pg_extern(
@@ -154,12 +134,8 @@ pub fn pipeline_mod<'e>(
 )]
 pub fn pipeline_power<'e>(
     rhs: f64,
-) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    build!(
-        UnstableTimeseriesPipelineElement {
-            element: Arithmetic { function: Power, rhs: rhs }
-        }
-    )
+) -> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Arithmetic { function: Power, rhs: rhs }.flatten()
 }
 
 // log(double) already exists as the log base 10 so we need a new name
@@ -171,12 +147,8 @@ pub fn pipeline_power<'e>(
 )]
 pub fn pipeline_log_n<'e>(
     rhs: f64,
-) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    build!(
-        UnstableTimeseriesPipelineElement {
-            element: Arithmetic { function: LogN, rhs: rhs }
-        }
-    )
+) -> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Arithmetic { function: LogN, rhs: rhs }.flatten()
 }
 
 //
@@ -190,12 +162,8 @@ pub fn pipeline_log_n<'e>(
     schema="toolkit_experimental"
 )]
 pub fn pipeline_abs<'e>()
--> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    build!(
-        UnstableTimeseriesPipelineElement {
-            element: Arithmetic { function: Abs, rhs: 0.0 }
-        }
-    )
+-> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Arithmetic { function: Abs, rhs: 0.0 }.flatten()
 }
 
 #[pg_extern(
@@ -205,12 +173,8 @@ pub fn pipeline_abs<'e>()
     schema="toolkit_experimental"
 )]
 pub fn pipeline_cbrt<'e>()
--> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    build!(
-        UnstableTimeseriesPipelineElement {
-            element: Arithmetic { function: Cbrt, rhs: 0.0 }
-        }
-    )
+-> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Arithmetic { function: Cbrt, rhs: 0.0 }.flatten()
 }
 
 #[pg_extern(
@@ -220,12 +184,8 @@ pub fn pipeline_cbrt<'e>()
     schema="toolkit_experimental"
 )]
 pub fn pipeline_ceil<'e>()
--> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    build!(
-        UnstableTimeseriesPipelineElement {
-            element: Arithmetic { function: Ceil, rhs: 0.0 }
-        }
-    )
+-> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Arithmetic { function: Ceil, rhs: 0.0 }.flatten()
 }
 
 #[pg_extern(
@@ -235,12 +195,8 @@ pub fn pipeline_ceil<'e>()
     schema="toolkit_experimental"
 )]
 pub fn pipeline_floor<'e>()
--> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    build!(
-        UnstableTimeseriesPipelineElement {
-            element: Arithmetic { function: Floor, rhs: 0.0 }
-        }
-    )
+-> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Arithmetic { function: Floor, rhs: 0.0 }.flatten()
 }
 
 #[pg_extern(
@@ -250,12 +206,8 @@ pub fn pipeline_floor<'e>()
     schema="toolkit_experimental"
 )]
 pub fn pipeline_ln<'e>()
--> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    build!(
-        UnstableTimeseriesPipelineElement {
-            element: Arithmetic { function: Ln, rhs: 0.0 }
-        }
-    )
+-> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Arithmetic { function: Ln, rhs: 0.0 }.flatten()
 }
 
 #[pg_extern(
@@ -265,12 +217,8 @@ pub fn pipeline_ln<'e>()
     schema="toolkit_experimental"
 )]
 pub fn pipeline_log10<'e>()
--> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    build!(
-        UnstableTimeseriesPipelineElement {
-            element: Arithmetic { function: Log10, rhs: 0.0 }
-        }
-    )
+-> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Arithmetic { function: Log10, rhs: 0.0 }.flatten()
 }
 
 #[pg_extern(
@@ -280,12 +228,8 @@ pub fn pipeline_log10<'e>()
     schema="toolkit_experimental"
 )]
 pub fn pipeline_round<'e>()
--> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    build!(
-        UnstableTimeseriesPipelineElement {
-            element: Arithmetic { function: Round, rhs: 0.0 }
-        }
-    )
+-> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Arithmetic { function: Round, rhs: 0.0 }.flatten()
 }
 
 
@@ -296,12 +240,8 @@ pub fn pipeline_round<'e>()
     schema="toolkit_experimental"
 )]
 pub fn pipeline_sign<'e>()
--> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    build!(
-        UnstableTimeseriesPipelineElement {
-            element: Arithmetic { function: Sign, rhs: 0.0 }
-        }
-    )
+-> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Arithmetic { function: Sign, rhs: 0.0 }.flatten()
 }
 
 #[pg_extern(
@@ -311,12 +251,8 @@ pub fn pipeline_sign<'e>()
     schema="toolkit_experimental"
 )]
 pub fn pipeline_sqrt<'e>()
--> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    build!(
-        UnstableTimeseriesPipelineElement {
-            element: Arithmetic { function: Sqrt, rhs: 0.0 }
-        }
-    )
+-> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Arithmetic { function: Sqrt, rhs: 0.0 }.flatten()
 }
 
 #[pg_extern(
@@ -326,12 +262,8 @@ pub fn pipeline_sqrt<'e>()
     schema="toolkit_experimental"
 )]
 pub fn pipeline_trunc<'e>()
--> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    build!(
-        UnstableTimeseriesPipelineElement {
-            element: Arithmetic { function: Trunc, rhs: 0.0 }
-        }
-    )
+-> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Arithmetic { function: Trunc, rhs: 0.0 }.flatten()
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/extension/src/time_series/pipeline/arithmetic.rs
+++ b/extension/src/time_series/pipeline/arithmetic.rs
@@ -497,20 +497,21 @@ mod tests {
                 {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":30.3}\
             ]");
 
-            let val = client.select(
-                &format!("SELECT (series |> cbrt())::TEXT FROM ({}) s", create_series),
-                None,
-                None
-            )
-                .first()
-                .get_one::<String>();
-            assert_eq!(val.unwrap(), "[\
-                {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":2.943382658441668},\
-                {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":-2.161592332945083},\
-                {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":2.7234356815688767},\
-                {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":-2.4986659549227817},\
-                {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":3.117555613369834}\
-            ]");
+            // TODO re-enable once made stable
+            // let val = client.select(
+            //     &format!("SELECT (series |> cbrt())::TEXT FROM ({}) s", create_series),
+            //     None,
+            //     None
+            // )
+            //     .first()
+            //     .get_one::<String>();
+            // assert_eq!(val.unwrap(), "[\
+            //     {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":2.943382658441668},\
+            //     {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":-2.161592332945083},\
+            //     {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":2.7234356815688767},\
+            //     {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":-2.4986659549227817},\
+            //     {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":3.117555613369834}\
+            // ]");
 
             let val = client.select(
                 &format!("SELECT (series |> ceil())::TEXT FROM ({}) s", create_series),
@@ -544,35 +545,37 @@ mod tests {
 
             // TODO why are there `null`s here?
             // Josh - likely JSON can't represent nans correctly...
-            let val = client.select(
-                &format!("SELECT (series |> ln())::TEXT FROM ({}) s", create_series),
-                None,
-                None
-            )
-                .first()
-                .get_one::<String>();
-            assert_eq!(val.unwrap(), "[\
-                {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":3.2386784521643803},\
-                {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":null},\
-                {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":3.005682604407159},\
-                {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":null},\
-                {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":3.4111477125153233}\
-            ]");
+            // TODO re-enable once made stable
+            // let val = client.select(
+            //     &format!("SELECT (series |> ln())::TEXT FROM ({}) s", create_series),
+            //     None,
+            //     None
+            // )
+            //     .first()
+            //     .get_one::<String>();
+            // assert_eq!(val.unwrap(), "[\
+            //     {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":3.2386784521643803},\
+            //     {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":null},\
+            //     {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":3.005682604407159},\
+            //     {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":null},\
+            //     {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":3.4111477125153233}\
+            // ]");
 
-            let val = client.select(
-                &format!("SELECT (series |> log10())::TEXT FROM ({}) s", create_series),
-                None,
-                None
-            )
-                .first()
-                .get_one::<String>();
-            assert_eq!(val.unwrap(), "[\
-                {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":1.4065401804339552},\
-                {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":null},\
-                {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":1.3053513694466237},\
-                {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":null},\
-                {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":1.481442628502305}\
-            ]");
+            // TODO re-enable once made stable
+            // let val = client.select(
+            //     &format!("SELECT (series |> log10())::TEXT FROM ({}) s", create_series),
+            //     None,
+            //     None
+            // )
+            //     .first()
+            //     .get_one::<String>();
+            // assert_eq!(val.unwrap(), "[\
+            //     {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":1.4065401804339552},\
+            //     {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":null},\
+            //     {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":1.3053513694466237},\
+            //     {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":null},\
+            //     {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":1.481442628502305}\
+            // ]");
 
             let val = client.select(
                 &format!("SELECT (series |> round())::TEXT FROM ({}) s", create_series),
@@ -604,20 +607,21 @@ mod tests {
                 {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":1.0}\
             ]");
 
-            let val = client.select(
-                &format!("SELECT (series |> sqrt())::TEXT FROM ({}) s", create_series),
-                None,
-                None
-            )
-                .first()
-                .get_one::<String>();
-            assert_eq!(val.unwrap(), "[\
-                {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":5.049752469181039},\
-                {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":null},\
-                {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":4.494441010848846},\
-                {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":null},\
-                {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":5.504543577809154}\
-            ]");
+            // TODO re-enable once made stable
+            // let val = client.select(
+            //     &format!("SELECT (series |> sqrt())::TEXT FROM ({}) s", create_series),
+            //     None,
+            //     None
+            // )
+            //     .first()
+            //     .get_one::<String>();
+            // assert_eq!(val.unwrap(), "[\
+            //     {\"ts\":\"2020-01-04 00:00:00+00\",\"val\":5.049752469181039},\
+            //     {\"ts\":\"2020-01-01 00:00:00+00\",\"val\":null},\
+            //     {\"ts\":\"2020-01-03 00:00:00+00\",\"val\":4.494441010848846},\
+            //     {\"ts\":\"2020-01-02 00:00:00+00\",\"val\":null},\
+            //     {\"ts\":\"2020-01-05 00:00:00+00\",\"val\":5.504543577809154}\
+            // ]");
 
             let val = client.select(
                 &format!("SELECT (series |> trunc())::TEXT FROM ({}) s", create_series),

--- a/extension/src/time_series/pipeline/delta.rs
+++ b/extension/src/time_series/pipeline/delta.rs
@@ -3,10 +3,6 @@ use pgx::*;
 
 use super::*;
 
-use crate::{
-    flatten,
-};
-
 // TODO is (immutable, parallel_safe) correct?
 #[pg_extern(
     immutable,
@@ -15,14 +11,8 @@ use crate::{
     schema="toolkit_experimental"
 )]
 pub fn delta_pipeline_element<'p, 'e>(
-) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    unsafe {
-        flatten!(
-            UnstableTimeseriesPipelineElement {
-                element: Element::Delta {}
-            }
-        )
-    }
+) -> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Element::Delta {}.flatten()
 }
 
 pub fn timeseries_delta<'s>(

--- a/extension/src/time_series/pipeline/fill_holes.rs
+++ b/extension/src/time_series/pipeline/fill_holes.rs
@@ -5,10 +5,6 @@ use flat_serialize_macro::FlatSerializable;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    flatten,
-};
-
 use super::*;
 
 // TODO: there are one or two other gapfill objects in this extension, these should be unified
@@ -91,23 +87,17 @@ impl FillMethod {
 )]
 pub fn holefill_pipeline_element<'e> (
     fill_method: String,
-) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    unsafe {
-        let fill_method = match fill_method.to_lowercase().as_str() {
-            "locf" => FillMethod::LOCF,
-            "interpolate" => FillMethod::Interpolate,
-            "linear" => FillMethod::Interpolate,
-            _ => panic!("Invalid downsample method")
-        };
+) -> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    let fill_method = match fill_method.to_lowercase().as_str() {
+        "locf" => FillMethod::LOCF,
+        "interpolate" => FillMethod::Interpolate,
+        "linear" => FillMethod::Interpolate,
+        _ => panic!("Invalid downsample method")
+    };
 
-        flatten!(
-            UnstableTimeseriesPipelineElement {
-                element: Element::FillHoles {
-                    fill_method
-                }
-            }
-        )
-    }
+    Element::FillHoles {
+        fill_method
+    }.flatten()
 }
 
 pub fn fill_holes<'s>(

--- a/extension/src/time_series/pipeline/map.rs
+++ b/extension/src/time_series/pipeline/map.rs
@@ -107,7 +107,6 @@ pub fn map_data_pipeline_element<'e>(
     }
 }
 
-
 pub fn apply_to(mut series: TimeSeries<'_>, func: pg_sys::RegProcedure)
 -> TimeSeries<'_> {
     let mut flinfo: pg_sys::FmgrInfo = unsafe {
@@ -154,7 +153,7 @@ pub fn apply_to(mut series: TimeSeries<'_>, func: pg_sys::RegProcedure)
     series
 }
 
-fn map_series(series: &mut TimeSeries<'_>, mut func: impl FnMut(f64) -> f64) {
+pub fn map_series(series: &mut TimeSeries<'_>, mut func: impl FnMut(f64) -> f64) {
     use SeriesType::*;
 
     match &mut series.series {

--- a/extension/src/time_series/pipeline/resample_to_rate.rs
+++ b/extension/src/time_series/pipeline/resample_to_rate.rs
@@ -7,10 +7,6 @@ use serde::{Deserialize, Serialize};
 
 use super::*;
 
-use crate::{
-    flatten,
-};
-
 type Interval = pg_sys::Datum;
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, FlatSerializable)]
@@ -79,7 +75,7 @@ pub fn resample_pipeline_element<'p, 'e>(
     resample_method: String,
     interval: Interval,
     snap_to_rate: bool,
-) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
+) -> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
     unsafe {
         let interval = interval as *const pg_sys::Interval;
         if (*interval).day > 0 || (*interval).month > 0 {
@@ -95,15 +91,11 @@ pub fn resample_pipeline_element<'p, 'e>(
             _ => panic!("Invalid downsample method")
         };
 
-        flatten!(
-            UnstableTimeseriesPipelineElement {
-                element: Element::ResampleToRate {
-                    interval,
-                    resample_method,
-                    snap_to_rate: if snap_to_rate {1} else {0},
-                }
-            }
-        )
+        Element::ResampleToRate {
+            interval,
+            resample_method,
+            snap_to_rate: if snap_to_rate {1} else {0},
+        }.flatten()
     }
 }
 

--- a/extension/src/time_series/pipeline/sort.rs
+++ b/extension/src/time_series/pipeline/sort.rs
@@ -3,10 +3,6 @@ use pgx::*;
 
 use super::*;
 
-use crate::{
-    flatten,
-};
-
 // TODO is (immutable, parallel_safe) correct?
 #[pg_extern(
     immutable,
@@ -15,14 +11,8 @@ use crate::{
     schema="toolkit_experimental"
 )]
 pub fn sort_pipeline_element<'p, 'e>(
-) -> toolkit_experimental::UnstableTimeseriesPipelineElement<'e> {
-    unsafe {
-        flatten!(
-            UnstableTimeseriesPipelineElement {
-                element: Element::Sort {}
-            }
-        )
-    }
+) -> toolkit_experimental::UnstableTimeseriesPipeline<'e> {
+    Element::Sort {}.flatten()
 }
 
 pub fn sort_timeseries(


### PR DESCRIPTION
This commit adds a `stats_agg()` finalizer for timeseries pipelines. This both serves as a demonstration for how to build finalizers, as well as being the most useful one as it allows users to extract avg, stddev and others while only running the pipeline a single time.

The first commit of this PR is a refactor. See the message for details.