### PR TITLE
EXPERIMENT lambda pipeline element

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,11 +154,32 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
 ]
 
 [[package]]
@@ -175,6 +196,12 @@ name = "bumpalo"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytecount"
@@ -351,6 +378,15 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
@@ -431,6 +467,12 @@ dependencies = [
  "log",
  "url",
 ]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fallible-iterator"
@@ -697,7 +739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -823,6 +865,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,9 +882,9 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
 dependencies = [
- "block-buffer",
- "digest",
- "opaque-debug",
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -950,6 +998,12 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
@@ -1006,6 +1060,49 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1",
+]
 
 [[package]]
 name = "pgx"
@@ -1555,6 +1652,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,11 +1675,11 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if 1.0.0",
  "cpuid-bool",
- "digest",
- "opaque-debug",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -1908,6 +2017,8 @@ dependencies = [
  "hyperloglogplusplus",
  "once_cell",
  "paste",
+ "pest",
+ "pest_derive",
  "pgx",
  "pgx-macros",
  "pgx-tests",
@@ -2004,6 +2115,12 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "uddsketch"

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -40,6 +40,9 @@ rand_distr = "0.4.0"
 rand_chacha = "0.3.0"
 ron="0.6.0"
 
+pest = "2.1"
+pest_derive = "2.1"
+
 [dev-dependencies]
 pgx-tests = {git="https://github.com/JLockerman/pgx.git", branch="timescale2"}
 approx = "0.4.0"

--- a/extension/sql/load-order.txt
+++ b/extension/sql/load-order.txt
@@ -13,6 +13,7 @@ stats_agg.generated.sql
 time_series_pipeline.generated.sql
 time_series_pipeline_delta.generated.sql
 time_series_pipeline_fill_holes.generated.sql
+time_series_pipeline_lambda.generated.sql
 time_series_pipeline_map.generated.sql
 time_series_pipeline_resample_to_rate.generated.sql
 time_series_pipeline_sort.generated.sql
@@ -21,6 +22,7 @@ time_series_pipeline_arithmetic.generated.sql
 time_series_pipeline_aggregation.generated.sql
 zz_triggers.generated.sql
 time_series_pipeline_expansion.generated.sql
+time_series_pipeline_filter.generated.sql
 schema_test.generated.sql
 serialization_collations.generated.sql
 serialization_types.generated.sql

--- a/extension/src/time_series/pipeline/aggregation.rs
+++ b/extension/src/time_series/pipeline/aggregation.rs
@@ -17,7 +17,7 @@ pg_type! {
     #[derive(Debug)]
     struct PipelineThenStatsAgg<'input> {
         num_elements: u64,
-        elements: [Element; self.num_elements],
+        elements: [Element<'input>; self.num_elements],
     }
 }
 
@@ -50,8 +50,8 @@ pub fn run_pipeline_then_stats_agg<'s, 'p>(
 }
 
 #[pg_extern(immutable, parallel_safe, schema="toolkit_experimental")]
-pub fn finalize_with_stats_agg<'p, 'e>(
-    mut pipeline: toolkit_experimental::UnstableTimevectorPipeline<'p>,
+pub fn finalize_with_stats_agg<'e>(
+    mut pipeline: toolkit_experimental::UnstableTimevectorPipeline<'e>,
     then_stats_agg: toolkit_experimental::PipelineThenStatsAgg<'e>,
 ) -> toolkit_experimental::PipelineThenStatsAgg<'e> {
     if then_stats_agg.num_elements == 0 {
@@ -130,7 +130,7 @@ pg_type! {
     #[derive(Debug)]
     struct PipelineThenSum<'input> {
         num_elements: u64,
-        elements: [Element; self.num_elements],
+        elements: [Element<'input>; self.num_elements],
     }
 }
 
@@ -179,8 +179,8 @@ pub fn arrow_pipeline_then_sum<'s, 'p>(
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn finalize_with_sum<'p, 'e>(
-    mut pipeline: toolkit_experimental::UnstableTimevectorPipeline<'p>,
+pub fn finalize_with_sum<'e>(
+    mut pipeline: toolkit_experimental::UnstableTimevectorPipeline<'e>,
     then_stats_agg: toolkit_experimental::PipelineThenSum<'e>,
 ) -> toolkit_experimental::PipelineThenSum<'e> {
     if then_stats_agg.num_elements == 0 {
@@ -229,7 +229,7 @@ pg_type! {
     #[derive(Debug)]
     struct PipelineThenAverage<'input> {
         num_elements: u64,
-        elements: [Element; self.num_elements],
+        elements: [Element<'input>; self.num_elements],
     }
 }
 
@@ -278,8 +278,8 @@ pub fn arrow_pipeline_then_average<'s, 'p>(
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn finalize_with_average<'p, 'e>(
-    mut pipeline: toolkit_experimental::UnstableTimevectorPipeline<'p>,
+pub fn finalize_with_average<'e>(
+    mut pipeline: toolkit_experimental::UnstableTimevectorPipeline<'e>,
     then_stats_agg: toolkit_experimental::PipelineThenAverage<'e>,
 ) -> toolkit_experimental::PipelineThenAverage<'e> {
     if then_stats_agg.num_elements == 0 {
@@ -328,7 +328,7 @@ pg_type! {
     #[derive(Debug)]
     struct PipelineThenNumVals<'input> {
         num_elements: u64,
-        elements: [Element; self.num_elements],
+        elements: [Element<'input>; self.num_elements],
     }
 }
 
@@ -370,8 +370,8 @@ pub fn arrow_pipeline_then_num_vals<'s, 'p>(
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn finalize_with_num_vals<'p, 'e>(
-    mut pipeline: toolkit_experimental::UnstableTimevectorPipeline<'p>,
+pub fn finalize_with_num_vals<'e>(
+    mut pipeline: toolkit_experimental::UnstableTimevectorPipeline<'e>,
     then_stats_agg: toolkit_experimental::PipelineThenNumVals<'e>,
 ) -> toolkit_experimental::PipelineThenNumVals<'e> {
     if then_stats_agg.num_elements == 0 {
@@ -416,7 +416,7 @@ pg_type! {
     #[derive(Debug)]
     struct PipelineThenCounterAgg<'input> {
         num_elements: u64,
-        elements: [Element; self.num_elements],
+        elements: [Element<'input>; self.num_elements],
     }
 }
 
@@ -440,8 +440,8 @@ pub fn run_pipeline_then_counter_agg<'s, 'p>(
 }
 
 #[pg_extern(immutable, parallel_safe, schema="toolkit_experimental")]
-pub fn finalize_with_counter_agg<'p, 'e>(
-    mut pipeline: toolkit_experimental::UnstableTimevectorPipeline<'p>,
+pub fn finalize_with_counter_agg<'e>(
+    mut pipeline: toolkit_experimental::UnstableTimevectorPipeline<'e>,
     then_counter_agg: toolkit_experimental::PipelineThenCounterAgg<'e>,
 ) -> toolkit_experimental::PipelineThenCounterAgg<'e> {
     if then_counter_agg.num_elements == 0 {
@@ -517,7 +517,7 @@ pg_type! {
     struct PipelineThenHyperLogLog<'input> {
         hll_size: u64,
         num_elements: u64,
-        elements: [Element; self.num_elements],
+        elements: [Element<'input>; self.num_elements],
     }
 }
 
@@ -539,8 +539,8 @@ pub fn run_pipeline_then_hyperloglog<'s, 'p>(
 }
 
 #[pg_extern(immutable, parallel_safe, schema="toolkit_experimental")]
-pub fn finalize_with_hyperloglog<'p, 'e>(
-    mut pipeline: toolkit_experimental::UnstableTimevectorPipeline<'p>,
+pub fn finalize_with_hyperloglog<'e>(
+    mut pipeline: toolkit_experimental::UnstableTimevectorPipeline<'e>,
     then_hyperloglog: toolkit_experimental::PipelineThenHyperLogLog<'e>,
 ) -> toolkit_experimental::PipelineThenHyperLogLog<'e> {
     if then_hyperloglog.num_elements == 0 {

--- a/extension/src/time_series/pipeline/filter.rs
+++ b/extension/src/time_series/pipeline/filter.rs
@@ -1,0 +1,132 @@
+
+use pgx::*;
+
+use super::*;
+
+// TODO is (stable, parallel_safe) correct?
+#[pg_extern(
+    immutable,
+    parallel_safe,
+    name="filter",
+    schema="toolkit_experimental"
+)]
+pub fn filter_lambda_pipeline_element<'l, 'e>(
+    lambda: toolkit_experimental::Lambda<'l>,
+) -> toolkit_experimental::UnstableTimevectorPipeline<'e> {
+    let expression = lambda.parse();
+    if expression.ty() != &lambda::Type::Bool {
+        panic!("invalid lambda type: the lambda must return a BOOLEAN")
+    }
+
+    Element::FilterLambda { lambda: lambda.into_data() }.flatten()
+}
+
+pub fn apply_lambda_to<'a>(mut series: Timevector<'a>, lambda: &lambda::LambdaData<'_>)
+-> Timevector<'a> {
+    let expression = lambda.parse();
+    if expression.ty() != &lambda::Type::Bool {
+        panic!("invalid lambda type: the lambda must return a BOOLEAN")
+    }
+
+    let mut executor = lambda::ExpressionExecutor::new(&expression);
+
+
+    let invoke = |time: i64, value: f64| {
+        use lambda::Value::*;
+        executor.reset();
+        let result = executor.exec(value, time);
+        match result {
+            Bool(b) => b,
+            _ => unreachable!(),
+        }
+    };
+
+    filter_lambda_over_series(&mut series, invoke);
+    series
+}
+
+pub fn filter_lambda_over_series(
+    series: &mut Timevector<'_>,
+    mut func: impl FnMut(i64, f64) -> bool,
+) {
+    use SeriesType::*;
+
+    match &mut series.series {
+        SortedSeries { points, num_points } | ExplicitSeries { points, num_points } => {
+            points.as_owned().retain(|p| func(p.ts, p.val));
+            *num_points = points.len() as _;
+        },
+        _ => {
+            let new_points: Vec<_> = series.iter().filter(|p| func(p.ts, p.val)).collect();
+            *series = build! {
+                Timevector {
+                    series: ExplicitSeries {
+                        num_points: new_points.len() as _,
+                        points: new_points.into(),
+                    },
+                }
+            }
+        }
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+mod tests {
+    use pgx::*;
+
+    #[pg_test]
+    fn test_pipeline_filter_lambda() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            // using the search path trick for this test b/c the operator is
+            // difficult to spot otherwise.
+            let sp = client.select("SELECT format(' %s, toolkit_experimental',current_setting('search_path'))", None, None).first().get_one::<String>().unwrap();
+            client.select(&format!("SET LOCAL search_path TO {}", sp), None, None);
+            client.select("SET timescaledb_toolkit_acknowledge_auto_drop TO 'true'", None, None);
+
+            client.select(
+                "CREATE TABLE series(time timestamptz, value double precision)",
+                None,
+                None
+            );
+            client.select(
+                "INSERT INTO series \
+                    VALUES \
+                    ('2020-01-04 UTC'::TIMESTAMPTZ, 25.0), \
+                    ('2020-01-01 UTC'::TIMESTAMPTZ, 10.0), \
+                    ('2020-01-03 UTC'::TIMESTAMPTZ, 20.0), \
+                    ('2020-01-02 UTC'::TIMESTAMPTZ, 15.0), \
+                    ('2020-01-05 UTC'::TIMESTAMPTZ, 30.0)",
+                None,
+                None
+            );
+
+            let val = client.select(
+                "SELECT (timevector(time, value))::TEXT FROM series",
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                (ts:\"2020-01-04 00:00:00+00\",val:25),\
+                (ts:\"2020-01-01 00:00:00+00\",val:10),\
+                (ts:\"2020-01-03 00:00:00+00\",val:20),\
+                (ts:\"2020-01-02 00:00:00+00\",val:15),\
+                (ts:\"2020-01-05 00:00:00+00\",val:30)\
+            ]");
+
+            let val = client.select(
+                "SELECT (timevector(time, value) -> filter($$ $time != '2020-01-05't and ($value = 10 or $value = 20) $$))::TEXT FROM series",
+                None,
+                None
+            )
+                .first()
+                .get_one::<String>();
+            assert_eq!(val.unwrap(), "[\
+                (ts:\"2020-01-01 00:00:00+00\",val:10),\
+                (ts:\"2020-01-03 00:00:00+00\",val:20)\
+            ]");
+        });
+    }
+}

--- a/extension/src/time_series/pipeline/lambda/executor.rs
+++ b/extension/src/time_series/pipeline/lambda/executor.rs
@@ -1,0 +1,334 @@
+
+use pgx::*;
+
+use super::*;
+
+pub struct ExpressionExecutor<'e> {
+    exprs: &'e Expression,
+    var_vals: Vec<Option<Value>>,
+}
+
+impl<'e> ExpressionExecutor<'e> {
+    pub fn new(exprs: &'e Expression) -> Self {
+        Self {
+            var_vals: vec![None; exprs.variables.len()],
+            exprs,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        for v in &mut self.var_vals {
+            *v = None
+        }
+    }
+
+    pub fn exec(&mut self, value: f64, time: i64) -> Value {
+        self.exec_expression(&self.exprs.expr, value, time)
+    }
+
+    fn exec_expression(&mut self, expr: &ExpressionSegment, value: f64, time: i64) -> Value {
+        use ExpressionSegment::*;
+        match expr {
+            ValueVar => Value::Double(value),
+            TimeVar => Value::Time(time),
+            DoubleConstant(f) => Value::Double(*f),
+            TimeConstant(t) => Value::Time(*t),
+            IntervalConstant(i) => Value::Interval(*i),
+
+            UserVar(i, _) => self.force_var(*i, value, time),
+
+            FunctionCall(function, args) =>
+                self.exec_function(function, args, value, time),
+
+            Unary(op, expr, ty) =>
+                self.exec_unary_op(*op, ty, expr, value, time),
+
+            Binary(op, left, right, ty) =>
+                self.exec_binary_op(*op, ty, left, right, value, time),
+
+            BuildTuple(exprs, _) =>
+                Value::Tuple(exprs.iter().map(|e| self.exec_expression(e, value, time)).collect()),
+        }
+    }
+
+    fn force_var(&mut self, i: usize, value: f64, time: i64) -> Value {
+        if let Some(value) = &self.var_vals[i] {
+            return value.clone()
+        }
+
+        let value = self.exec_expression(&self.exprs.variables[i], value, time);
+        self.var_vals[i] = Some(value.clone());
+        value
+    }
+
+    fn exec_function(
+        &mut self,
+        function: &Function,
+        args: &[ExpressionSegment],
+        value: f64,
+        time: i64,
+    ) -> Value {
+        use Function::*;
+        macro_rules! unary_function {
+            ($func:ident ( )) => {
+                {
+                    let then = self.exec_expression(&args[0], value, time).float();
+                    then.$func().into()
+                }
+            };
+        }
+        macro_rules! binary_function {
+            ($func:ident ( )) => {
+                {
+                    let args = &args[0..2];
+                    let a = self.exec_expression(&args[0], value, time).float();
+                    let b = self.exec_expression(&args[1], value, time).float();
+                    a.$func(b).into()
+                }
+            };
+        }
+        match function {
+            Abs => unary_function!(abs()),
+            Cbrt => unary_function!(cbrt()),
+            Ceil => unary_function!(ceil()),
+            Floor => unary_function!(floor()),
+            Ln => unary_function!(ln()),
+            Log10 => unary_function!(log10()),
+            Log => {
+                let base = self.exec_expression(&args[1], value, time).float();
+                let a = self.exec_expression(&args[0], value, time).float();
+                a.log(base).into()
+            },
+            Pi => std::f64::consts::PI.into(),
+            Round => unary_function!(round()),
+            Sign => unary_function!(signum()),
+            Sqrt => unary_function!(sqrt()),
+            Trunc => unary_function!(trunc()),
+            Acos => unary_function!(acos()),
+            Asin => unary_function!(asin()),
+            Atan => unary_function!(atan()),
+            Atan2 => binary_function!(atan2()),
+            Cos => unary_function!(cos()),
+            Sin => unary_function!(sin()),
+            Tan => unary_function!(tan()),
+            Sinh => unary_function!(sinh()),
+            Cosh => unary_function!(cosh()),
+            Tanh => unary_function!(tanh()),
+            Asinh => unary_function!(asinh()),
+            Acosh => unary_function!(acosh()),
+            Atanh => unary_function!(atanh()),
+        }
+    }
+
+    fn exec_unary_op(
+        &mut self,
+        op: UnaryOp,
+        ty: &Type,
+        expr: &ExpressionSegment,
+        value: f64,
+        time: i64
+    ) -> Value {
+        use UnaryOp::*;
+        use Type::*;
+        match op {
+            Not => {
+                let val = self.exec_expression(expr, value, time).bool();
+                (!val).into()
+            },
+            Negative => {
+                match ty {
+                    Double => {
+                        let val = self.exec_expression(expr, value, time).float();
+                        (-val).into()
+                    },
+                    // TODO interval?
+                    _ => unreachable!(),
+                }
+            },
+        }
+    }
+
+    fn exec_binary_op(
+        &mut self,
+        op: BinOp,
+        ty: &Type,
+        left: &ExpressionSegment,
+        right: &ExpressionSegment,
+        value: f64,
+        time: i64
+    ) -> Value {
+        use BinOp::*;
+        use Type::*;
+
+        // FIXME pgx wraps all functions in rust wrappers, which makes them
+        //       uncallable with DirectFunctionCall(). Is there a way to
+        //       export both?
+        // TODO This is fixed in a newer pgx version, should remove after upgrade
+        extern "C" {
+            fn interval_pl(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum;
+            fn interval_mi(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum;
+            fn interval_mul(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum;
+            fn interval_div(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum;
+
+            fn timestamptz_pl_interval(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum;
+            fn timestamptz_mi_interval(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum;
+        }
+
+        macro_rules! float_op {
+            (($left: ident, $right: ident) $calc: expr) => {
+                {
+                    let $left = self.exec_expression(left, value, time).float();
+                    let $right = self.exec_expression(right, value, time).float();
+                    ($calc).into()
+                }
+            };
+        }
+
+        macro_rules! interval_op {
+            (($left: ident, $right: ident) $calc: ident) => {
+                {
+                    let left = self.exec_expression(left, value, time).interval();
+                    let right = self.exec_expression(right, value, time).interval();
+
+                    let res: *mut pg_sys::Interval = unsafe {
+                        pg_sys::DirectFunctionCall2Coll(
+                            Some($calc),
+                            pg_sys::InvalidOid,
+                            left as _,
+                            right as _
+                        ) as _
+                    };
+                    assert!(!res.is_null());
+                    Value::Interval(res)
+                }
+            };
+        }
+
+        macro_rules! interval_float_op {
+            (($left: ident, $right: ident) $calc: ident) => {
+                {
+                    let left = self.exec_expression(left, value, time).interval();
+                    let right = self.exec_expression(right, value, time).float();
+
+                    let res: *mut pg_sys::Interval = unsafe {
+                        pg_sys::DirectFunctionCall2Coll(
+                            Some($calc),
+                            pg_sys::InvalidOid,
+                            left as _,
+                            right.into_datum().unwrap(),
+                        ) as _
+                    };
+                    assert!(!res.is_null());
+                    Value::Interval(res)
+                }
+            };
+        }
+
+        macro_rules! time_op {
+            (($left: ident, $right: ident) $calc: ident) => {
+                {
+                    let left = self.exec_expression(left, value, time).time();
+                    let right = self.exec_expression(right, value, time).interval();
+
+                    let res: i64 = unsafe {
+                        pg_sys::DirectFunctionCall2Coll(
+                            Some($calc),
+                            pg_sys::InvalidOid,
+                            left as _,
+                            right as _
+                        ) as _
+                    };
+
+                    Value::Time(res)
+                }
+            };
+        }
+
+        match op {
+            // arithmetic operators
+            Plus =>
+                match ty {
+                    Double => float_op!((left, right) left + right),
+                    Time => time_op!((left, right) timestamptz_pl_interval),
+                    Interval => interval_op!((left, right) interval_pl),
+                    _ => unreachable!(),
+                },
+
+            Minus =>
+                match ty {
+                    Double => float_op!((left, right) left - right),
+                    Time => time_op!((left, right) timestamptz_mi_interval),
+                    Interval => interval_op!((left, right) interval_mi),
+                    _ => unreachable!(),
+                },
+
+            Mul => match ty {
+                Double => float_op!((left, right) left * right),
+                Interval => interval_float_op!((left, right) interval_mul),
+                _ => unreachable!(),
+            },
+
+            Div => match ty {
+                Double => float_op!((left, right) left / right),
+                Interval => interval_float_op!((left, right) interval_div),
+                _ => unreachable!(),
+            }
+
+            Pow => float_op!((left, right) left.powf(right)),
+
+            // comparison operators
+            Eq => {
+                let left = self.exec_expression(left, value, time);
+                let right = self.exec_expression(right, value, time);
+                (left == right).into()
+            },
+
+            Neq => {
+                let left = self.exec_expression(left, value, time);
+                let right = self.exec_expression(right, value, time);
+                (left != right).into()
+            },
+
+            Lt => {
+                let left = self.exec_expression(left, value, time);
+                let right = self.exec_expression(right, value, time);
+                (left < right).into()
+            },
+
+            Gt => {
+                let left = self.exec_expression(left, value, time);
+                let right = self.exec_expression(right, value, time);
+                (left > right).into()
+            },
+
+            Le => {
+                let left = self.exec_expression(left, value, time);
+                let right = self.exec_expression(right, value, time);
+                (left <= right).into()
+            },
+
+            Ge => {
+                let left = self.exec_expression(left, value, time);
+                let right = self.exec_expression(right, value, time);
+                (left >= right).into()
+            },
+
+            // boolean operators
+            And => {
+                let left = self.exec_expression(left, value, time).bool();
+                if !left {
+                    return false.into()
+                }
+                self.exec_expression(right, value, time)
+            },
+
+            Or => {
+                let left = self.exec_expression(left, value, time).bool();
+                if left {
+                    return true.into()
+                }
+                self.exec_expression(right, value, time)
+            },
+        }
+    }
+}

--- a/extension/src/time_series/pipeline/lambda/lambda_expr.pest
+++ b/extension/src/time_series/pipeline/lambda/lambda_expr.pest
@@ -1,0 +1,47 @@
+calculation = _{ SOI ~ let_expr ~ EOI }
+let_expr = { ("let" ~ var ~ "=" ~ tuple ~ ";")* ~ tuple }
+tuple = { binops ~ ("," ~ binops)* }
+binops = { unary ~ (operation ~ unary)* }
+unary = _{ neg | not | term }
+neg = { "-" ~ unary }
+not = { ^"not" ~ unary }
+term = _{
+    val_var | time_var | var
+    | time | interval | num | function
+    | "(" ~ let_expr ~ ")"
+}
+function = { function_name ~ "(" ~ (binops ~ ("," ~ binops)*  ~ ","?)? ~ ")" }
+
+operation = _{
+    add | subtract | multiply | divide | power
+    | eq | neq | le | ge | lt | gt
+    | and | or
+}
+    add      = { "+" }
+    subtract = { "-" }
+    multiply = { "*" }
+    divide   = { "/" }
+    power    = { "^" }
+    eq       = { "=" }
+    neq      = { "!=" | "<>" }
+    lt       = { "<" }
+    le       = { "<=" }
+    gt       = { ">" }
+    ge       = { ">=" }
+    and      = { ^"and" }
+    or       = { ^"or" }
+
+num = @{ int ~ ("." ~ ASCII_DIGIT*)? ~ (^"e" ~ int)? }
+    int = { ("+" | "-")? ~ ASCII_DIGIT+ }
+
+time_var = @{ ^"$time" }
+val_var = @{ ^"$value" }
+
+time = @{ string ~ "t" }
+interval = @{ string ~ "i" }
+string = _{ "'" ~ (!"'" ~ ANY)* ~ "'" }
+
+var = @{ "$" ~ (ASCII_ALPHANUMERIC | "_")+ }
+function_name = @{ ASCII_ALPHA ~ ASCII_ALPHANUMERIC* }
+
+WHITESPACE = _{ " " | "\t" }

--- a/extension/src/time_series/pipeline/lambda/parser.rs
+++ b/extension/src/time_series/pipeline/lambda/parser.rs
@@ -1,0 +1,435 @@
+
+use std::{collections::HashMap, ffi::CString};
+
+use pgx::*;
+
+use super::*;
+
+use pest::{
+    Parser,
+    prec_climber::{PrecClimber, Operator, Assoc},
+    iterators::{
+        Pair,
+        Pairs,
+    },
+};
+
+use Rule::*;
+use ExpressionSegment::*;
+use UnaryOp::*;
+use Type::*;
+
+// Idealized expression grammar ignoring precedence
+// ```
+// Expression       :=  'let' Variable '=' Expression ';' Expression | BinaryExpression
+// BinaryExpression := PrefixExpression ({',', '+', '-', '*', ...}  BinaryExpression)
+// PrefixExpression := {'-', 'NOT'} ParenExpression
+// ParenExpression  := '(' Expression ')' | Variable | Literal
+// Variable         := $[a-bA-B_][a-bA-B0-9_]*
+// Literal          := <number> | '<string>'
+// ```
+// Josh - I believe this is unambiguous and LL(1), but we should check before
+//        stabilization
+// FIXME check the grammar
+
+#[derive(pest_derive::Parser)]
+#[grammar = "time_series/pipeline/lambda/lambda_expr.pest"] // relative to src
+pub struct ExpressionParser;
+
+pub fn parse_expression(input: &str) -> Expression {
+    let parsed = ExpressionParser::parse(calculation, input)
+        .unwrap_or_else(|e| panic!("{}", e));
+
+    let mut variables = Vec::new();
+    let expr = build_expression(parsed, &mut variables, &mut HashMap::new());
+    Expression { variables, expr, }
+}
+
+// main parsing function.
+fn build_expression<'a>(
+    parsed: Pairs<'a, Rule>,
+    var_expressions: &mut Vec<ExpressionSegment>,
+    known_vars: &mut HashMap<&'a str, (Type, usize)>,
+) -> ExpressionSegment {
+    // Everything except binary operations are handled by `parse_primary()`
+    // when we encounter a sequence of binary operations eg `<> + <> * <>`
+    // the `(Expression, op, Expression)` triple is passed to `build_binary_op()`
+    // in descending precedence order.
+    PREC_CLIMBER.climb(parsed,
+        |pair| parse_primary(pair, var_expressions, known_vars),
+        |left: ExpressionSegment, op: Pair<Rule>, right: ExpressionSegment| build_binary_op(op, left, right))
+}
+
+
+// handles everything except infix binary operators, which are handled by the
+// precedence climber and `build_binary_op()`
+fn parse_primary<'a>(
+    pair: Pair<'a, Rule>,
+    var_expressions: &mut Vec<ExpressionSegment>,
+    known_vars: &mut HashMap<&'a str, (Type, usize)>,
+) -> ExpressionSegment {
+    // HOW TO READ:
+    //   every rule (the left hand side of the `=` in the `.pest` file) has a
+    //   variant in the following `match` statement. When seeing a rule like
+    //   ```
+    //   foo = { bar ~ "baz" ~ qux }
+    //   ```
+    //   1. `pair.as_str()` will be the entire string that matched the rule.
+    //   2. `pair.into_iterator()` returns an iterator over the `Pair`s
+    //       representing the sub rules. In this case it'll return two, one for
+    //       `bar` and one for `qux`. These 'Pair's can be passed back to
+    //       `parse_primary()` to parse them into `Expression`s for further
+    //       handling.
+    match pair.as_rule() {
+        num => {
+            let val: f64 = pair.as_str().parse().unwrap();
+            DoubleConstant(val).into()
+        },
+
+        val_var => ValueVar.into(),
+        time_var => TimeVar.into(),
+
+        time => {
+            let s = pair.as_str();
+            let parsed_time = parse_timestamptz(&s[1..s.len()-2]);
+            TimeConstant(parsed_time).into()
+        },
+
+        interval => {
+            let s = pair.as_str();
+            let parsed_interval = parse_interval(&s[1..s.len()-2]);
+            IntervalConstant(parsed_interval).into()
+        },
+
+        var => {
+            let (ty, v) = known_vars.get(pair.as_str())
+                .unwrap_or_else(|| panic!("unknown variable: {}", pair.as_str()))
+                .clone();
+            UserVar(v, ty)
+        },
+
+        function => {
+            let mut pairs = pair.into_inner();
+            let func_name = pairs.next().unwrap();
+            let (num_args, func_id) = BUILTIN_FUNCTION.get(func_name.as_str())
+                .unwrap_or_else(|| panic!("unknown function: {}", func_name.as_str()))
+                .clone();
+
+            let args: Vec<_> = pairs.map(|p| parse_primary(p, var_expressions, known_vars))
+                .collect();
+            if args.len() != num_args {
+                panic!(
+                    "function `{}` expects {} arguments and received {}",
+                    func_name.as_str(),
+                    num_args,
+                    args.len(),
+                )
+            }
+
+            FunctionCall(func_id, args)
+        }
+
+        neg => {
+            let value = pair.into_inner().next().unwrap();
+            let value = parse_primary(value, var_expressions, known_vars);
+            if value.ty() != &Double {
+                panic!("can only apply `-` to a DOUBLE PRECISION")
+            }
+            Unary(Negative, value.into(), Double)
+        },
+
+        not => {
+            let value = pair.into_inner().next().unwrap();
+            let value = parse_primary(value, var_expressions, known_vars);
+            if value.ty() != &Bool {
+                panic!("can only apply NOT to a BOOLEAN")
+            }
+            Unary(Not, value.into(), Bool)
+        },
+
+        // pass the sequence of binary operation to the precedence_climber to handle
+        binops => build_expression(pair.into_inner(), var_expressions, known_vars),
+
+        let_expr => {
+            // let_expr has two forms
+            // `let <variable> = <expression>; <expression>` and `<expression>`
+            // if we have more than one sub-pair in our pairs then we know we're
+            // in the first state, otherwise we must be in the second.
+            let mut pairs = pair.into_inner();
+            let var_name_or_expr = pairs.next().unwrap();
+            let var_value = match pairs.next() {
+                None => return parse_primary(var_name_or_expr, var_expressions, known_vars),
+                Some(val) => val,
+
+            };
+            let remaining = pairs.next().unwrap();
+            assert!(pairs.next().is_none());
+
+            let var_value = parse_primary(var_value, var_expressions, known_vars);
+
+            let var_name = var_name_or_expr.as_str();
+            known_vars.entry(var_name)
+                .and_modify(|_| panic!("duplicate var {}", var_name))
+                .or_insert_with(|| (var_value.ty().clone(), var_expressions.len()));
+            var_expressions.push(var_value);
+
+            parse_primary(remaining, var_expressions, known_vars)
+        },
+
+        tuple => {
+            // the tuple rule effectively has two forms
+            // `<binops>` and `<binops> (, <binops>)+`
+            // it's only in the second case that we'll actually build something
+            // of a tuple type, in the former we'll just turn into the inner
+            // expression.
+            let mut pairs = pair.into_inner();
+            let first = pairs.next().unwrap();
+            let first_val = parse_primary(first, var_expressions, known_vars);
+            match pairs.next() {
+                None => first_val,
+                Some(pair) => {
+                    let mut vals = vec![first_val];
+                    let val = parse_primary(pair, var_expressions, known_vars);
+                    vals.push(val);
+                    for p in pairs {
+                        let val = parse_primary(p, var_expressions, known_vars);
+                        vals.push(val);
+                    }
+                    let ty = Tuple(vals.iter().map(|v| v.ty().clone()).collect());
+                    BuildTuple(vals, ty)
+                },
+
+            }
+        },
+
+        // operations marked with a `_` or that are below a `@` are never passed
+        // to us, so we can ignore them.
+        EOI | int | operation | string
+        | unary | term | function_name | WHITESPACE | calculation
+            => unreachable!("{} should be transparent", pair),
+
+        // infix operations should be passed to `build_binary_op()` by the
+        // precedence climber, so we should never see them here.
+        add | subtract | multiply | divide
+        | power | eq | neq | lt | le
+        | gt | ge | and | or
+            => unreachable!("{} should be handled by precedence climbing", pair),
+    }
+}
+
+fn build_binary_op(op: Pair<Rule>, left: ExpressionSegment, right: ExpressionSegment) -> ExpressionSegment {
+    use BinOp::*;
+    macro_rules! return_ty {
+        ($op:literal $(($l: pat, $r:pat) => $ty:expr),+ $(,)?) => {
+            match (left.ty(), right.ty()) {
+                $(($l, $r) => $ty,)+
+                // TODO the error should report the location
+                (l, r) => panic!(
+                    concat!("no operator `{:?} {op} {:?}` only ",
+                        $("`", stringify!($l), " {op} ", stringify!($r), "` ",)+
+                    ),
+                    l, r, op=$op),
+            }
+        };
+    }
+    match op.as_rule() {
+        add => {
+            let result_type = return_ty!("+"
+                (Double, Double) => Double,
+                (Time, Interval) => Time,
+                (Interval, Interval) => Interval,
+            );
+            Binary(Plus, left.into(), right.into(), result_type)
+        },
+
+        subtract => {
+            let result_type = return_ty!("-"
+                (Double, Double) => Double,
+                (Time, Interval) => Time,
+                (Interval, Interval) => Interval,
+            );
+            Binary(Minus, left.into(), right.into(), result_type)
+        },
+
+        multiply =>
+            match (left.ty(), right.ty()) {
+                (Double, Double) => Binary(Mul, left.into(), right.into(), Double),
+                (Interval, Double) => Binary(Mul, left.into(), right.into(), Interval),
+                // TODO right now BinOp(Mul, .., Interval) expects the interval on the left
+                //      and the double on the left. We could check in the executor which one
+                //      actually is, but it seems easier to just revers the value here if
+                //      they're in an unexpected order.
+                (Double, Interval) => Binary(Mul, right.into(), left.into(), Interval),
+                (l, r) => panic!("no operator `{:?} * {:?}` only `DOUBLE * DOUBLE` and `INTERVAL * FLOAT`", l, r)
+            },
+
+        divide => {
+            let result_type = return_ty!("/"
+                (Double, Double) => Double,
+                (Interval, Double) => Interval,
+            );
+            Binary(Div, left.into(), right.into(), result_type)
+        },
+
+        power => {
+            let result_type = return_ty!("^"
+                (Double, Double) => Double,
+            );
+            Binary(Pow, left.into(), right.into(), result_type)
+        },
+
+        eq => {
+            if left.ty() != right.ty() {
+                panic!("mismatched types for `=`: {:?}, {:?}", left.ty(), right.ty())
+            }
+            Binary(Eq, left.into(), right.into(), Bool)
+        },
+
+        neq => {
+            if left.ty() != right.ty() {
+                panic!("mismatched types for `!=`: {:?}, {:?}", left.ty(), right.ty())
+            }
+            Binary(Neq, left.into(), right.into(), Bool)
+        },
+
+        lt => {
+            if left.ty() != right.ty() {
+                panic!("mismatched types for `<`: {:?}, {:?}", left.ty(), right.ty())
+            }
+            Binary(Lt, left.into(), right.into(), Bool)
+        },
+
+        le => {
+            if left.ty() != right.ty() {
+                panic!("mismatched types for `<=`: {:?}, {:?}", left.ty(), right.ty())
+            }
+            Binary(Le, left.into(), right.into(), Bool)
+        },
+
+        gt => {
+            if left.ty() != right.ty() {
+                panic!("mismatched types for `>`: {:?}, {:?}", left.ty(), right.ty())
+            }
+            Binary(Gt, left.into(), right.into(), Bool)
+
+        },
+
+        ge => {
+            if left.ty() != right.ty() {
+                panic!("mismatched types for `>=`: {:?}, {:?}", left.ty(), right.ty())
+            }
+            Binary(Ge, left.into(), right.into(), Bool)
+
+        },
+
+        and => {
+            let result_type = return_ty!("and"
+                (Bool, Bool) => Bool,
+            );
+            Binary(And, left.into(), right.into(), result_type)
+        },
+
+        or => {
+            let result_type = return_ty!("or"
+                (Bool, Bool) => Bool,
+            );
+            Binary(Or, left.into(), right.into(), result_type)
+        },
+
+        _ => unreachable!(),
+    }
+}
+
+fn parse_timestamptz(val: &str) -> i64 {
+    // FIXME pgx wraps all functions in rust wrappers, which makes them
+    //       uncallable with DirectFunctionCall(). Is there a way to
+    //       export both?
+    extern "C" {
+        fn timestamptz_in(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum;
+    }
+
+    let cstr = CString::new(val).unwrap();
+    let parsed_time = unsafe {
+        pg_sys::DirectFunctionCall3Coll(
+            Some(timestamptz_in),
+            pg_sys::InvalidOid as _,
+            cstr.as_ptr() as _,
+            pg_sys::InvalidOid as _,
+            (-1i32) as _
+        )
+    };
+    parsed_time as _
+}
+
+fn parse_interval(val: &str) -> *mut pg_sys::Interval {
+    // FIXME pgx wraps all functions in rust wrappers, which makes them
+    //       uncallable with DirectFunctionCall(). Is there a way to
+    //       export both?
+    extern "C" {
+        fn interval_in(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum;
+    }
+
+    let cstr = CString::new(val).unwrap();
+    let parsed_interval = unsafe {
+        pg_sys::DirectFunctionCall3Coll(
+            Some(interval_in),
+            pg_sys::InvalidOid as _,
+            cstr.as_ptr() as _,
+            pg_sys::InvalidOid as _,
+            (-1i32) as _
+        )
+    };
+    parsed_interval as _
+}
+
+// This static determines the precedence of infix operators
+static PREC_CLIMBER: once_cell::sync::Lazy<PrecClimber<Rule>> = once_cell::sync::Lazy::new(|| {
+    use Assoc::*;
+
+    // operators according to their precedence, ordered in a vector
+    // from lowest to highest. Multiple operators with the same precedence are
+    // joined with `|`
+    PrecClimber::new(vec![
+        Operator::new(or, Left),
+        Operator::new(and, Left),
+        Operator::new(eq, Left) | Operator::new(neq, Left)
+        | Operator::new(lt, Left) | Operator::new(le, Left)
+        | Operator::new(gt, Left) | Operator::new(ge, Left),
+        Operator::new(add, Left) | Operator::new(subtract, Left),
+        Operator::new(multiply, Left) | Operator::new(divide, Left),
+        Operator::new(power, Right),
+    ])
+});
+
+// Table of builtin functions (all of them for now).
+// Maps function name to a tuple (num arguments, function identifier)
+static BUILTIN_FUNCTION: once_cell::sync::Lazy<HashMap<&str, (usize, Function)>> =  once_cell::sync::Lazy::new(|| {
+    use Function::*;
+    std::array::IntoIter::new([
+        ("abs",   (1, Abs)),
+        ("cbrt",  (1, Cbrt)),
+        ("ceil",  (1, Ceil)),
+        ("floor", (1, Floor)),
+        ("ln",    (1, Ln)),
+        ("log10", (1, Log10)),
+        ("log",   (2, Log)),
+        ("pi",    (0, Pi)),
+        ("round", (1, Round)),
+        ("sign",  (1, Sign)),
+        ("sqrt",  (1, Sqrt)),
+        ("trunc", (1, Trunc)),
+        ("acos",  (1, Acos)),
+        ("asin",  (1, Asin)),
+        ("atan",  (1, Atan)),
+        ("atan2", (2, Atan2)),
+        ("cos",   (1, Cos)),
+        ("sin",   (1, Sin)),
+        ("tan",   (1, Tan)),
+        ("sinh",  (1, Sinh)),
+        ("cosh",  (1, Cosh)),
+        ("tanh",  (1, Tanh)),
+        ("asinh", (1, Asinh)),
+        ("acosh", (1, Acosh)),
+        ("atanh", (1, Atanh)),
+    ]).collect()
+});


### PR DESCRIPTION
This PR adds an experimental lambda pipeline elements for `map` and `filter`. This element used like
```SQL
series -> map($$ ($time + '1 day'i, $value * 2) $$) -> filter($$ $time != '2020-01-01' and $value != 0 $$)
```
can be used to map arbitrary expression yielding either a `f64` or a `(TimestampTZ, f64)` pair over a timeseries, and filter timeseries based on an expression that returns TRUE if an element should be retained by the timeseries.

These elements are _very_ experimental, and if merged, would likely bake in experimental for a good while before they're ready for merge.

---

This PR is now in a reviewable state. It _could_ use a revalidation that the lifetime changes are correct.

<details><summary>old checklist</summary>
This PR is still incomplete as of yet, and there are a number of features which would ideally be added before merge:

- [x] `filter()` element.
- [x] order comparison operators: `<`, `>`, `<=`, `>=`.
- [x] mathematical functions such as `abs()` see [the postgres tables](https://www.postgresql.org/docs/12/functions-math.html#FUNCTIONS-MATH-FUNC-TABLEl).
- [x] prefix operators: `-`, `NOT`.
</details>