### PR TITLE
Add toolkit docker repo

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -59,7 +59,7 @@ jobs:
           push: true
           context: .
           file: ./docker/nightly/Dockerfile
-          tags: timescaledev/timescale-analytics:nightly
+          tags: timescaledev/timescale-analytics:nightly,timescaledev/timescaledb-toolkit:nightly
 
       - name: Image digest
         run: echo ${{ steps.image_build.outputs.digest }}


### PR DESCRIPTION
We wanted to switch the nightly image tag to `timescaledev/timescaledb-toolkit:nightly` when we changed the extension name, but the docker bot didn't have permission. This should be fixed now so adding the new tag. We'll keep the old tag around so those using it can keep doing so.