### PR TITLE
Update rust to 1.57

### DIFF
--- a/crates/flat_serialize/flat_serialize/src/lib.rs
+++ b/crates/flat_serialize/flat_serialize/src/lib.rs
@@ -6,9 +6,18 @@ pub enum WrapErr {
     InvalidTag(usize),
 }
 
+/// Trait marking that a type can be translated to and from a flat buffer
+/// without copying or allocation.
+///
+/// # Safety
 /// For a type to be `FlatSerializable` it must contain no pointers, have no
-/// interior padding, must have a `size >= alignmen` and must have
-/// `size % align = 0`. Use `#[derive(FlatSerializable)]` to implement this.
+/// interior padding, must have a `size >= alignment` and must have
+/// `size % align = 0`. In general this should not be implemented manually, and
+/// you should only use `#[derive(FlatSerializable)]` or `flat_serialize!{}` to
+/// implement this.
+/// **NOTE** we currently allow types with invalid bit patterns, such as `bool`
+/// to be `FlatSerializable` making this trait inappropriate to use on untrusted
+/// input.
 pub unsafe trait FlatSerializable<'input>: Sized + 'input {
     const MIN_LEN: usize;
     const REQUIRED_ALIGNMENT: usize;

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.56 AS pgx_builder
+FROM rust:1.57 AS pgx_builder
 
 RUN apt-get update \
     && apt-get install -y clang libclang1 sudo bash cmake \

--- a/extension/src/palloc.rs
+++ b/extension/src/palloc.rs
@@ -16,6 +16,14 @@ pub unsafe fn in_memory_context<T, F: FnOnce() -> T>(
 
 pub use pgx::Internal;
 
+/// Extension trait to translate postgres-understood `pgx::Internal` type into
+/// the well-typed pointer type `Option<Inner<T>>`.
+///
+/// # Safety
+///
+/// This trait should only ever be implemented for `pgx::Internal`
+/// There is an lifetime constraint on the returned pointer, though this is
+/// currently implicit.
 pub unsafe trait InternalAsValue {
     // unsafe fn value_or<T, F: FnOnce() -> T>(&mut self) -> &mut T;
     unsafe fn to_inner<T>(self) -> Option<Inner<T>>;
@@ -36,6 +44,11 @@ unsafe impl InternalAsValue for Internal {
     }
 }
 
+/// Extension trait to turn the typed pointers `Inner<...>` and
+/// `Option<Inner<...>>` into the postgres-understood `pgx::Internal` type.
+///
+/// # Safety
+/// The value input must live as long as postgres expects. TODO more info
 pub unsafe trait ToInternal {
     fn internal(self) -> Internal;
 }


### PR DESCRIPTION
This allows us to finally use real error messages in the flat_serialize
alignment checks!
Also requires cleaning up some new clippy lints.