### PR TITLE
Update table printing in sql-doctester

### DIFF
--- a/tools/sql-doctester/src/runner.rs
+++ b/tools/sql-doctester/src/runner.rs
@@ -241,6 +241,11 @@ fn stringify_table(table: &Vec<Vec<String>>) -> String {
     }
     let mut width = vec![0; table[0].len()];
     for row in table {
+        // Ensure that we have width for every column
+        // TODO this shouldn't be needed, but somtimes is?
+        if width.len() < row.len() {
+            width.extend((0..row.len()-width.len()).map(|_| 0));
+        }
         for (i, value) in row.iter().enumerate() {
             width[i] = max(width[i], value.len())
         }


### PR DESCRIPTION
In a version of PR #246 we encountered an index-out-of-bounds that _appears_ to be do to the table printing code. The most likely cause of this is the first row has fewer columns than latter ones, so this commit adds a defensive check for this.