### PR TITLE
Add `unnest()` and `series() finalizers

### DIFF
--- a/docs/asap.md
+++ b/docs/asap.md
@@ -13,7 +13,7 @@ The [ASAP smoothing alogrithm](https://arxiv.org/pdf/1703.00983.pdf) is designed
 
 Timescale's ASAP smoothing is implemented as a PostgresQL aggregate over a series of timestamps and values, with an additional target resolution used to control the output size.  The implementation will take the incoming data and attempt to bucket the points into even sized buckets such the number of buckets approximates the target resolution and each bucket contains a similar number of points (if necessary, gaps will be filled by interpolating the buckets on either side at this point).  It will then attempt to identify good candidate intervals for smoothing the data (using the Wiener-Khinchin theorem to find periods of high autocorrelation), and then choose the candidate that produces the smoothest graph while having the same degree of outlier values.
 
-The output of the postgres aggregate is a timescale timeseries object describing the start and step interval times and listing the values.  This can be passed to our `unnest_series` API to produce a table of time, value points.  The aggreates are also currently not partializeable or combinable.
+The output of the postgres aggregate is a timescale timeseries object describing the start and step interval times and listing the values.  This can be passed to our `unnest` API to produce a table of time, value points.  The aggreates are also currently not partializeable or combinable.
 
 ## Usage Example <a id="asap-example"></a>
 
@@ -48,7 +48,7 @@ It is hard to look at this data and make much sense of how the temperature has c
 We can use ASAP smoothing here to get a much clearer picture of the behavior over this interval.
 
 ```SQL ,ignore
-SELECT * FROM toolkit_experimental.unnest_series((SELECT toolkit_experimental.asap_smooth(month, value, 800) FROM temperatures));
+SELECT * FROM toolkit_experimental.unnest((SELECT toolkit_experimental.asap_smooth(month, value, 800) FROM temperatures));
 ```
 ```
                 time                 |       value
@@ -70,7 +70,7 @@ SELECT * FROM toolkit_experimental.unnest_series((SELECT toolkit_experimental.as
 ...
 ```
 
-Note the use of the `unnest_series` here to unpack the results of the `asap_smooth` command.  The output of this command is ~800 points of smoothed data (in this case it ended up being 888 points each representing a rolling moving average of about 21.5 years).  We can view of graph of these values to get a much clearer picture of how the temperature has fluctuated over this time:
+Note the use of the `unnest` here to unpack the results of the `asap_smooth` command.  The output of this command is ~800 points of smoothed data (in this case it ended up being 888 points each representing a rolling moving average of about 21.5 years).  We can view of graph of these values to get a much clearer picture of how the temperature has fluctuated over this time:
 
 ![Smoothed data](images/ASAP_smoothed.png)
 
@@ -102,7 +102,7 @@ This normalize time, value pairs over a given interval and return a smoothed rep
 
 |Column|Type|Description|
 |---|---|---|
-| `normalizedtimeseries` | `NormalizedTimeSeries` | A object representing a series of values occurring at set intervals from a starting time.  It can be unpacked via `unnest_series` |
+| `normalizedtimeseries` | `NormalizedTimeSeries` | A object representing a series of values occurring at set intervals from a starting time.  It can be unpacked via `unnest` |
 <br>
 
 ### Sample Usages <a id="asap-examples"></a>
@@ -124,7 +124,7 @@ SELECT
 </div>
 
 ```SQL
-SELECT * FROM toolkit_experimental.unnest_series(
+SELECT * FROM toolkit_experimental.unnest(
     (SELECT toolkit_experimental.asap_smooth(date, reading, 8)
      FROM metrics));
 ```

--- a/docs/lttb.md
+++ b/docs/lttb.md
@@ -40,7 +40,7 @@ to 34 points
 
 ```SQL
 SELECT time, value::numeric(10,2)
-FROM toolkit_experimental.unnest_series((
+FROM toolkit_experimental.unnest((
     SELECT toolkit_experimental.lttb(time, val, 34)
     FROM sample_data))
 ```
@@ -101,7 +101,7 @@ resulting data looks less and less like the original
 
 ```SQL
 SELECT time, value::numeric(10,2)
-FROM toolkit_experimental.unnest_series((
+FROM toolkit_experimental.unnest((
     SELECT toolkit_experimental.lttb(time, val, 17)
     FROM sample_data))
 ```
@@ -132,7 +132,7 @@ FROM toolkit_experimental.unnest_series((
 
 ```SQL
 SELECT time, value::numeric(10,2)
-FROM toolkit_experimental.unnest_series((
+FROM toolkit_experimental.unnest((
     SELECT toolkit_experimental.lttb(time, val, 8)
     FROM sample_data))
 ```
@@ -165,7 +165,7 @@ toolkit_experimental.lttb(
 ```
 
 This will construct and return a sorted timeseries with at most `resolution`
-points. `toolkit_experimental.unnest_series(...)` can be used to
+points. `toolkit_experimental.unnest(...)` can be used to
 extract the `(time, value)` pairs from this series
 
 ### Required Arguments <a id="lttb-required-arguments"></a>
@@ -180,7 +180,7 @@ extract the `(time, value)` pairs from this series
 
 ```SQL
 SELECT time, value
-FROM toolkit_experimental.unnest_series((
+FROM toolkit_experimental.unnest((
     SELECT toolkit_experimental.lttb(time, val, 4)
     FROM sample_data))
 ```

--- a/docs/timeseries.md
+++ b/docs/timeseries.md
@@ -46,7 +46,7 @@ We can now use this timeseries to efficiently move the data around to other func
 
 ```SQL
 SELECT time, value::numeric(10,2) FROM
-toolkit_experimental.unnest_series((SELECT toolkit_experimental.lttb(timeseries, 20) FROM series));
+toolkit_experimental.unnest((SELECT toolkit_experimental.lttb(timeseries, 20) FROM series));
 ```
 ```output
           time          |       value
@@ -80,7 +80,7 @@ Aggregate Functions
 > - [rollup (summary form)](#timeseries-summary)
 
 Accessor Functions
-> - [unnest_series](#timeseries_unnest)
+> - [unnest](#timeseries_unnest)
 
 
 ---
@@ -161,10 +161,10 @@ FROM series;
 
 ---
 
-## **unnest_series** <a id="timeseries_unnest"></a>
+## **unnest** <a id="timeseries_unnest"></a>
 
 ```SQL ,ignore
-unnest_series(
+unnest(
     series timeseries
 ) RETURNS TABLE("time" timestamp with time zone, value double precision)
 ```
@@ -180,13 +180,13 @@ The unnest function is used to get the (time, value) pairs back out of a timeser
 ### Returns
 |Column|Type|Description|
 |---|---|---|
-| `unnest_series` | `TABLE` | The (time,value) records contained in the timeseries. |
+| `unnest` | `TABLE` | The (time,value) records contained in the timeseries. |
 <br>
 
 ### Sample Usage <a id="timeseries_unnest-examples"></a>
 
 ```SQL
-SELECT toolkit_experimental.unnest_series(
+SELECT toolkit_experimental.unnest(
     (SELECT toolkit_experimental.timeseries(a.time, a.value)
     FROM
         (SELECT time, value
@@ -196,7 +196,7 @@ SELECT toolkit_experimental.unnest_series(
 LIMIT 10;
 ```
 ```output
-                 unnest_series
+                 unnest
 -----------------------------------------------
  ("2020-01-01 00:00:00+00",1009.8399687963981)
  ("2020-01-01 00:10:00+00",873.6326953620166)

--- a/docs/timeseries_pipeline_elements.md
+++ b/docs/timeseries_pipeline_elements.md
@@ -62,7 +62,7 @@ CREATE VIEW daily_delta AS
 This command creates a timeseries from the time and temperature columns (grouped by device), sorts them in increasing time, aggregates them as a daily average, interpolates the values for any missing days, and computes the deltas between days.  Now we can look at the deltas for a specific device:
 
 ```SQL
-SELECT time, value::numeric(4,2) AS delta FROM toolkit_experimental.unnest_series((SELECT deltas FROM daily_delta WHERE device = 3));
+SELECT time, value::numeric(4,2) AS delta FROM toolkit_experimental.unnest((SELECT deltas FROM daily_delta WHERE device = 3));
 ```
 ```output
           time          | delta
@@ -145,7 +145,7 @@ This element will return a new timeseries where each point is the difference bet
 ### Sample Usage <a id="timeseries_pipeline_delta-examples"></a>
 ```SQL
 SELECT time, value
-FROM toolkit_experimental.unnest_series(
+FROM toolkit_experimental.unnest(
     (SELECT toolkit_experimental.timeseries('2020-01-01'::timestamptz + step * '1 day'::interval, step * step)
         -> toolkit_experimental.delta()
     FROM generate_series(1, 5) step)
@@ -193,7 +193,7 @@ Valid fill methods are:
 ### Sample Usage <a id="timeseries_pipeline_fill_holes-examples"></a>
 ```SQL
 SELECT time, value
-FROM toolkit_experimental.unnest_series(
+FROM toolkit_experimental.unnest(
     (SELECT toolkit_experimental.timeseries('2020-01-01'::timestamptz + step * step * '1 hour'::interval, step * step)
         -> (toolkit_experimental.resample_to_rate('nearest', '1 hour', true)
         ->  toolkit_experimental.fill_holes('locf'))
@@ -249,7 +249,7 @@ SELECT timeseries(time, value) -> sort() -> lttb() FROM data;
 ### Sample Usage <a id="timeseries_pipeline_lttb-examples"></a>
 ```SQL
 SELECT time, value
-FROM toolkit_experimental.unnest_series(
+FROM toolkit_experimental.unnest(
     (SELECT toolkit_experimental.timeseries('2020-01-01 UTC'::TIMESTAMPTZ + make_interval(days=>(foo*10)::int), 10 + 5 * cos(foo))
         -> toolkit_experimental.lttb(4)
     FROM generate_series(1,11,0.1) foo)
@@ -304,7 +304,7 @@ In all cases, if there are no points in the input series in the interval range o
 ### Sample Usage <a id="timeseries_pipeline_resample_to_rate-examples"></a>
 ```SQL
 SELECT time, value::numeric(4,2)
-FROM toolkit_experimental.unnest_series(
+FROM toolkit_experimental.unnest(
     (SELECT toolkit_experimental.timeseries('2020-01-01'::TIMESTAMPTZ + step *step * step * '1 minute'::interval, step)
         -> toolkit_experimental.resample_to_rate('weighted_average', '1 hour', true)
     FROM generate_series(1,10) step)
@@ -348,7 +348,7 @@ This element takes in a timeseries and returns a timeseries consisting of the sa
 ### Sample Usage <a id="timeseries_pipeline_sort-examples"></a>
 ```SQL
 SELECT time, value
-FROM toolkit_experimental.unnest_series(
+FROM toolkit_experimental.unnest(
     (SELECT toolkit_experimental.timeseries('2020-01-06'::timestamptz - step * '1 day'::interval, step * step)
         -> toolkit_experimental.sort()
     FROM generate_series(1, 5) step)

--- a/extension/sql/load-order.txt
+++ b/extension/sql/load-order.txt
@@ -23,3 +23,4 @@ zz_triggers.generated.sql
 schema_test.generated.sql
 serialization_collations.generated.sql
 serialization_types.generated.sql
+time_series_pipeline_expansion.generated.sql

--- a/extension/src/asap.rs
+++ b/extension/src/asap.rs
@@ -282,7 +282,7 @@ mod tests {
             // and our decreased values should be around 64-72.  However, since the output is
             // rolling averages, expect these values to impact the results around these ranges as well.
 
-            client.select("create table asap_vals as SELECT * FROM toolkit_experimental.unnest_series((SELECT toolkit_experimental.asap_smooth(date, value, 100) FROM asap_test ))", None, None);
+            client.select("create table asap_vals as SELECT * FROM toolkit_experimental.unnest((SELECT toolkit_experimental.asap_smooth(date, value, 100) FROM asap_test ))", None, None);
 
             let sanity = client.select("SELECT COUNT(*) FROM asap_vals", None, None).first()
                 .get_one::<i32>().unwrap();
@@ -338,7 +338,7 @@ mod tests {
             client.select(
                 "create table asap_vals2 as
                 SELECT *
-                FROM toolkit_experimental.unnest_series(
+                FROM toolkit_experimental.unnest(
                     (SELECT toolkit_experimental.asap_smooth(
                         (SELECT toolkit_experimental.timeseries(date, value) FROM asap_test),
                         100)

--- a/extension/src/lttb.rs
+++ b/extension/src/lttb.rs
@@ -283,7 +283,7 @@ mod tests {
             client.select(
                 "INSERT INTO results1
                 SELECT time, value
-                FROM toolkit_experimental.unnest_series(
+                FROM toolkit_experimental.unnest(
                     (SELECT toolkit_experimental.lttb(time, value, 100) FROM test)
                 );", None, None);
 
@@ -291,7 +291,7 @@ mod tests {
             client.select(
                 "INSERT INTO results2
                 SELECT time, value
-                FROM toolkit_experimental.unnest_series(
+                FROM toolkit_experimental.unnest(
                     (SELECT toolkit_experimental.lttb(
                         (SELECT toolkit_experimental.timeseries(time, value) FROM test), 100)
                     )

--- a/extension/src/time_series.rs
+++ b/extension/src/time_series.rs
@@ -199,7 +199,7 @@ pub static TIMESERIES_OID: once_cell::sync::Lazy<pg_sys::Oid> = once_cell::sync:
 });
 
 #[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
-pub fn unnest_series(
+pub fn unnest(
     series: toolkit_experimental::TimeSeries<'_>,
 ) -> impl std::iter::Iterator<Item = (name!(time,pg_sys::TimestampTz),name!(value,f64))> + '_ {
     series.into_iter().map(|points| (points.ts, points.val))

--- a/extension/src/time_series/pipeline.rs
+++ b/extension/src/time_series/pipeline.rs
@@ -6,6 +6,7 @@ mod delta;
 mod map;
 mod arithmetic;
 mod aggregation;
+mod expansion;
 
 use std::convert::TryInto;
 

--- a/extension/src/time_series/pipeline/expansion.rs
+++ b/extension/src/time_series/pipeline/expansion.rs
@@ -77,7 +77,7 @@ pub fn arrow_run_pipeline_then_unnest<'s, 'p>(
 {
     let series = run_pipeline_elements(timeseries, pipeline.elements.iter())
         .0.into_owned();
-    crate::time_series::unnest_series(series.into())
+    crate::time_series::unnest(series.into())
 }
 
 

--- a/extension/src/time_series/pipeline/expansion.rs
+++ b/extension/src/time_series/pipeline/expansion.rs
@@ -1,0 +1,117 @@
+
+use std::{iter::Iterator, mem::replace};
+
+use pgx::*;
+
+use super::*;
+
+use crate::{
+    ron_inout_funcs, pg_type, build,
+};
+
+// hack to allow us to qualify names with "toolkit_experimental"
+// so that pgx generates the correct SQL
+pub mod toolkit_experimental {
+    pub(crate) use super::*;
+    varlena_type!(PipelineThenUnnest);
+}
+
+pg_type! {
+    #[derive(Debug)]
+    struct PipelineThenUnnest<'input> {
+        num_elements: u64,
+        elements: [Element; self.num_elements],
+    }
+}
+
+ron_inout_funcs!(PipelineThenUnnest);
+
+#[pg_extern(
+    immutable,
+    parallel_safe,
+    name="unnest",
+    schema="toolkit_experimental"
+)]
+pub fn pipeline_unnest<'e>() -> toolkit_experimental::PipelineThenUnnest<'e> {
+    build! {
+        PipelineThenUnnest {
+            num_elements: 0,
+            elements: vec![].into(),
+        }
+    }
+}
+
+#[pg_operator(immutable, parallel_safe)]
+#[opname(->)]
+pub fn arrow_finalize_with_unnest<'p, 'e>(
+    mut pipeline: toolkit_experimental::UnstableTimeseriesPipeline<'p>,
+    then_stats_agg: toolkit_experimental::PipelineThenUnnest<'e>,
+) -> toolkit_experimental::PipelineThenUnnest<'e> {
+    if then_stats_agg.num_elements == 0 {
+        // flatten immediately so we don't need a temporary allocation for elements
+        return unsafe {flatten! {
+            PipelineThenUnnest {
+                num_elements: pipeline.0.num_elements,
+                elements: pipeline.0.elements,
+            }
+        }}
+    }
+
+    let mut elements = replace(pipeline.elements.as_owned(), vec![]);
+    elements.extend(then_stats_agg.elements.iter());
+    build! {
+        PipelineThenUnnest {
+            num_elements: elements.len().try_into().unwrap(),
+            elements: elements.into(),
+        }
+    }
+}
+
+
+#[pg_operator(immutable, parallel_safe)]
+#[opname(->)]
+pub fn arrow_run_pipeline_then_unnest<'s, 'p>(
+    timeseries: toolkit_experimental::TimeSeries<'s>,
+    pipeline: toolkit_experimental::PipelineThenUnnest<'p>,
+) -> impl Iterator<Item = (name!(time,pg_sys::TimestampTz),name!(value,f64))>
+{
+    let series = run_pipeline_elements(timeseries, pipeline.elements.iter())
+        .0.into_owned();
+    crate::time_series::unnest_series(series.into())
+}
+
+
+#[cfg(any(test, feature = "pg_test"))]
+mod tests {
+    use pgx::*;
+
+    #[pg_test]
+    fn test_unnest_finalizer() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            // using the search path trick for this test b/c the operator is
+            // difficult to spot otherwise.
+            let sp = client.select("SELECT format(' %s, toolkit_experimental',current_setting('search_path'))", None, None).first().get_one::<String>().unwrap();
+            client.select(&format!("SET LOCAL search_path TO {}", sp), None, None);
+            client.select("SET timescaledb_toolkit_acknowledge_auto_drop TO 'true'", None, None);
+
+            // we use a subselect to guarantee order
+            let create_series = "SELECT timeseries(time, value) as series FROM \
+                (VALUES ('2020-01-04 UTC'::TIMESTAMPTZ, 25.0), \
+                    ('2020-01-01 UTC'::TIMESTAMPTZ, 10.0), \
+                    ('2020-01-03 UTC'::TIMESTAMPTZ, 20.0), \
+                    ('2020-01-02 UTC'::TIMESTAMPTZ, 15.0), \
+                    ('2020-01-05 UTC'::TIMESTAMPTZ, 30.0)) as v(time, value)";
+
+            let val = client.select(
+                &format!("SELECT array_agg(val)::TEXT \
+                    FROM (SELECT series -> unnest() as val FROM ({}) s) t", create_series),
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "{\"(\\\"2020-01-04 00:00:00+00\\\",25)\",\"(\\\"2020-01-01 00:00:00+00\\\",10)\",\"(\\\"2020-01-03 00:00:00+00\\\",20)\",\"(\\\"2020-01-02 00:00:00+00\\\",15)\",\"(\\\"2020-01-05 00:00:00+00\\\",30)\"}");
+        });
+    }
+}

--- a/extension/src/time_series/pipeline/map.rs
+++ b/extension/src/time_series/pipeline/map.rs
@@ -300,7 +300,7 @@ mod tests {
             client.select(
                 "CREATE FUNCTION jan_3_x3(timeseries) RETURNS timeseries AS $$\
                     SELECT timeseries(time, value * 3) \
-                    FROM (SELECT (unnest_series($1)).*) a \
+                    FROM (SELECT (unnest($1)).*) a \
                     WHERE time='2020-01-03 00:00:00+00';\
                 $$ LANGUAGE SQL",
                 None,


### PR DESCRIPTION
This PR adds finalizers for `unnest()` and `series()`. It allows users to do
```SQL
series -> unnest()
```
to unnest a timeseries and
```SQL
series -> series()
```
to indicate they want a materialized timeseries.