### PR TITLE
Walk dir in `post-install`'s `--dir`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,6 +1135,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 name = "post-install"
 version = "0.1.0"
 dependencies = [
+ "walkdir",
  "xshell",
 ]
 

--- a/tools/post-install/Cargo.toml
+++ b/tools/post-install/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2018"
 
 [dependencies]
 xshell = "0.1.14"
+walkdir = "2"


### PR DESCRIPTION
This commit updates `post-intall --dir` to walk the directory looking for the `.control` and `.so` files in order to find the correct directories. It turns out to be difficult to manually determine which
directory to pass to `--dir`, and the format after the `share`/`extension` might not be the same in every instance, so this should fix both problems.

bors r+