### PR TITLE
Update comment in control file

### DIFF
--- a/extension/timescaledb_toolkit.control
+++ b/extension/timescaledb_toolkit.control
@@ -1,4 +1,4 @@
-comment = 'timescaledb_toolkit'
+comment = 'Library of analytical hyperfunctions, time-series pipelining, and other SQL utilities'
 default_version = '1.4'
 relocatable = false
 superuser = false


### PR DESCRIPTION
The comment in the control file is shown as the extension description
inside postgres, so this patch replaces it with a longer description.