### PR TITLE
Add serialization tests

### DIFF
--- a/crates/hyperloglogplusplus/src/dense.rs
+++ b/crates/hyperloglogplusplus/src/dense.rs
@@ -6,7 +6,7 @@ use crate::hyperloglog_data::{
 use crate::{registers::Registers, Extractable};
 
 #[derive(Clone)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct Storage<'s> {
     pub registers: Registers<'s>,
     // TODO can be derived from block.len()

--- a/crates/hyperloglogplusplus/src/lib.rs
+++ b/crates/hyperloglogplusplus/src/lib.rs
@@ -14,14 +14,14 @@ mod hyperloglog_data;
 pub mod registers;
 pub mod sparse;
 
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq)]
 pub struct HyperLogLog<'s, T: ?Sized, B> {
     storage: HyperLogLogStorage<'s>,
     pub buildhasher: B,
     _pd: PhantomData<T>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq)]
 pub enum HyperLogLogStorage<'s> {
     Sparse(sparse::Storage<'s>),
     Dense(dense::Storage<'s>),
@@ -104,7 +104,7 @@ impl<'s, T, B> HyperLogLog<'s, T, B> {
         &self.storage
     }
 
-    fn merge_all(&mut self) {
+    pub fn merge_all(&mut self) {
         match &mut self.storage {
             HyperLogLogStorage::Sparse(s) => s.merge_buffers(),
             HyperLogLogStorage::Dense(_) => {},

--- a/crates/hyperloglogplusplus/src/registers.rs
+++ b/crates/hyperloglogplusplus/src/registers.rs
@@ -19,7 +19,7 @@ use std::{borrow::Cow, convert::TryInto, debug_assert};
 // and treat the block like a regular integer, using shifts to get the
 // values in and out
 #[derive(Clone)]
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, PartialEq)]
 pub struct Registers<'s>(Cow<'s, [u8]>);
 
 impl<'s> Registers<'s> {

--- a/crates/hyperloglogplusplus/src/sparse.rs
+++ b/crates/hyperloglogplusplus/src/sparse.rs
@@ -12,7 +12,7 @@ use self::varint::*;
 
 mod varint;
 
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq)]
 pub struct Storage<'s> {
     to_merge: HashSet<Encoded>,
     pub compressed: Compressed<'s>,

--- a/crates/hyperloglogplusplus/src/sparse/varint.rs
+++ b/crates/hyperloglogplusplus/src/sparse/varint.rs
@@ -12,7 +12,7 @@ pub fn decompression_iter<'a, 'b>(Compressed(bytes): &'a Compressed<'b>) -> impl
 }
 
 #[derive(Default)]
-#[derive(serde::Serialize, serde::Deserialize, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq)]
 pub struct Compressed<'c>(Cow<'c, [u8]>);
 
 impl<'c> Compressed<'c> {

--- a/crates/udd-sketch/src/lib.rs
+++ b/crates/udd-sketch/src/lib.rs
@@ -63,14 +63,14 @@ impl SketchHashKey {
 }
 
 // Entries in the SketchHashMap contain a count and the next valid index of the map.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct SketchHashEntry {
     count: u64,
     next: SketchHashKey,
 }
 
 // SketchHashMap is a special hash map of SketchHashKey->count that also keeps the equivalent of a linked list of the entries by increasing key value.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 struct SketchHashMap {
     map: HashMap<SketchHashKey, SketchHashEntry>,
     head: SketchHashKey,
@@ -184,7 +184,7 @@ impl SketchHashMap {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct UDDSketch {
     buckets: SketchHashMap,
     alpha: f64,

--- a/extension/src/aggregate_utils.rs
+++ b/extension/src/aggregate_utils.rs
@@ -20,9 +20,12 @@ pub unsafe fn in_aggregate_context<T, F: FnOnce() -> T>(
     crate::palloc::in_memory_context(mctx, f)
 }
 
-pub fn aggregate_mctx(fcinfo: pg_sys::FunctionCallInfo) -> Option<pg_sys::MemoryContext> {
+pub unsafe fn aggregate_mctx(fcinfo: pg_sys::FunctionCallInfo) -> Option<pg_sys::MemoryContext> {
+    if fcinfo.is_null() {
+        return Some(pg_sys::CurrentMemoryContext)
+    }
     let mut mctx = null_mut();
-    let is_aggregate = unsafe { pg_sys::AggCheckCallContext(fcinfo, &mut mctx) };
+    let is_aggregate = pg_sys::AggCheckCallContext(fcinfo, &mut mctx);
     if is_aggregate == 0 {
         return None;
     } else {


### PR DESCRIPTION
This change validates the byte format our structures serialize as so
that we can determine if these values ever change.