### PR TITLE
Fix bug in timevector serialization

### DIFF
--- a/crates/flat_serialize/flat_serialize/src/lib.rs
+++ b/crates/flat_serialize/flat_serialize/src/lib.rs
@@ -428,8 +428,7 @@ where T: serde::Serialize + Clone + FlatSerializable<'i> {
         S: serde::Serializer {
         use serde::ser::SerializeSeq;
 
-        // TODO len should be computable
-        let mut s = serializer.serialize_seq(None)?;
+        let mut s = serializer.serialize_seq(Some(self.len()))?;
         for t in self.iter() {
             s.serialize_element(&t)?
         }


### PR DESCRIPTION
The size needs to be known ahead of time.