### PR TITLE
Add grant on experimental schema

### DIFF
--- a/extension/src/zz_triggers.rs
+++ b/extension/src/zz_triggers.rs
@@ -8,6 +8,7 @@ fn timescaledb_toolkit_probe() {
 }
 
 extension_sql!(r#"
+GRANT USAGE ON SCHEMA toolkit_experimental TO PUBLIC;
 CREATE OR REPLACE FUNCTION disallow_experimental_dependencies()
   RETURNS event_trigger
  LANGUAGE plpgsql


### PR DESCRIPTION
It's getting too difficult to maintain a separate patch just to get the experimental schema working on cloud, so this commit adds the GRANT to the main branch. Now, if users want to lock down the experimental schema they will need to do so after extension installation and update.