### PR TITLE
Start testing on Postgres 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
   schedule:
     # we build at 8am UTC, 3am Eastern, midnight Pacific
     - cron:  '0 8 * * 1-4'
+  workflow_dispatch:
 
 jobs:
   test12:
@@ -121,3 +122,59 @@ jobs:
       run: |
         sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo pgx stop pg13 && /usr/local/cargo/bin/cargo pgx start pg13"
         sql-doctester -h localhost -s "CREATE EXTENSION timescaledb; CREATE EXTENSION timescaledb_toolkit; SET SESSION TIMEZONE TO 'UTC'" -p 28813 docs
+
+  test14:
+    name: Test PG 14
+    runs-on: ubuntu-latest
+    container:
+      image: timescaledev/rust-pgx:latest
+      env:
+        CARGO_INCREMENTAL: 0
+        CARGO_NET_RETRY: 10
+        CI: 1
+        RUST_BACKTRACE: short
+        RUSTUP_MAX_RETRIES: 10
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: chown Repository
+      run: chown -R postgres .
+
+    - name: Cache cargo directories
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: ${{ runner.os }}-cargo-build-target-pg14-3
+        restore-keys: |
+          ${{ runner.os }}-cargo-build-target-pg14-2
+          ${{ runner.os }}-cargo-pg14
+
+    - name: Cache cargo target dir
+      uses: actions/cache@v2
+      with:
+        path: target
+        key: ${{ runner.os }}-cargo-build-target-pg14-3
+        restore-keys: |
+          ${{ runner.os }}-cargo-build-target-pg14-2
+          ${{ runner.os }}-cargo-build-target-pg14
+
+    - name: Run PG 14 Tests
+      run: sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo test --workspace --features 'pg14 pg_test'"
+
+    - name: Run post-install tests
+      run: |
+        sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo pgx stop pg14 && /usr/local/cargo/bin/cargo pgx start pg14"
+        RUST_BACKTRACE=short cargo run --manifest-path ./tools/post-install/Cargo.toml /home/postgres/.pgx/14.0/pgx-install/bin/pg_config
+        cargo run --manifest-path ./tools/testrunner/Cargo.toml -- -h localhost -p 28813
+
+    # TODO These require TimescaleDB to support pg14
+    # - name: Run Doc Tests
+    #   run: |
+    #     sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo pgx stop pg14 && /usr/local/cargo/bin/cargo pgx start pg14"
+    #     sql-doctester -h localhost -s "CREATE EXTENSION timescaledb; CREATE EXTENSION timescaledb_toolkit; SET SESSION TIMEZONE TO 'UTC'" -p 28813 docs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,9 +827,9 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "heapless"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe65ef062f1af5b1b189842b0bc45bd671c38e1d22c6aa22e6ada03d01026d53"
+checksum = "9c1ad878e07405df82b695089e63d278244344f80e764074d0bdfe99b89460f3"
 dependencies = [
  "atomic-polyfill",
  "hash32",
@@ -1275,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afda51b125b4d6cd101c50f51cd09dbf968ad3a6d14d3533e53e474af7c058"
+checksum = "2fe3d7b5af6534a84b66109d175a9c944aa41744dab8e9385cb78f624f3a0050"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1303,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5e052bcc9c551130b30806321cbc97958ee04189de24602dce0b53a92a1dc85"
+checksum = "1d0794ddeee7ff991c81cc8a1daa6f9f3b486ede60a6b58f26a68e63d842ffd8"
 dependencies = [
  "pgx-utils",
  "proc-macro-crate",
@@ -1317,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afae320962dbef5ccd08906823b61d0c2f062b878e95843977b4f79fda0f2d17"
+checksum = "497951e5c77c486eb6fef8e2f13123d8632bd7598f722c24ea4288ed70b3d446"
 dependencies = [
  "bindgen",
  "build-deps",
@@ -1337,9 +1337,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2613daf5279634fbdbaac5e13845d31c65a8ba04a4c107303011da8a79d53ad3"
+checksum = "07bb7daa249b3b4a1c67201e739a0e676fff33c99fd2f2c16c09e815d00745a7"
 dependencies = [
  "colored",
  "lazy_static",
@@ -1357,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-utils"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98ed72f6ecc3ec6a8981c2c30ad4aa8a074cde3eaa2c13f9ed84c7462995f7a2"
+checksum = "22f7b0970c6257f3cd415956df476270bc1eca2e07072c1cc4f0fc2cf4f5494b"
 dependencies = [
  "clap",
  "color-eyre",
@@ -2160,9 +2160,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99beeb0daeac2bd1e86ac2c21caddecb244b39a093594da1a661ec2060c7aedd"
+checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
  "itoa",
  "libc",

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -16,8 +16,8 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14"]
 pg_test = ["approx"]
 
 [dependencies]
-pgx = "0.2.1"
-pgx-macros = "0.2.1"
+pgx = "0.2.4"
+pgx-macros = "0.2.4"
 encodings = {path="../crates/encodings"}
 flat_serialize = {path="../crates/flat_serialize/flat_serialize"}
 flat_serialize_macro = {path="../crates/flat_serialize/flat_serialize_macro"}
@@ -45,5 +45,5 @@ pest = "2.1"
 pest_derive = "2.1"
 
 [dev-dependencies]
-pgx-tests = "0.2.1"
+pgx-tests = "0.2.4"
 approx = "0.4.0"

--- a/extension/src/serialization/functions.rs
+++ b/extension/src/serialization/functions.rs
@@ -20,7 +20,6 @@ pub struct PgProcId(pub Oid);
 
 impl_flat_serializable!(PgProcId);
 
-use super::{pg_server_to_any, PG_UTF8};
 // FIXME upstream to pgx
 // TODO use this or regprocedureout()?
 extern "C" {
@@ -35,7 +34,7 @@ impl Serialize for PgProcId {
         unsafe {
             let qualified_name = format_procedure_qualified(self.0);
             let len = CStr::from_ptr(qualified_name).to_bytes().len();
-            let qualified_name = pg_server_to_any(qualified_name, len as _, PG_UTF8);
+            let qualified_name = pg_sys::pg_server_to_any(qualified_name, len as _, pg_sys::pg_enc_PG_UTF8 as _);
             let qualified_name = CStr::from_ptr(qualified_name);
             let qualified_name = qualified_name.to_str().unwrap();
             qualified_name.serialize(serializer)

--- a/extension/src/serialization/types.rs
+++ b/extension/src/serialization/types.rs
@@ -194,8 +194,6 @@ impl ShortTypIdSerializer {
 #[repr(transparent)]
 pub struct PgTypId(pub Oid);
 
-use super::{pg_server_to_any, pg_any_to_server, PG_UTF8};
-
 impl Serialize for PgTypId {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -216,13 +214,13 @@ impl Serialize for PgTypId {
             }
 
             let namespace_len = CStr::from_ptr(namespace).to_bytes().len();
-            let namespace = pg_server_to_any(namespace, namespace_len as _, PG_UTF8);
+            let namespace = pg_sys::pg_server_to_any(namespace, namespace_len as _, pg_sys::pg_enc_PG_UTF8 as _);
             let namespace = CStr::from_ptr(namespace);
             let namespace = namespace.to_str().unwrap();
 
             let type_name = (*type_tuple).typname.data.as_ptr();
             let type_name_len = CStr::from_ptr(type_name).to_bytes().len();
-            let type_name = pg_server_to_any(type_name, type_name_len as _, PG_UTF8);
+            let type_name = pg_sys::pg_server_to_any(type_name, type_name_len as _, pg_sys::pg_enc_PG_UTF8 as _);
             let type_name = CStr::from_ptr(type_name);
             let type_name = type_name.to_str().unwrap();
 
@@ -248,10 +246,10 @@ impl<'de> Deserialize<'de> for PgTypId {
         );
         let (namespace_len, name_len) = (namespace.to_bytes().len(), name.to_bytes().len());
         unsafe {
-            let namespace = pg_any_to_server(namespace.as_ptr(), namespace_len as _, PG_UTF8);
+            let namespace = pg_sys::pg_any_to_server(namespace.as_ptr(), namespace_len as _, pg_sys::pg_enc_PG_UTF8 as _);
             let namespace = CStr::from_ptr(namespace);
 
-            let name = pg_any_to_server(name.as_ptr(), name_len as _, PG_UTF8);
+            let name = pg_sys::pg_any_to_server(name.as_ptr(), name_len as _, pg_sys::pg_enc_PG_UTF8 as _);
             let name = CStr::from_ptr(name);
 
             let namespace_id = pg_sys::LookupExplicitNamespace(namespace.as_ptr(), true as _);

--- a/extension/src/time_series/pipeline.rs
+++ b/extension/src/time_series/pipeline.rs
@@ -230,14 +230,7 @@ pub(crate) unsafe fn pipeline_support_helper(
         return ptr::null_mut::<pg_sys::Expr>().internal()
     }
 
-    //FIXME add include/nodes/supportnodes.h to pgx headers
-    #[repr(C)]
-    struct SupportRequestSimplify {
-        ty: pg_sys::NodeTag,
-        root: *mut pg_sys::PlannerInfo,
-        fcall: *mut pg_sys::FuncExpr,
-    }
-    let req: *mut SupportRequestSimplify = input.cast();
+    let req: *mut pg_sys::SupportRequestSimplify = input.cast();
 
     let final_executor = (*req).fcall;
     let original_args = PgList::from_pg((*final_executor).args);


### PR DESCRIPTION
With pgx 2.4 we have [all the headers](https://github.com/zombodb/pgx/pull/289) we need to run the Toolkit on pg14! This commit starts running CI tests on it. This isn't _quite_ complete yet since TimescaleDB does not yet support pg14, so we can't run our continuous aggregate tests on it. Once that's done we should be able to just throw a switch and release.

Also removes some now-unneeded external definitions.