### PR TITLE
Lambda fixes

### DIFF
--- a/extension/src/time_series/pipeline/lambda.rs
+++ b/extension/src/time_series/pipeline/lambda.rs
@@ -780,6 +780,24 @@ mod tests {
                     r#" binop Plus Double: "Double(6.0)""#,
                 ],
             );
+
+            let rows: Vec<_> = trace_lambda!(
+                client,
+                "let $foo = -2;\nlet $bar = $foo * $foo;\n $bar * $bar"
+            );
+            assert_eq!(
+                &*rows,
+                [ // TODO try and fix parsing so than `-2` parses as a constant `-2`
+                    r#"          f64 const: "Double(2.0)""#,
+                    r#"uop Negative Double: "Double(-2.0)""#,
+                    r#" user var 0: Double: "Double(-2.0)""#,
+                    r#" user var 0: Double: "Double(-2.0)""#,
+                    r#"   binop Mul Double: "Double(4.0)""#,
+                    r#" user var 1: Double: "Double(4.0)""#,
+                    r#" user var 1: Double: "Double(4.0)""#,
+                    r#"   binop Mul Double: "Double(16.0)""#,
+                ],
+            );
         });
     }
 }

--- a/extension/src/time_series/pipeline/lambda/lambda_expr.pest
+++ b/extension/src/time_series/pipeline/lambda/lambda_expr.pest
@@ -44,4 +44,4 @@ string = _{ "'" ~ (!"'" ~ ANY)* ~ "'" }
 var = @{ "$" ~ (ASCII_ALPHANUMERIC | "_")+ }
 function_name = @{ ASCII_ALPHA ~ ASCII_ALPHANUMERIC* }
 
-WHITESPACE = _{ " " | "\t" }
+WHITESPACE = _{ " " | "\t" | NEWLINE }

--- a/extension/src/time_series/pipeline/lambda/parser.rs
+++ b/extension/src/time_series/pipeline/lambda/parser.rs
@@ -151,29 +151,27 @@ fn parse_primary<'a>(
         binops => build_expression(pair.into_inner(), var_expressions, known_vars),
 
         let_expr => {
-            // let_expr has two forms
-            // `let <variable> = <expression>; <expression>` and `<expression>`
-            // if we have more than one sub-pair in our pairs then we know we're
-            // in the first state, otherwise we must be in the second.
             let mut pairs = pair.into_inner();
-            let var_name_or_expr = pairs.next().unwrap();
-            let var_value = match pairs.next() {
-                None => return parse_primary(var_name_or_expr, var_expressions, known_vars),
-                Some(val) => val,
+            loop {
+                // let_expr has two forms
+                // `let <variable> = <expression>; <expression>` and `<expression>`
+                // if we have more than one sub-pair in our pairs then we know we're
+                // in the first state, otherwise we must be in the second.
+                let var_name_or_expr = pairs.next().unwrap();
+                let var_value = match pairs.next() {
+                    None => return parse_primary(var_name_or_expr, var_expressions, known_vars),
+                    Some(val) => val,
 
-            };
-            let remaining = pairs.next().unwrap();
-            assert!(pairs.next().is_none());
+                };
 
-            let var_value = parse_primary(var_value, var_expressions, known_vars);
+                let var_value = parse_primary(var_value, var_expressions, known_vars);
 
-            let var_name = var_name_or_expr.as_str();
-            known_vars.entry(var_name)
-                .and_modify(|_| panic!("duplicate var {}", var_name))
-                .or_insert_with(|| (var_value.ty().clone(), var_expressions.len()));
-            var_expressions.push(var_value);
-
-            parse_primary(remaining, var_expressions, known_vars)
+                let var_name = var_name_or_expr.as_str();
+                known_vars.entry(var_name)
+                    .and_modify(|_| panic!("duplicate var {}", var_name))
+                    .or_insert_with(|| (var_value.ty().clone(), var_expressions.len()));
+                var_expressions.push(var_value);
+            }
         },
 
         tuple => {


### PR DESCRIPTION
Two minor fixes to lambdas:
 1. Allow newlines within lambdas.
 2. Allow the parsing of multiple successive `let`s instead of stopping
    at the first.

Altogether this allows the parsing of expressions such as
```SQL
let $foo = -2;
let $bar = $foo * $foo;
$bar * $bar
```