### PR TITLE
make `->` public

### DIFF
--- a/extension/sql/load-order.txt
+++ b/extension/sql/load-order.txt
@@ -22,8 +22,8 @@ time_series_pipeline_arithmetic.generated.sql
 time_series_pipeline_aggregation.generated.sql
 zz_triggers.generated.sql
 time_series_pipeline_expansion.generated.sql
+time_series_pipeline_fill_to.generated.sql
+time_series_pipeline_filter.generated.sql
 schema_test.generated.sql
 serialization_collations.generated.sql
 serialization_types.generated.sql
-time_series_pipeline_fill_to.generated.sql
-time_series_pipeline_filter.generated.sql

--- a/extension/src/time_series/pipeline/expansion.rs
+++ b/extension/src/time_series/pipeline/expansion.rs
@@ -251,7 +251,7 @@ mod tests {
                 .by_ordinal(1).unwrap()
                 .value::<String>().unwrap();
             assert_eq!(output.trim(), "Output: \
-                run_pipeline(\
+                arrow_run_pipeline(\
                     arrow_run_pipeline_then_materialize(\
                         timevector('2021-01-01 00:00:00+00'::timestamp with time zone, '0.1'::double precision), \
                         '(version:1,num_elements:2,elements:[\


### PR DESCRIPTION
This moves the remaining `->` operators to the public schema. This means they can be used like
```SQL
SELECT
    toolkit_experimental.timevector(time, measurement)
        -> toolkit_experimental.power(2)
        -> toolkit_experimental.ln()
        -> toolkit_experimental.round()
        -> toolkit_experimental.unnest()
```
Since all the elements are unstable, this will not affect our stability guarantees or checks.

bors merge