### PR TITLE
Add workflow to automatically build packages

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -1,0 +1,25 @@
+# Trigger package workflows on release tagging
+name: Build packages
+on:
+  push:
+    tags:
+    - "[0-9]+.[0-9]+.[0-9]+"
+jobs:
+  package:
+    env:
+      GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB_PACKAGE }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set env
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+
+      - name: Debian and Ubuntu packages
+        if: always()
+        run: |
+          gh workflow run toolkit-apt.yml -R timescale/release-build-scripts -r master -f version=${{ env.RELEASE_VERSION }} -f upload-artifacts=true
+
+      - name: RPM packages
+        if: always()
+        run: |
+          gh workflow run toolkit-rpm.yml -R timescale/release-build-scripts -r master -f version=${{ env.RELEASE_VERSION }} -f upload-artifacts=true
+


### PR DESCRIPTION
This patch adds a workflow that triggers the packaging process
for Debian, Ubuntu and RPM packages whenever a release is tagged.