### PR TITLE
Fix potential memory leak and add size checks

### DIFF
--- a/extension/src/time_series.rs
+++ b/extension/src/time_series.rs
@@ -75,17 +75,9 @@ impl<'input> InOutFuncs for Timevector<'input> {
     {
         use crate::serialization::str_from_db_encoding;
 
-        // SAFETY our serde shims will allocate and leak copies of all
-        // the data, so the lifetimes of the borrows aren't actually
-        // relevant to the output lifetime
-        // TODO reduce allocation
-        let series: Vec<TSPoint> = unsafe {
-            unsafe fn extend_lifetime(s: &str) -> &'static str {
-                std::mem::transmute(s)
-            }
-            let input = extend_lifetime(str_from_db_encoding(input));
-            ron::from_str(input).unwrap()
-        };
+        // TODO reduce allocation?
+        let input = str_from_db_encoding(input);
+        let series: Vec<TSPoint> = ron::from_str(input).unwrap();
         unsafe {
             flatten! {
                 Timevector {

--- a/extension/src/type_builder.rs
+++ b/extension/src/type_builder.rs
@@ -262,16 +262,8 @@ macro_rules! ron_inout_funcs {
             {
                 use $crate::serialization::str_from_db_encoding;
 
-                // SAFETY our serde shims will allocate and leak copies of all
-                // the data, so the lifetimes of the borrows aren't actually
-                // relevant to the output lifetime
-                let val = unsafe {
-                    unsafe fn extend_lifetime(s: &str) -> &'static str {
-                        std::mem::transmute(s)
-                    }
-                    let input = extend_lifetime(str_from_db_encoding(input));
-                    ron::from_str(input).unwrap()
-                };
+                let input = str_from_db_encoding(input);
+                let val = ron::from_str(input).unwrap();
                 unsafe { Self(val, $crate::type_builder::CachedDatum::None).flatten() }
             }
         }


### PR DESCRIPTION
This commit fixes a potential memory leak in the serialize code that's a holdover from when we tried to allocate in CurrentMemoryContext. It also adds some size checks to ensure we error on output not input.

This commit should not be merged until @WireBaron's serialization tests are ready in order to ensure that we don't accidentally break backwards compatibility in our serialization format.