### PR TITLE
Move timescale-analytics refs to timescaledb-toolkit

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,19 +6,19 @@
 This repository is the home of the TimescaleDB Toolkit team. Our mission is to
 ease all things analytics when using TimescaleDB, with a particular focus on
 developer ergonomics and performance. Our issue tracker contains more
-on [the features we're planning to work on](https://github.com/timescale/timescale-analytics/labels/proposed-feature)
-and [the problems we're trying to solve](https://github.com/timescale/timescale-analytics/labels/feature-request),
-and our [Discussions forum](https://github.com/timescale/timescale-analytics/discussions) contains ongoing conversation.
+on [the features we're planning to work on](https://github.com/timescale/timescaledb-toolkit/labels/proposed-feature)
+and [the problems we're trying to solve](https://github.com/timescale/timescaledb-toolkit/labels/feature-request),
+and our [Discussions forum](https://github.com/timescale/timescaledb-toolkit/discussions) contains ongoing conversation.
 
 Documentation for this version of the TimescaleDB Toolkit extension can be found
-in this repository at [`docs`](https://github.com/timescale/timescale-analytics/tree/main/docs).
+in this repository at [`docs`](https://github.com/timescale/timescaledb-toolkit/tree/main/docs).
 
 
 ## 🖥 Try It Out ##
 
 The extension comes pre-installed on all [Timescale Forge](https://console.forge.timescale.com/) instances, and also on our full-featured [`timescale/timescaledb-ha` docker image](https://hub.docker.com/r/timescale/timescaledb-ha).
 
-We also provide nightly builds as a docker images in `timescaledev/timescale-analytics:nightly`.
+We also provide nightly builds as a docker images in `timescaledev/timescaledb-toolkit:nightly`.
 
 All versions of the extension contain experimental features in the `toolkit_experimental`, schema see [our docs section on experimental features](/docs/README.md#tag-notes) for
 more details.
@@ -48,8 +48,8 @@ cargo pgx init --pg13 pg_config
 
 Download or clone this repository, and switch to the `extension` subdirectory, e.g.
 ```bash
-git clone https://github.com/timescale/timescale-analytics && \
-cd timescale-analytics/extension
+git clone https://github.com/timescale/timescaledb-toolkit && \
+cd timescaledb-toolkit/extension
 ```
 Then run
 ```
@@ -62,9 +62,9 @@ cargo run --manifest-path ../tools/post-install/Cargo.toml -- pg_config
 The TimescaleDB Toolkit project is still in the initial planning stage as we
 decide our priorities and what to implement first. As such, now is a great time
 to help shape the project's direction! Have a look at the
-[list of features we're thinking of working on](https://github.com/timescale/timescale-analytics/labels/proposed-feature)
+[list of features we're thinking of working on](https://github.com/timescale/timescaledb-toolkit/labels/proposed-feature)
 and feel free to comment on the features, expand the list, or
-hop on the [Discussions forum](https://github.com/timescale/timescale-analytics/discussions) for more in-depth discussions.
+hop on the [Discussions forum](https://github.com/timescale/timescaledb-toolkit/discussions) for more in-depth discussions.
 
 ### 🔨 Building ###
 

--- a/crates/counter-agg/src/lib.rs
+++ b/crates/counter-agg/src/lib.rs
@@ -71,7 +71,7 @@ impl CounterSummary {
         //TODO: test this
         if incoming.ts == self.last.ts {
             // if two points are equal we only use the first we see
-            // see discussion at https://github.com/timescale/timescale-analytics/discussions/65
+            // see discussion at https://github.com/timescale/timescaledb-toolkit/discussions/65
             return Ok(());
         }
         if incoming.val < self.last.val {

--- a/crates/time-weighted-average/src/lib.rs
+++ b/crates/time-weighted-average/src/lib.rs
@@ -44,7 +44,7 @@ impl TimeWeightSummary {
         }
         if pt.ts == self.last.ts {
             // if two points are equal we only use the first we see
-            // see discussion at https://github.com/timescale/timescale-analytics/discussions/65
+            // see discussion at https://github.com/timescale/timescaledb-toolkit/discussions/65
             return Ok(());
         }
         self.w_sum += self.method.weighted_sum(self.last, pt);

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -42,7 +42,7 @@ RUN set -ex \
     && rm -rf ~/timescaledb
 
 # install doctester
-RUN cargo install --git https://github.com/timescale/timescale-analytics.git --branch main sql-doctester
+RUN cargo install --git https://github.com/timescale/timescaledb-toolkit.git --branch main sql-doctester
 
 FROM pgx_builder AS rust-pgx
 

--- a/docker/nightly/Dockerfile
+++ b/docker/nightly/Dockerfile
@@ -27,14 +27,14 @@ RUN set -ex \
     && cargo install --git https://github.com/JLockerman/pgx.git --branch timescale cargo-pgx \
     && cargo pgx init --pg13 /usr/lib/postgresql/13/bin/pg_config
 
-COPY . /rust/timescale-analytics
+COPY . /rust/timescaledb-toolkit
 
 RUN set -ex \
     && chown -R postgres:postgres /rust \
     && chown postgres:postgres -R "${CARGO_HOME}" \
     && chown postgres:postgres -R /usr/share/postgresql \
     && chown postgres:postgres -R /usr/lib/postgresql \
-    && cd /rust/timescale-analytics \
+    && cd /rust/timescaledb-toolkit \
         && cd extension \
         && cargo pgx install --release \
         && cargo run --manifest-path ../tools/post-install/Cargo.toml -- pg_config

--- a/tools/sql-doctester/Readme.md
+++ b/tools/sql-doctester/Readme.md
@@ -42,7 +42,7 @@ Delta
 ## Installation ##
 
 ```bash
-cargo install --git https://github.com/timescale/timescale-analytics.git --branch main sql-doctester
+cargo install --git https://github.com/timescale/timescaledb-toolkit.git --branch main sql-doctester
 ```
 
 ## Usage ##


### PR DESCRIPTION
I just saw a few references from this project before the renaming. So, moving them to the actual project URL.