### PR TITLE
aggregate builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aggregate_builder"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,6 +2207,7 @@ dependencies = [
 name = "timescaledb_toolkit"
 version = "0.3.0"
 dependencies = [
+ "aggregate_builder",
  "approx",
  "asap",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "crates/counter-agg",
     "crates/time-series",
     "crates/stats-agg",
+    "crates/aggregate_builder"
 ]
 
 [profile.dev]

--- a/crates/aggregate_builder/Cargo.toml
+++ b/crates/aggregate_builder/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "aggregate_builder"
+version = "0.1.0"
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = {version="1.0", features=["extra-traits", "visit", "visit-mut", "full"]}
+quote = "1.0"
+proc-macro2 = "1.0"

--- a/crates/aggregate_builder/Readme.md
+++ b/crates/aggregate_builder/Readme.md
@@ -1,0 +1,82 @@
+# Aggregate Builder #
+
+Library for building Postgres [aggregate functions](https://www.postgresql.org/docs/current/xaggr.html)
+that imitates
+[`CREATE AGGREGATE`](https://www.postgresql.org/docs/current/sql-createaggregate.html).
+
+## Syntax ##
+
+Current syntax looks something like like
+
+```rust
+#[aggregate] impl aggregate_name {
+    type State = InternalTransitionType;
+
+    fn transition(
+        state: Option<Inner<State>>,
+        #[sql_type("sql_type")] argument: RustType, // can have an arbitrary number of args
+    ) -> Option<Inner<State>> {
+        // transition function function body goes here
+    }
+
+    fn finally(state: Option<Inner<State>>) -> Option<ResultType> {
+        // final function function body goes here
+    }
+
+    // the remaining items are optional
+
+    // parallel-safety marker if desireable
+    const PARALLEL_SAFE: bool = true;
+
+    fn serialize(state: Inner<State>) -> bytea {
+        // serialize function body goes here
+    }
+
+    fn deserialize(bytes: bytea) -> Inner<State> {
+        // deserialize function body goes here
+    }
+
+    fn combine(state1: Option<Inner<State>>, state2: Option<Inner<State>>) -> Option<Inner<State>> {
+        // combine function body goes here
+    }
+}
+```
+
+All items except for `type State`, `fn transition()`, and `fn finally()` are
+optional. The SQL for the aggregate and its functions will be created
+automatically, and any necessary memory context switching is handled
+automatically for most cases¹.
+
+¹It will switch to the aggregate memory context before calling the transition
+function body and the combine function body. Looking through `array_agg()`'s
+code this seems to be the correct places to do so. Note that if you want to
+allocate in the aggregate memory context in the final function other work may
+be needed.
+
+## Example ##
+
+Below is a complete example of an `arbitrary()` aggregate that returns one of
+the aggregated values.
+
+```rust
+#[aggregate] impl arbitrary {
+    type State = String;
+
+    fn transition(
+        state: Option<Inner<State>>,
+        #[sql_type("text")] value: String,
+    ) -> Option<Inner<State>> {
+        match state {
+            Some(value) => Some(value),
+            None => Some(value.into()),
+        }
+    }
+
+    fn finally(mut state: Option<Inner<State>>) -> Option<String> {
+        match &mut state {
+            None => None,
+            Some(state) => Some(state.clone()),
+        }
+    }
+}
+```

--- a/crates/aggregate_builder/Readme.md
+++ b/crates/aggregate_builder/Readme.md
@@ -13,9 +13,9 @@ Current syntax looks something like like
     type State = InternalTransitionType;
 
     fn transition(
-        state: Option<Inner<State>>,
+        state: Option<State>,
         #[sql_type("sql_type")] argument: RustType, // can have an arbitrary number of args
-    ) -> Option<Inner<State>> {
+    ) -> Option<State> {
         // transition function function body goes here
     }
 
@@ -32,11 +32,11 @@ Current syntax looks something like like
         // serialize function body goes here
     }
 
-    fn deserialize(bytes: bytea) -> Inner<State> {
+    fn deserialize(bytes: bytea) -> State {
         // deserialize function body goes here
     }
 
-    fn combine(state1: Option<&State>, state2: Option<&State>) -> Option<Inner<State>> {
+    fn combine(state1: Option<&State>, state2: Option<&State>) -> Option<State> {
         // combine function body goes here
     }
 }
@@ -55,28 +55,204 @@ be needed.
 
 ## Example ##
 
-Below is a complete example of an `arbitrary()` aggregate that returns one of
+Below is a complete example of an `anything()` aggregate that returns one of
 the aggregated values.
 
 ```rust
-#[aggregate] impl arbitrary {
+#[aggregate] impl anything {
     type State = String;
 
     fn transition(
-        state: Option<Inner<State>>,
+        state: Option<State>,
         #[sql_type("text")] value: String,
-    ) -> Option<Inner<State>> {
-        match state {
-            Some(value) => Some(value),
-            None => Some(value.into()),
-        }
+    ) -> Option<State> {
+        state.or(Some(value))
     }
 
-    fn finally(mut state: Option<&State>) -> Option<String> {
-        match &mut state {
-            None => None,
-            Some(state) => Some(state.clone()),
+    fn finally(state: Option<&State>) -> Option<String> {
+        state.as_deref().cloned()
+    }
+}
+```
+
+## Expansion ##
+
+Ignoring some supplementary type checking we add to improve error messages, the
+macro expands aggregate definitions to rust code something like the following
+(explanations as comments in-line)
+```rust
+// we nest things within a module to mimic the namespacing of an `impl` block
+pub mod aggregate_name {
+    // glob import to further act like an `impl`
+    use super::*;
+
+    pub type State = String;
+
+    // PARALLEL_SAFE constant in case someone wants to use it
+    // unlikely to be actually used in practice
+    #[allow(dead_code)]
+    pub const PARALLEL_SAFE: bool = true;
+
+    #[pgx::pg_extern(immutable, parallel_safe)]
+    pub fn aggregate_name_transition_fn_outer(
+        __inner: pgx::Internal,
+        value: RustType,
+        __fcinfo: pg_sys::FunctionCallInfo,
+    ) -> Internal {
+        use crate::palloc::{Inner, InternalAsValue, ToInternal};
+        unsafe {
+            // Translate from the SQL type to the rust one
+            // we actually store an `Option<State>` rather than a `State`.
+            let mut __inner: Option<Inner<Option<State>>> = __inner.to_inner();
+            // We steal the state out from under the pointer leaving `None` in
+            // its place. This means that if the inner transition function
+            // panics the inner transition function will free `State` while the
+            // teardown hook in the aggregate memory context will only free inner
+            let inner: Option<State> = match &mut __inner {
+                None => None,
+                Some(inner) => Option::take(&mut **inner),
+            };
+            let state: Option<State> = inner;
+            // Switch to the aggregate memory context. This ensures that the
+            // transition state lives for as long as the aggregate, and that if
+            // we allocate from Postgres within the inner transition function
+            // those too will stay around.
+            crate::aggregate_utils::in_aggregate_context(__fcinfo, || {
+                // call the inner transition function
+                let result = transition(state, value);
+
+                // return the state to postgres, if we have a pointer just store
+                // in that, if not allocate one only if needed.
+                let state: Option<State> = result;
+                __inner = match (__inner, state) {
+                    (None, None) => None,
+                    (None, state @ Some(..)) => Some(state.into()),
+                    (Some(mut inner), state) => {
+                        *inner = state;
+                        Some(inner)
+                    }
+                };
+                __inner.internal()
+            })
         }
     }
+    pub fn transition(state: Option<State>, value: String) -> Option<State> {
+        // elided
+    }
+
+    #[pgx::pg_extern(immutable, parallel_safe)]
+    pub fn aggregate_name_finally_fn_outer(
+        __internal: pgx::Internal,
+        __fcinfo: pg_sys::FunctionCallInfo,
+    ) -> Option<String> {
+        use crate::palloc::InternalAsValue;
+        unsafe {
+            // Convert to the rust transition type, see the comment in the
+            // transition function for why we store an `Option<State>`
+            let mut input: Option<Inner<Option<State>>> = __internal.to_inner();
+            let input: Option<&mut State> = input.as_deref_mut()
+                .map(|i| i.as_mut())
+                .flatten();
+            // We pass in an `Option<&mut State>`; `Option<>` because the
+            // transition state might not have been initialized yet;
+            // `&mut State` since while the final function has unique access to
+            // the transition function it must leave it a valid state when it's
+            // finished
+            let state: Option<&mut State> = input;
+            finally(state)
+        }
+    }
+    pub fn finally(state: Option<&mut State>) -> Option<String> {
+        // elided
+    }
+
+    #[pgx::pg_extern(strict, immutable, parallel_safe, schema = "toolkit_experimental")]
+    pub fn aggregate_name_serialize_fn_outer(__internal: pgx::Internal) -> bytea {
+        use crate::palloc::{Inner, InternalAsValue};
+        // Convert to the rust transition type, see the comment in the
+        // transition function for why we store an `Option<State>`
+        let input: Option<Inner<Option<State>>> = unsafe { __internal.to_inner() };
+        let mut input: Inner<Option<State>> = input.unwrap();
+        // We pass by-reference for the same reason as the final function.
+        // Note that _technically_ you should not mutate in the serialize,
+        // function though there are cases you can get away with it when using
+        // an `internal` transition type.
+        let input: &mut State = input.as_mut().unwrap();
+        let state: &State = input;
+        serialize(state)
+    }
+    pub fn serialize(state: &State) -> bytea {
+        // elided
+    }
+
+    #[pgx::pg_extern(strict, immutable, parallel_safe, schema = "toolkit_experimental")]
+    pub fn aggregate_name_deserialize_fn_outer(
+        bytes: crate::raw::bytea,
+        _internal: Internal,
+    ) -> Internal {
+        use crate::palloc::ToInternal;
+        let result = deserialize(bytes);
+        let state: State = result;
+        // Convert to the rust transition type, see the comment in the
+        // transition function for why we store an `Option<State>`.
+        // We deliberately don't switch to the aggregate transition context
+        // because the postgres aggregates do not do so.
+        let state: Inner<Option<State>> = Some(state).into();
+        unsafe { Some(state).internal() }
+    }
+    pub fn deserialize(bytes: crate::raw::bytea) -> State {
+        // elided
+    }
+
+    #[pgx::pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
+    pub fn aggregate_name_combine_fn_outer(
+        a: Internal,
+        b: Internal,
+        __fcinfo: pg_sys::FunctionCallInfo,
+    ) -> Internal {
+        use crate::palloc::{Inner, InternalAsValue, ToInternal};
+        unsafe {
+            // Switch to the aggregate memory context. This ensures that the
+            // transition state lives for as long as the aggregate, and that if
+            // we allocate from Postgres within the inner transition function
+            // those too will stay around.
+            crate::aggregate_utils::in_aggregate_context(__fcinfo, || {
+                let result = combine(a.to_inner().as_deref(), b.to_inner().as_deref());
+                let state: Option<State> = result;
+                let state = match state {
+                    None => None,
+                    state @ Some(..) => {
+                        let state: Inner<Option<State>> = state.into();
+                        Some(state)
+                    }
+                };
+                state.internal()
+            })
+        }
+    }
+    pub fn combine(a: Option<&State>, b: Option<&State>) -> Option<State> {
+        // elided
+    }
+
+    // SQL generated for the aggregate
+    pgx::extension_sql!("\n\
+        CREATE AGGREGATE toolkit_experimental.aggregate_name (value RustType) (\n\
+            stype = internal,\n\
+            sfunc = toolkit_experimental.aggregate_name_transition_fn_outer,\n\
+            finalfunc = toolkit_experimental.aggregate_name_finally_fn_outer,\n\
+            parallel = safe,\n
+            serialfunc = toolkit_experimental.aggregate_name_serialize_fn_outer,\n\
+            deserialfunc = toolkit_experimental.aggregate_name_deserialize_fn_outer,\n\
+            combinefunc = toolkit_experimental.aggregate_name_combine_fn_outer\n\
+        );\n",
+        name = "aggregate_name_extension_sql",
+        requires = [
+            aggregate_name_transition_fn_outer,
+            aggregate_name_finally_fn_outer,
+            aggregate_name_serialize_fn_outer,
+            aggregate_name_deserialize_fn_outer,
+            aggregate_name_combine_fn_outer,
+        ],
+    );
 }
 ```

--- a/crates/aggregate_builder/Readme.md
+++ b/crates/aggregate_builder/Readme.md
@@ -19,7 +19,7 @@ Current syntax looks something like like
         // transition function function body goes here
     }
 
-    fn finally(state: Option<Inner<State>>) -> Option<ResultType> {
+    fn finally(state: Option<&mut State>) -> Option<ResultType> {
         // final function function body goes here
     }
 
@@ -28,7 +28,7 @@ Current syntax looks something like like
     // parallel-safety marker if desireable
     const PARALLEL_SAFE: bool = true;
 
-    fn serialize(state: Inner<State>) -> bytea {
+    fn serialize(state: &State) -> bytea {
         // serialize function body goes here
     }
 
@@ -36,7 +36,7 @@ Current syntax looks something like like
         // deserialize function body goes here
     }
 
-    fn combine(state1: Option<Inner<State>>, state2: Option<Inner<State>>) -> Option<Inner<State>> {
+    fn combine(state1: Option<&State>, state2: Option<&State>) -> Option<Inner<State>> {
         // combine function body goes here
     }
 }
@@ -72,7 +72,7 @@ the aggregated values.
         }
     }
 
-    fn finally(mut state: Option<Inner<State>>) -> Option<String> {
+    fn finally(mut state: Option<&State>) -> Option<String> {
         match &mut state {
             None => None,
             Some(state) => Some(state.clone()),

--- a/crates/aggregate_builder/src/lib.rs
+++ b/crates/aggregate_builder/src/lib.rs
@@ -1,0 +1,749 @@
+
+use std::borrow::Cow;
+
+use proc_macro::{TokenStream};
+
+use proc_macro2::{Span, TokenStream as TokenStream2};
+
+use quote::{quote, quote_spanned};
+
+use syn::{Token, parse::{Parse, ParseStream}, parse_macro_input, punctuated::Punctuated, spanned::Spanned, token::Comma, parse_quote};
+
+#[proc_macro_attribute]
+pub fn aggregate(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    // Parse the input tokens into a syntax tree
+    let input = parse_macro_input!(item as Aggregate);
+    let expanded = expand(input);
+    if cfg!(feature = "print-generated") {
+        println!("{}", expanded.to_string());
+    }
+    expanded.into()
+}
+
+// like ItemImpl except that we allow `name: Type "SqlType"` for `fn transition`
+struct Aggregate {
+    schema: Option<syn::Ident>,
+    name: syn::Ident,
+
+    state_ty: AggregateTy,
+
+    parallel_safe: Option<syn::LitBool>,
+
+    transition_fn: AggregateFn,
+    final_fn: AggregateFn,
+
+    serialize_fn: Option<AggregateFn>,
+    deserialize_fn: Option<AggregateFn>,
+    combine_fn: Option<AggregateFn>,
+}
+
+enum AggregateItem {
+    State(AggregateTy),
+    Fn(AggregateFn),
+    ParallelSafe(AggregateParallelSafe),
+}
+
+struct AggregateTy {
+    ident: syn::Ident,
+    ty: Box<syn::Type>,
+}
+
+struct AggregateParallelSafe {
+    value: syn::LitBool,
+}
+
+struct AggregateFn {
+    ident: syn::Ident,
+    sql_name: Option<syn::LitStr>,
+    parens: syn::token::Paren,
+    args: Punctuated<AggregateArg, Comma>,
+    ret: syn::ReturnType,
+    body: syn::Block,
+}
+
+struct AggregateArg {
+    rust: syn::PatType,
+    sql: Option<syn::LitStr>,
+}
+
+macro_rules! error {
+    ($span: expr, $fmt: literal, $($arg:expr),* $(,)?) => {
+        return Err(syn::Error::new($span, format!($fmt, $($arg),*)))
+    };
+    ($span: expr, $msg: literal) => {
+        return Err(syn::Error::new($span, $msg))
+    };
+}
+
+macro_rules! check_duplicate {
+    ($val: expr, $span:expr, $name: expr) => {
+        if $val.is_some() {
+            error!($span, "duplicate {}")
+        }
+    };
+}
+
+impl Parse for Aggregate {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let _: Token![impl] = input.parse()?;
+
+        let first_path_segment = input.parse()?;
+        let (schema, name): (_, syn::Ident) =
+            if input.peek(Token![::]) {
+                let _: Token![::] = input.parse()?;
+                (Some(first_path_segment), input.parse()?)
+            } else {
+                (None, first_path_segment)
+            };
+
+        let body;
+        let _brace_token = syn::braced!(body in input);
+        let mut state_ty = None;
+
+        let mut parallel_safe = None;
+
+        let mut fns: Vec<AggregateFn> = vec![];
+        while !body.is_empty() {
+            use AggregateItem::*;
+            let item = body.parse()?;
+            match item {
+                State(ty) => {
+                    if ty.ident != "State" {
+                        error!(ty.ident.span(), "unexpected `type {}`, expected `State`", ty.ident)
+                    }
+                    if state_ty.is_some() {
+                        error!(ty.ident.span(), "duplicate `type State`")
+                    }
+                    state_ty = Some(ty);
+                },
+                ParallelSafe(safe) => parallel_safe = Some(safe.value),
+                Fn(f) => {
+                    fns.push(f);
+                },
+            }
+        }
+
+        let mut transition_fn = None;
+        let mut final_fn = None;
+        let mut serialize_fn = None;
+        let mut deserialize_fn = None;
+        let mut combine_fn = None;
+        for f in fns {
+            if f.ident == "transition" {
+                check_duplicate!(transition_fn, f.ident.span(), "`fn transition`");
+                if f.args.is_empty() {
+                    error!(f.parens.span, "transition function must have at least one argument")
+                }
+                for arg in f.args.iter().skip(1) {
+                    if arg.sql.is_none() {
+                        error!(arg.rust.span(), "missing SQL type")
+                    }
+                }
+                transition_fn = Some(f);
+            } else if f.ident == "finally" {
+                check_duplicate!(final_fn, f.ident.span(), "`fn finally`");
+                if f.args.len() != 1 {
+                    error!(f.parens.span, "final function must have at one argument of type `Option<Inner<State>>`")
+                }
+                if f.args[0].sql.is_some() {
+                    error!(f.args[0].sql.span(), "should not have SQL type, will be inferred")
+                }
+                final_fn = Some(f);
+            } else if f.ident == "serialize" {
+                check_duplicate!(serialize_fn, f.ident.span(), "`fn serialize`");
+                if f.args.len() != 1 {
+                    error!(f.parens.span, "serialize function must have at one argument of type `Inner<State>`")
+                }
+                if f.args[0].sql.is_some() {
+                    error!(f.args[0].sql.span(), "should not have SQL type, will be inferred")
+                }
+                serialize_fn = Some(f);
+            } else if f.ident == "deserialize" {
+                check_duplicate!(deserialize_fn, f.ident.span(), "`fn deserialize`");
+                if f.args.len() != 1 {
+                    error!(f.parens.span, "deserialize function must have at one argument of type `bytea`")
+                }
+                if f.args[0].sql.is_some() {
+                    error!(f.args[0].sql.span(), "should not have SQL type, will be inferred")
+                }
+                deserialize_fn = Some(f);
+            } else if f.ident == "combine" {
+                check_duplicate!(combine_fn, f.ident.span(), "`fn combine`");
+                if f.args.len() != 2 {
+                    error!(f.parens.span, "deserialize function must have at one argument of type `Option<Inner<State>>`")
+                }
+                for arg in &f.args {
+                    if arg.sql.is_some() {
+                        error!(arg.sql.span(), "should not have SQL type, will be inferred")
+                    }
+                }
+                combine_fn = Some(f)
+            } else {
+                error!(
+                    f.ident.span(),
+                    "unexpected `fn {}`, expected one of `transition`, `final`, `serialize`, or `deserialize`",
+                    f.ident
+                )
+            }
+        }
+
+
+        let state_ty = match state_ty  {
+            Some(state_ty) => state_ty,
+            None => error!(name.span(), "missing `type State = ...;`"),
+        };
+
+        let transition_fn = match transition_fn  {
+            Some(transition_fn) => transition_fn,
+            None => error!(name.span(), "missing `fn transition`"),
+        };
+
+        let final_fn = match final_fn  {
+            Some(final_fn) => final_fn,
+            None => error!(name.span(), "missing `fn final`"),
+        };
+
+        Ok(Aggregate {
+            schema,
+            name,
+            state_ty,
+            parallel_safe,
+            transition_fn,
+            final_fn,
+            serialize_fn,
+            deserialize_fn,
+            combine_fn,
+        })
+    }
+}
+
+impl Parse for AggregateItem {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let ahead = input.fork();
+        let _ = ahead.call(syn::Attribute::parse_outer)?;
+        let lookahead = ahead.lookahead1();
+        if lookahead.peek(Token![fn]) {
+            input.parse().map(AggregateItem::Fn)
+        } else if lookahead.peek(Token![type]) {
+            input.parse().map(AggregateItem::State)
+        } else if lookahead.peek(Token![const]) {
+            input.parse().map(AggregateItem::ParallelSafe)
+        } else {
+            Err(lookahead.error())
+        }
+    }
+}
+
+impl Parse for AggregateTy {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let _: Token![type] = input.parse()?;
+        let ident = input.parse()?;
+        let _: Token![=] = input.parse()?;
+        let ty = Box::new(input.parse()?);
+        let _: Token![;] = input.parse()?;
+        Ok(Self { ident, ty })
+    }
+}
+
+impl Parse for AggregateParallelSafe {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let _: Token![const] = input.parse()?;
+        let name: syn::Ident = input.parse()?;
+        if name != "PARALLEL_SAFE" {
+            error!(name.span(), "unexpected const `{}` expected `PARALLEL_SAFE`", name)
+        }
+        let _: Token![:] = input.parse()?;
+        let ty: syn::Ident = input.parse()?;
+        if ty != "bool" {
+            error!(ty.span(), "unexpected type `{}` expected `bool`", ty)
+        }
+        let _: Token![=] = input.parse()?;
+        let value = input.parse()?;
+        let _: Token![;] = input.parse()?;
+        Ok(Self { value })
+    }
+}
+
+impl Parse for AggregateFn {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut attributes = input.call(syn::Attribute::parse_outer)?;
+        let _: Token![fn] = input.parse()?;
+        let ident = input.parse()?;
+
+        let contents;
+        let parens = syn::parenthesized!(contents in input);
+
+        let mut args = Punctuated::new();
+        while !contents.is_empty() {
+            let arg = contents.parse()?;
+            args.push(arg);
+            if contents.is_empty() {
+                break
+            }
+            let comma: Token![,] = contents.parse()?;
+            args.push_punct(comma);
+        };
+
+        let ret = input.parse()?;
+        let body = input.parse()?;
+
+        let expected_path = parse_quote!(sql_name);
+        let sql_name = match take_attr(&mut attributes, &expected_path) {
+            None => None,
+            Some(attribute) => attribute.parse_args()?
+        };
+        if !attributes.is_empty() {
+            error!(attributes[0].span(), "unexpected attribute")
+        }
+        Ok(Self {
+            ident,
+            sql_name,
+            parens,
+            args,
+            ret,
+            body,
+        })
+    }
+}
+
+impl Parse for AggregateArg {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let arg: syn::FnArg = input.parse()?;
+        let mut rust = match arg {
+            syn::FnArg::Typed(pat) => pat,
+            _ => error!(arg.span(), "`self` is not a valid aggregate argument"),
+        };
+        let sql = {
+            let expected_path = parse_quote!(sql_type);
+            let attribute = take_attr(&mut rust.attrs, &expected_path);
+            match attribute {
+                None => None,
+                Some(attribute) => attribute.parse_args()?
+            }
+        };
+        Ok(Self {
+            rust,
+            sql,
+        })
+    }
+}
+
+fn take_attr(attrs: &mut Vec<syn::Attribute>, path: &syn::Path)
+-> Option<syn::Attribute> {
+    let idx = attrs.iter().enumerate().find(|(_, a)| &a.path == path);
+    match idx {
+        None => None,
+        Some((idx, _)) => {
+            let attribute = attrs.remove(idx);
+            Some(attribute)
+        }
+    }
+}
+
+//
+//
+//
+//
+
+fn expand(agg: Aggregate) -> TokenStream2 {
+    use std::fmt::Write;
+    let Aggregate {
+        schema,
+        name,
+        state_ty,
+        parallel_safe,
+        transition_fn,
+        final_fn,
+        serialize_fn,
+        deserialize_fn,
+        combine_fn,
+    } = agg;
+
+    let state_ty = state_ty.ty;
+
+    let transition_fns = transition_fn.transition_fn_tokens(&schema, &name);
+    let final_fns = final_fn.final_fn_tokens(&schema, &name);
+
+    let mut extension_sql_reqs = vec![
+        transition_fn.outer_ident(&name),
+        final_fn.outer_ident(&name),
+    ];
+
+    let schema_qualifier = match &schema {
+        Some(schema) => format!("{}.", schema),
+        None => String::new(),
+    };
+    let mut create = format!("\nCREATE AGGREGATE {}{} (", schema_qualifier, name);
+    for (i, (name, arg)) in transition_fn.sql_args().enumerate() {
+        if i != 0 {
+            let _ = write!(&mut create, ", ");
+        }
+        if let Some(name) = name {
+            let _ = write!(&mut create, "{} ", name);
+        }
+        let _ = write!(&mut create, "{}", arg);
+    }
+    let _ = write!(
+        &mut create,
+        ") (\n    \
+            stype = internal,\n    \
+            sfunc = {}{},\n    \
+            finalfunc = {}{}",
+        schema_qualifier, transition_fn.outer_ident(&name),
+        schema_qualifier, final_fn.outer_ident(&name),
+    );
+
+    let parallel_safe = parallel_safe.map(|p| {
+        let value = p.value();
+        let _ = write!(&mut create, ",\n    parallel = {}",
+            if value {
+                "safe"
+            } else {
+                "unsafe"
+            });
+        quote!(pub const PARALLEL_SAFE: bool = #value;)
+    });
+
+    let mut add_function =
+        |f: AggregateFn,
+        field: &str,
+        make_tokens: fn(&AggregateFn, &Option<syn::Ident>, &syn::Ident) -> TokenStream2| {
+            extension_sql_reqs.push(f.outer_ident(&name));
+            let _ = write!(
+                &mut create,
+                ",\n    {} = {}{}",
+                field,
+                schema_qualifier,
+                f.outer_ident(&name)
+            );
+            make_tokens(&f, &schema, &name)
+    };
+    let serialize_fns = serialize_fn.map(|f| add_function(f, "serialfunc", AggregateFn::serialize_fn_tokens));
+    let deserialize_fns = deserialize_fn.map(|f| add_function(f, "deserialfunc", AggregateFn::deserialize_fn_tokens));
+    let combine_fns = combine_fn.map(|f| add_function(f, "combinefunc", AggregateFn::combine_fn_tokens));
+
+    let _ = write!(&mut create, "\n);\n");
+
+    let extension_sql_name = format!("{}_extension_sql", name);
+
+    quote! {
+        pub mod #name {
+            use super::*;
+
+            pub type State = #state_ty;
+
+            #parallel_safe
+
+            #transition_fns
+
+            #final_fns
+            #serialize_fns
+            #deserialize_fns
+            #combine_fns
+
+            pgx::extension_sql!(
+                #create,
+                name=#extension_sql_name,
+                requires=[#(#extension_sql_reqs),*],
+            );
+        }
+    }
+}
+
+impl AggregateFn {
+    fn transition_fn_tokens(&self, schema: &Option<syn::Ident>, aggregate_name: &syn::Ident) -> TokenStream2 {
+        let outer_ident = self.outer_ident(aggregate_name);
+        let Self {
+            ident,
+            args,
+            body,
+            ret,
+            ..
+        } = self;
+
+        let schema = schema.as_ref().map(|s| {
+            let s = format!("{}", s);
+            quote!(, schema = #s)
+        });
+
+        let state_type_check = state_type_check_tokens(&*args[0].rust.ty, Some(()));
+
+        let arg_signatures = args.iter()
+            .skip(1)
+            .map(|arg| &arg.rust);
+        let arg_vals: Punctuated<syn::Pat, Comma> = args.iter()
+            .skip(1)
+            .map(arg_ident)
+            .collect();
+
+        let inner_arg_signatures = args.iter().map(|arg| &arg.rust);
+
+        let return_type_check = state_type_check_tokens(&*ret_type(ret), Some(()));
+
+        quote! {
+
+            #state_type_check
+
+            #return_type_check
+
+            #[pgx::pg_extern(immutable, parallel_safe #schema)]
+            pub fn #outer_ident(
+                __internal: pgx::Internal,
+                #(#arg_signatures,)*
+                __fcinfo: pg_sys::FunctionCallInfo
+            ) -> Internal {
+                use crate::palloc::{InternalAsValue, ToInternal};
+                unsafe {
+                    crate::aggregate_utils::in_aggregate_context(__fcinfo, ||
+                        #ident(__internal.to_inner(), #arg_vals).internal()
+                    )
+                }
+            }
+
+            pub fn #ident(#(#inner_arg_signatures),*) #ret
+                #body
+        }
+    }
+
+    fn final_fn_tokens(&self, schema: &Option<syn::Ident>, aggregate_name: &syn::Ident) -> TokenStream2 {
+        let outer_ident = self.outer_ident(aggregate_name);
+        let Self {
+            ident,
+            args,
+            ret,
+            body,
+            ..
+        } = self;
+
+        let schema = schema.as_ref().map(|s| {
+            let s = format!("{}", s);
+            quote!(, schema = #s)
+        });
+
+        let state_type_check = state_type_check_tokens(&*args[0].rust.ty, Some(()));
+        let arg_vals: Punctuated<syn::Pat, Comma> = args.iter()
+            .skip(1)
+            .map(arg_ident)
+            .collect();
+
+        let inner_arg_signatures = args.iter().map(|arg| &arg.rust);
+
+        quote! {
+            #state_type_check
+
+            #[pgx::pg_extern(immutable, parallel_safe #schema)]
+            pub fn #outer_ident(
+                __internal: pgx::Internal,
+                __fcinfo: pg_sys::FunctionCallInfo
+            ) #ret {
+                use crate::palloc::{InternalAsValue, ToInternal};
+                unsafe {
+                    #ident(__internal.to_inner(), #arg_vals)
+                }
+            }
+
+            pub fn #ident(#(#inner_arg_signatures,)*) #ret
+                #body
+        }
+    }
+
+    fn serialize_fn_tokens(&self, schema: &Option<syn::Ident>, aggregate_name: &syn::Ident) -> TokenStream2 {
+        let outer_ident = self.outer_ident(aggregate_name);
+        let Self {
+            ident,
+            args,
+            ret,
+            body,
+            ..
+        } = self;
+
+        let schema = schema.as_ref().map(|s| {
+            let s = format!("{}", s);
+            quote!(, schema = #s)
+        });
+
+        let state_type_check = state_type_check_tokens(&*args[0].rust.ty, None);
+
+        let return_type_check = bytea_type_check_tokens(&*ret_type(ret));
+
+        let inner_arg_signatures = args.iter().map(|arg| &arg.rust);
+
+        quote! {
+            #state_type_check
+
+            #return_type_check
+
+            #[pgx::pg_extern(strict, immutable, parallel_safe #schema)]
+            pub fn #outer_ident(
+                __internal: pgx::Internal,
+            ) -> bytea {
+                use crate::palloc::InternalAsValue;
+                unsafe {
+                    #ident(__internal.to_inner().unwrap())
+                }
+            }
+
+            pub fn #ident(#(#inner_arg_signatures,)*)
+            -> bytea
+                #body
+        }
+    }
+
+    fn deserialize_fn_tokens(&self, schema: &Option<syn::Ident>, aggregate_name: &syn::Ident) -> TokenStream2 {
+        let outer_ident = self.outer_ident(aggregate_name);
+        let Self {
+            ident,
+            args,
+            ret,
+            body,
+            ..
+        } = self;
+
+        let schema = schema.as_ref().map(|s| {
+            let s = format!("{}", s);
+            quote!(, schema = #s)
+        });
+
+        let state_name = arg_ident(&args[0]);
+
+        let state_type_check = bytea_type_check_tokens(&*args[0].rust.ty);
+
+        let return_type_check = state_type_check_tokens(&*ret_type(ret), None);
+
+        // int8_avg_deserialize allocates in CurrentMemoryContext, so we do the same
+        // https://github.com/postgres/postgres/blob/f920f7e799c587228227ec94356c760e3f3d5f2b/src/backend/utils/adt/numeric.c#L5728-L5770
+        quote! {
+            #state_type_check
+
+            #return_type_check
+
+            #[pgx::pg_extern(strict, immutable, parallel_safe #schema)]
+            pub fn #outer_ident(
+                bytes: crate::raw::bytea,
+                _internal: Internal
+            ) -> Internal {
+                use crate::palloc::ToInternal;
+                unsafe {
+                    #ident(bytes).internal()
+                }
+            }
+
+            pub fn #ident(#state_name: crate::raw::bytea) #ret
+                #body
+        }
+    }
+
+    fn combine_fn_tokens(&self, schema: &Option<syn::Ident>, aggregate_name: &syn::Ident) -> TokenStream2 {
+        let outer_ident = self.outer_ident(aggregate_name);
+        let Self {
+            ident,
+            args,
+            ret,
+            body,
+            ..
+        } = self;
+
+        let schema = schema.as_ref().map(|s| {
+            let s = format!("{}", s);
+            quote!(, schema = #s)
+        });
+
+        let a_name = arg_ident(&args[0]);
+        let b_name = arg_ident(&args[1]);
+
+        let state_type_check_a = state_type_check_tokens(&*args[0].rust.ty, Some(()));
+        let state_type_check_b = state_type_check_tokens(&*args[1].rust.ty, Some(()));
+
+        let return_type_check = state_type_check_tokens(&*ret_type(ret), Some(()));
+
+        let inner_arg_signatures = args.iter().map(|arg| &arg.rust);
+
+        quote! {
+            #state_type_check_a
+            #state_type_check_b
+            #return_type_check
+
+            #[pgx::pg_extern(immutable, parallel_safe #schema)]
+            pub fn #outer_ident(
+                #a_name: Internal,
+                #b_name: Internal,
+                __fcinfo: pg_sys::FunctionCallInfo
+            ) -> Internal {
+                use crate::palloc::{InternalAsValue, ToInternal};
+                unsafe {
+                    crate::aggregate_utils::in_aggregate_context(__fcinfo, ||
+                        #ident(#a_name.to_inner(), #b_name.to_inner()).internal()
+                    )
+                }
+            }
+
+            pub fn #ident(#(#inner_arg_signatures,)*) #ret
+                #body
+        }
+    }
+
+    fn outer_ident(&self, aggregate_name: &syn::Ident) -> syn::Ident {
+        let name = match &self.sql_name {
+            Some(name) => name.value(),
+            None => format!("{}_{}_fn_outer", aggregate_name, self.ident),
+        };
+        syn::Ident::new(&name, Span::call_site())
+    }
+
+    fn sql_args(&self) -> impl Iterator<Item=(Option<&syn::Ident>, String)> {
+        self.args.iter().skip(1).map(|arg| {
+            let ident = match &*arg.rust.pat {
+                syn::Pat::Ident(id) => Some(&id.ident),
+                _ => None,
+            };
+            (ident, arg.sql.as_ref().expect("missing sql arg").value())
+        })
+    }
+}
+
+fn arg_ident(arg: &AggregateArg) -> syn::Pat {
+    syn::Pat::clone(&*arg.rust.pat)
+}
+
+fn ret_type(ret: &syn::ReturnType) -> Cow<'_, syn::Type> {
+    match ret {
+        syn::ReturnType::Default => Cow::Owned(parse_quote!(())),
+        syn::ReturnType::Type(_, ty) => Cow::Borrowed(ty),
+    }
+}
+
+fn state_type_check_tokens(ty: &syn::Type, optional: Option<()>) -> TokenStream2 {
+    match optional {
+        Some(..) => {
+            type_check_tokens(
+                ty,
+                parse_quote!(Option<crate::palloc::Inner<State>>),
+                parse_quote!(None)
+            )
+        },
+        None => {
+            type_check_tokens(
+                ty,
+                parse_quote!(crate::palloc::Inner<State>),
+                parse_quote!(crate::palloc::Inner(std::ptr::NonNull::dangling()))
+            )
+        },
+    }
+}
+
+fn bytea_type_check_tokens(ty: &syn::Type) -> TokenStream2 {
+    type_check_tokens(ty, parse_quote!(bytea), parse_quote!(crate::raw::bytea(0)))
+}
+
+fn type_check_tokens(
+    user_ty: &syn::Type,
+    expected_type: syn::Type,
+    initializer: syn::Expr,
+) -> TokenStream2 {
+    quote_spanned!{user_ty.span()=>
+        const _: () = {
+            let _user: #user_ty = #initializer;
+            let _expected: #expected_type = _user;
+        };
+    }
+}

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -31,6 +31,8 @@ time_series = {path="../crates/time-series"}
 asap = {path="../crates/asap"}
 spacesaving = {path="../crates/spacesaving"}
 
+aggregate_builder = {path="../crates/aggregate_builder"}
+
 approx = {version = "0.4.0", optional = true}
 bincode = "1.3.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/extension/src/aggregate_builder_tests.rs
+++ b/extension/src/aggregate_builder_tests.rs
@@ -1,0 +1,219 @@
+// Tests for `aggregate_builder::aggregate`. This can't be in the
+// aggregate_builder crate because it requires too much of postgres to actually
+// function
+use aggregate_builder::aggregate;
+
+use pgx::*;
+
+use crate::{
+    palloc::Inner,
+    raw::bytea,
+};
+
+// just about the simplest aggregate `arbitrary()` returns an arbitrary element
+// from the input set. We have three versions
+//  1. `anything()` tests that the minimal functionality works.
+//  2. `cagg_anything()` tests that the config we use for caggs (serialization
+//     but not parallel-safe) outputs the expected config.
+//  3. `parallel_anything()` tests that the parallel version outputs the expected
+//      config.
+#[aggregate] impl toolkit_experimental::anything {
+    type State = String;
+
+    fn transition(
+        state: Option<Inner<State>>,
+        #[sql_type("text")] value: String,
+    ) -> Option<Inner<State>> {
+        match state {
+            Some(value) => Some(value),
+            None => Some(value.into()),
+        }
+    }
+
+    fn finally(state: Option<Inner<State>>) -> Option<String> {
+        state.as_deref().cloned()
+    }
+}
+
+#[aggregate] impl toolkit_experimental::cagg_anything {
+    type State = String;
+
+    fn transition(
+        state: Option<Inner<State>>,
+        #[sql_type("text")] value: String,
+    ) -> Option<Inner<State>> {
+        match state {
+            Some(value) => Some(value),
+            None => Some(value.into()),
+        }
+    }
+
+    fn finally(state: Option<Inner<State>>) -> Option<String> {
+        state.as_deref().cloned()
+    }
+
+    fn serialize(state: Inner<State>) -> bytea {
+        crate::do_serialize!(state)
+    }
+
+    fn deserialize(bytes: bytea) -> Inner<State> {
+        crate::do_deserialize!(bytes, State)
+    }
+}
+
+#[aggregate] impl toolkit_experimental::parallel_anything {
+    type State = String;
+
+    fn transition(
+        state: Option<Inner<State>>,
+        #[sql_type("text")] value: String,
+    ) -> Option<Inner<State>> {
+        match state {
+            Some(value) => Some(value),
+            None => Some(value.into()),
+        }
+    }
+
+    fn finally(state: Option<Inner<State>>) -> Option<String> {
+        state.as_deref().cloned()
+    }
+
+    const PARALLEL_SAFE: bool = true;
+
+    fn serialize(state: Inner<State>) -> bytea {
+        crate::do_serialize!(state)
+    }
+
+    fn deserialize(bytes: bytea) -> Inner<State> {
+        crate::do_deserialize!(bytes, State)
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgx::*;
+    use pgx_macros::pg_test;
+
+    #[pg_test]
+    fn test_anything_in_experimental_and_returns_first() {
+        Spi::execute(|client| {
+            let output = client.select(
+                "SELECT toolkit_experimental.anything(val) \
+                FROM (VALUES ('foo'), ('bar'), ('baz')) as v(val)",
+                None,
+                None,
+            ).first()
+                .get_one::<String>();
+            assert_eq!(output.as_deref(), Some("foo"));
+        })
+    }
+
+    #[pg_test]
+    fn test_anything_has_correct_fn_names_and_def() {
+        Spi::execute(|client| {
+            let spec = get_aggregate_spec(&client, "anything");
+            // output is
+            //   fn kind (`a`), volatility, parallel-safety, num args, final fn modify (is this right?)
+            //   transition type (`internal`)
+            //   output type
+            //   transition fn name,
+            //   final fn name,
+            //   serialize fn name or - if none,
+            //   deserialize fn name or - if none,
+            assert_eq!(
+                spec,
+                "(\
+                    a,i,u,1,r,\
+                    internal,\
+                    text,\
+                    toolkit_experimental.anything_transition_fn_outer,\
+                    toolkit_experimental.anything_finally_fn_outer,\
+                    -,\
+                    -\
+                )"
+            );
+        });
+    }
+
+    #[pg_test]
+    fn test_cagg_anything_has_correct_fn_names_and_def() {
+        Spi::execute(|client| {
+            let spec = get_aggregate_spec(&client, "cagg_anything");
+            // output is
+            //   fn kind (`a`), volatility, parallel-safety, num args, final fn modify (is this right?)
+            //   transition type (`internal`)
+            //   output type
+            //   transition fn name,
+            //   final fn name,
+            //   serialize fn name or - if none,
+            //   deserialize fn name or - if none,
+            assert_eq!(
+                spec,
+                "(\
+                    a,i,u,1,r,\
+                    internal,\
+                    text,\
+                    toolkit_experimental.cagg_anything_transition_fn_outer,\
+                    toolkit_experimental.cagg_anything_finally_fn_outer,\
+                    toolkit_experimental.cagg_anything_serialize_fn_outer,\
+                    toolkit_experimental.cagg_anything_deserialize_fn_outer\
+                )"
+            );
+        });
+    }
+
+    #[pg_test]
+    fn test_parallel_anything_has_correct_fn_names_and_def() {
+        Spi::execute(|client| {
+            let spec = get_aggregate_spec(&client, "parallel_anything");
+            // output is
+            //   fn kind (`a`), volatility, parallel-safety, num args, final fn modify (is this right?)
+            //   transition type (`internal`)
+            //   output type
+            //   transition fn name,
+            //   final fn name,
+            //   serialize fn name or - if none,
+            //   deserialize fn name or - if none,
+            assert_eq!(
+                spec,
+                "(\
+                    a,i,s,1,r,\
+                    internal,\
+                    text,\
+                    toolkit_experimental.parallel_anything_transition_fn_outer,\
+                    toolkit_experimental.parallel_anything_finally_fn_outer,\
+                    toolkit_experimental.parallel_anything_serialize_fn_outer,\
+                    toolkit_experimental.parallel_anything_deserialize_fn_outer\
+                )"
+            );
+        });
+    }
+
+    // It gets annoying, and segfaulty to handle many arguments from the Spi.
+    // For simplicity, we just return a single string representing the tuple
+    // and use string-comparison.
+    fn get_aggregate_spec(client: &spi::SpiClient, aggregate_name: &str) -> String {
+        client.select(
+            &format!(r#"SELECT (
+                prokind,
+                provolatile,
+                proparallel,
+                pronargs,
+                aggfinalmodify,
+                aggtranstype::regtype,
+                prorettype::regtype,
+                aggtransfn,
+                aggfinalfn,
+                aggserialfn,
+                aggdeserialfn)::TEXT
+            FROM pg_proc, pg_aggregate
+            WHERE proname = '{}'
+              AND pg_proc.oid = aggfnoid;"#, aggregate_name),
+            None,
+            None,
+        ).first()
+            .get_one::<String>()
+            .expect("no aggregate found")
+    }
+}

--- a/extension/src/aggregate_builder_tests.rs
+++ b/extension/src/aggregate_builder_tests.rs
@@ -30,7 +30,7 @@ use crate::{
         }
     }
 
-    fn finally(state: Option<Inner<State>>) -> Option<String> {
+    fn finally(state: Option<&mut State>) -> Option<String> {
         state.as_deref().cloned()
     }
 }
@@ -48,11 +48,11 @@ use crate::{
         }
     }
 
-    fn finally(state: Option<Inner<State>>) -> Option<String> {
+    fn finally(state: Option<&mut State>) -> Option<String> {
         state.as_deref().cloned()
     }
 
-    fn serialize(state: Inner<State>) -> bytea {
+    fn serialize(state: &State) -> bytea {
         crate::do_serialize!(state)
     }
 
@@ -60,8 +60,7 @@ use crate::{
         crate::do_deserialize!(bytes, State)
     }
 
-    fn combine(a: Option<Inner<State>>, b: Option<Inner<State>>)
-    -> Option<Inner<State>> {
+    fn combine(a: Option<&State>, b: Option<&State>) -> Option<Inner<State>> {
         a.or(b).map(|i| i.clone().into())
     }
 }
@@ -79,13 +78,13 @@ use crate::{
         }
     }
 
-    fn finally(state: Option<Inner<State>>) -> Option<String> {
+    fn finally(state: Option<&mut State>) -> Option<String> {
         state.as_deref().cloned()
     }
 
     const PARALLEL_SAFE: bool = true;
 
-    fn serialize(state: Inner<State>) -> bytea {
+    fn serialize(state: &State) -> bytea {
         crate::do_serialize!(state)
     }
 
@@ -93,8 +92,7 @@ use crate::{
         crate::do_deserialize!(bytes, State)
     }
 
-    fn combine(a: Option<Inner<State>>, b: Option<Inner<State>>)
-    -> Option<Inner<State>> {
+    fn combine(a: Option<&State>, b: Option<&State>) -> Option<Inner<State>> {
         a.or(b).map(|i| i.clone().into())
     }
 }

--- a/extension/src/aggregate_builder_tests.rs
+++ b/extension/src/aggregate_builder_tests.rs
@@ -59,6 +59,11 @@ use crate::{
     fn deserialize(bytes: bytea) -> Inner<State> {
         crate::do_deserialize!(bytes, State)
     }
+
+    fn combine(a: Option<Inner<State>>, b: Option<Inner<State>>)
+    -> Option<Inner<State>> {
+        a.or(b).map(|i| i.clone().into())
+    }
 }
 
 #[aggregate] impl toolkit_experimental::parallel_anything {
@@ -86,6 +91,11 @@ use crate::{
 
     fn deserialize(bytes: bytea) -> Inner<State> {
         crate::do_deserialize!(bytes, State)
+    }
+
+    fn combine(a: Option<Inner<State>>, b: Option<Inner<State>>)
+    -> Option<Inner<State>> {
+        a.or(b).map(|i| i.clone().into())
     }
 }
 
@@ -130,6 +140,7 @@ mod tests {
                     toolkit_experimental.anything_transition_fn_outer,\
                     toolkit_experimental.anything_finally_fn_outer,\
                     -,\
+                    -,\
                     -\
                 )"
             );
@@ -157,7 +168,8 @@ mod tests {
                     toolkit_experimental.cagg_anything_transition_fn_outer,\
                     toolkit_experimental.cagg_anything_finally_fn_outer,\
                     toolkit_experimental.cagg_anything_serialize_fn_outer,\
-                    toolkit_experimental.cagg_anything_deserialize_fn_outer\
+                    toolkit_experimental.cagg_anything_deserialize_fn_outer,\
+                    toolkit_experimental.cagg_anything_combine_fn_outer\
                 )"
             );
         });
@@ -184,7 +196,8 @@ mod tests {
                     toolkit_experimental.parallel_anything_transition_fn_outer,\
                     toolkit_experimental.parallel_anything_finally_fn_outer,\
                     toolkit_experimental.parallel_anything_serialize_fn_outer,\
-                    toolkit_experimental.parallel_anything_deserialize_fn_outer\
+                    toolkit_experimental.parallel_anything_deserialize_fn_outer,\
+                    toolkit_experimental.parallel_anything_combine_fn_outer\
                 )"
             );
         });
@@ -206,7 +219,8 @@ mod tests {
                 aggtransfn,
                 aggfinalfn,
                 aggserialfn,
-                aggdeserialfn)::TEXT
+                aggdeserialfn,
+                aggcombinefn)::TEXT
             FROM pg_proc, pg_aggregate
             WHERE proname = '{}'
               AND pg_proc.oid = aggfnoid;"#, aggregate_name),

--- a/extension/src/aggregate_builder_tests.rs
+++ b/extension/src/aggregate_builder_tests.rs
@@ -21,13 +21,10 @@ use crate::{
     type State = String;
 
     fn transition(
-        state: Option<Inner<State>>,
+        state: Option<State>,
         #[sql_type("text")] value: String,
-    ) -> Option<Inner<State>> {
-        match state {
-            Some(value) => Some(value),
-            None => Some(value.into()),
-        }
+    ) -> Option<State> {
+        state.or(Some(value))
     }
 
     fn finally(state: Option<&mut State>) -> Option<String> {
@@ -39,13 +36,10 @@ use crate::{
     type State = String;
 
     fn transition(
-        state: Option<Inner<State>>,
+        state: Option<State>,
         #[sql_type("text")] value: String,
-    ) -> Option<Inner<State>> {
-        match state {
-            Some(value) => Some(value),
-            None => Some(value.into()),
-        }
+    ) -> Option<State> {
+        state.or(Some(value))
     }
 
     fn finally(state: Option<&mut State>) -> Option<String> {
@@ -56,12 +50,12 @@ use crate::{
         crate::do_serialize!(state)
     }
 
-    fn deserialize(bytes: bytea) -> Inner<State> {
+    fn deserialize(bytes: bytea) -> State {
         crate::do_deserialize!(bytes, State)
     }
 
-    fn combine(a: Option<&State>, b: Option<&State>) -> Option<Inner<State>> {
-        a.or(b).map(|i| i.clone().into())
+    fn combine(a: Option<&State>, b: Option<&State>) -> Option<State> {
+        a.or(b).cloned()
     }
 }
 
@@ -69,13 +63,10 @@ use crate::{
     type State = String;
 
     fn transition(
-        state: Option<Inner<State>>,
+        state: Option<State>,
         #[sql_type("text")] value: String,
-    ) -> Option<Inner<State>> {
-        match state {
-            Some(value) => Some(value),
-            None => Some(value.into()),
-        }
+    ) -> Option<State> {
+        state.or(Some(value))
     }
 
     fn finally(state: Option<&mut State>) -> Option<String> {
@@ -88,12 +79,12 @@ use crate::{
         crate::do_serialize!(state)
     }
 
-    fn deserialize(bytes: bytea) -> Inner<State> {
+    fn deserialize(bytes: bytea) -> State {
         crate::do_deserialize!(bytes, State)
     }
 
-    fn combine(a: Option<&State>, b: Option<&State>) -> Option<Inner<State>> {
-        a.or(b).map(|i| i.clone().into())
+    fn combine(a: Option<&State>, b: Option<&State>) -> Option<State> {
+        a.or(b).cloned()
     }
 }
 

--- a/extension/src/counter_agg.rs
+++ b/extension/src/counter_agg.rs
@@ -1,9 +1,5 @@
 use serde::{Serialize, Deserialize};
 
-use std::{
-    slice,
-};
-
 use pgx::*;
 
 use flat_serialize::*;

--- a/extension/src/hyperloglog.rs
+++ b/extension/src/hyperloglog.rs
@@ -4,7 +4,6 @@ use std::{
     convert::TryInto,
     hash::{BuildHasher, Hasher},
     mem::size_of,
-    slice,
 };
 
 use serde::{Deserialize, Serialize};

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -22,6 +22,9 @@ mod serialization;
 mod schema_test;
 mod raw;
 
+#[cfg(any(test, feature = "pg_test"))]
+mod aggregate_builder_tests;
+
 // This should be last so we don't run our warning trigger on when
 // installing this extension
 pub mod zz_triggers;

--- a/extension/src/schema_test.rs
+++ b/extension/src/schema_test.rs
@@ -1,4 +1,4 @@
-
+#[cfg(any(test, feature = "pg_test"))]
 use pgx::*;
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/extension/src/stats_agg.rs
+++ b/extension/src/stats_agg.rs
@@ -1,6 +1,3 @@
-use std::{
-    slice,
-};
 
 use pgx::*;
 

--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -1,5 +1,5 @@
 
-use std::{convert::TryInto, mem::take, ops::Deref, slice};
+use std::{convert::TryInto, mem::take, ops::Deref};
 
 use serde::{Serialize, Deserialize};
 

--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -1,6 +1,8 @@
 
 use std::{convert::TryInto, mem::take, ops::Deref};
 
+use aggregate_builder::aggregate;
+
 use serde::{Serialize, Deserialize};
 
 use pgx::*;
@@ -12,10 +14,11 @@ use crate::{
     ron_inout_funcs,
     flatten,
     palloc::{Internal, InternalAsValue, Inner, ToInternal}, pg_type,
+    raw::bytea,
     accessors::toolkit_experimental,
 };
 
-use tdigest::{
+use ::tdigest::{
     TDigest as InternalTDigest,
     Centroid,
 };
@@ -49,110 +52,78 @@ impl TDigestTransState {
     }
 }
 
-// PG function for adding values to a digest.
-// Null values are ignored.
-#[pg_extern(immutable, parallel_safe)]
-pub fn tdigest_trans(
-    state: Internal,
-    size: i32,
-    value: Option<f64>,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
-    tdigest_trans_inner(unsafe{ state.to_inner() }, size, value, fcinfo).internal()
-}
-pub fn tdigest_trans_inner(
-    state: Option<Inner<TDigestTransState>>,
-    size: i32,
-    value: Option<f64>,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<Inner<TDigestTransState>> {
-    unsafe {
-        in_aggregate_context(fcinfo, || {
-            let value = match value {
-                None => return state,
-                // NaNs are nonsensical in the context of a percentile, so exclude them
-                Some(value) => if value.is_nan() {return state} else {value},
-            };
-            let mut state = match state {
-                None => TDigestTransState{
-                    buffer: vec![],
-                    digested: InternalTDigest::new_with_size(size.try_into().unwrap()),
-                }.into(),
-                Some(state) => state,
-            };
-            state.push(value);
-            Some(state)
-        })
-    }
-}
+#[aggregate] impl tdigest {
+    type State = TDigestTransState;
 
-// PG function for merging digests.
-#[pg_extern(immutable, parallel_safe)]
-pub fn tdigest_combine(
-    state1: Internal,
-    state2: Internal,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
-    unsafe {
-        tdigest_combine_inner(state1.to_inner(), state2.to_inner(), fcinfo).internal()
+    const PARALLEL_SAFE: bool = true;
+
+    #[sql_name("tdigest_trans")]
+    fn transition(
+        state: Option<Inner<State>>,
+        #[sql_type("int")] size: i32,
+        #[sql_type("DOUBLE PRECISION")] value: Option<f64>) -> Option<Inner<State>> {
+        let value = match value {
+            None => return state,
+            // NaNs are nonsensical in the context of a percentile, so exclude them
+            Some(value) => if value.is_nan() {return state} else {value},
+        };
+        let mut state = match state {
+            None => TDigestTransState{
+                buffer: vec![],
+                digested: InternalTDigest::new_with_size(size.try_into().unwrap()),
+            }.into(),
+            Some(state) => state,
+        };
+        state.push(value);
+        Some(state)
     }
 
-}
+    #[sql_name("tdigest_final")]
+    fn finally(mut state: Option<Inner<State>>) -> Option<TDigest<'static>> {
+        let state = match &mut state {
+            None => return None,
+            Some(state) => state,
+        };
+        state.digest();
 
-pub fn tdigest_combine_inner(
-    state1: Option<Inner<TDigestTransState>>,
-    state2: Option<Inner<TDigestTransState>>,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<Inner<TDigestTransState>> {
-    unsafe {
-        in_aggregate_context(fcinfo, || {
-            match (state1, state2) {
-                (None, None) => None,
-                (None, Some(state2)) => Some(state2.clone().into()),
-                (Some(state1), None) => Some(state1.clone().into()),
-                (Some(state1), Some(state2)) => {
-                    assert_eq!(state1.digested.max_size(), state2.digested.max_size());
-                    let digvec = vec![state1.digested.clone(), state2.digested.clone()];
-                    if !state1.buffer.is_empty() {
-                        digvec[0].merge_unsorted(state1.buffer.clone());  // merge_unsorted should take a reference
-                    }
-                    if !state2.buffer.is_empty() {
-                        digvec[1].merge_unsorted(state2.buffer.clone());
-                    }
+        TDigest::from_internal_tdigest(&state.digested).into()
+    }
 
-                    Some(TDigestTransState {
-                            buffer: vec![],
-                            digested: InternalTDigest::merge_digests(digvec),
-                        }.into()
-                    )
+    #[sql_name("tdigest_serialize")]
+    fn serialize(mut state: Inner<State>) -> bytea {
+        state.digest();
+        crate::do_serialize!(state)
+    }
+
+    #[sql_name("tdigest_deserialize")]
+    fn deserialize(bytes: bytea) -> Inner<State> {
+        crate::do_deserialize!(bytes, TDigestTransState)
+    }
+
+    #[sql_name("tdigest_combine")]
+    fn combine(state1: Option<Inner<State>>, state2: Option<Inner<State>>) -> Option<Inner<State>> {
+        match (state1, state2) {
+            (None, None) => None,
+            (None, Some(state2)) => Some(state2.clone().into()),
+            (Some(state1), None) => Some(state1.clone().into()),
+            (Some(state1), Some(state2)) => {
+                assert_eq!(state1.digested.max_size(), state2.digested.max_size());
+                let digvec = vec![state1.digested.clone(), state2.digested.clone()];
+                if !state1.buffer.is_empty() {
+                    digvec[0].merge_unsorted(state1.buffer.clone());  // merge_unsorted should take a reference
                 }
+                if !state2.buffer.is_empty() {
+                    digvec[1].merge_unsorted(state2.buffer.clone());
+                }
+
+                Some(TDigestTransState {
+                        buffer: vec![],
+                        digested: InternalTDigest::merge_digests(digvec),
+                    }.into()
+                )
             }
-        })
+        }
     }
-}
-
-use crate::raw::bytea;
-
-#[pg_extern(immutable, parallel_safe)]
-pub fn tdigest_serialize(
-    state: Internal,
-) -> bytea {
-    let state: &mut TDigestTransState = unsafe { state.get_mut().unwrap() };
-    state.digest();
-    crate::do_serialize!(state)
-}
-
-#[pg_extern(strict, immutable, parallel_safe)]
-pub fn tdigest_deserialize(
-    bytes: bytea,
-    _internal: Internal,
-) -> Internal {
-    tdigest_deserialize_inner(bytes).internal()
-}
-pub fn tdigest_deserialize_inner(
-    bytes: bytea,
-) -> Inner<TDigestTransState> {
-    crate::do_deserialize!(bytes, TDigestTransState)
 }
 
 // PG object for the digest.
@@ -205,42 +176,6 @@ impl<'input> TDigest<'input> {
         }
     }
 }
-
-// PG function to generate a user-facing TDigest object from an internal TDigestTransState.
-#[pg_extern(immutable, parallel_safe)]
-fn tdigest_final(
-    state: Internal,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<TDigest<'static>> {
-    unsafe {
-        in_aggregate_context(fcinfo, || {
-            let state: &mut TDigestTransState = match state.get_mut() {
-                None => return None,
-                Some(state) => state,
-            };
-            state.digest();
-
-            TDigest::from_internal_tdigest(&state.digested).into()
-        })
-    }
-}
-
-
-extension_sql!("\n\
-    CREATE AGGREGATE tdigest(size int, value DOUBLE PRECISION)\n\
-    (\n\
-        sfunc = tdigest_trans,\n\
-        stype = internal,\n\
-        finalfunc = tdigest_final,\n\
-        combinefunc = tdigest_combine,\n\
-        serialfunc = tdigest_serialize,\n\
-        deserialfunc = tdigest_deserialize,\n\
-        parallel = safe\n\
-    );\n\
-",
-name = "tdigest_agg",
-requires = [tdigest_trans, tdigest_final, tdigest_combine, tdigest_serialize, tdigest_deserialize],
-);
 
 #[pg_extern(immutable, parallel_safe)]
 pub fn tdigest_compound_trans(
@@ -634,22 +569,21 @@ mod tests {
     #[pg_test]
     fn test_tdigest_byte_io() {
         unsafe {
-            use std::ptr;
-            let state = tdigest_trans_inner(None, 100, Some(14.0), ptr::null_mut());
-            let state = tdigest_trans_inner(state, 100, Some(18.0), ptr::null_mut());
-            let state = tdigest_trans_inner(state, 100, Some(22.7), ptr::null_mut());
-            let state = tdigest_trans_inner(state, 100, Some(39.42), ptr::null_mut());
-            let state = tdigest_trans_inner(state, 100, Some(-43.0), ptr::null_mut());
+            let state = super::tdigest::transition(None,  100, Some(14.0));
+            let state = super::tdigest::transition(state, 100, Some(18.0));
+            let state = super::tdigest::transition(state, 100, Some(22.7));
+            let state = super::tdigest::transition(state, 100, Some(39.42));
+            let state = super::tdigest::transition(state, 100, Some(-43.0));
 
             let mut control = state.unwrap();
-            let buffer = tdigest_serialize(Inner::from(control.clone()).internal());
+            let buffer = super::tdigest::serialize(Inner::from(control.clone()));
             let buffer = pgx::varlena::varlena_to_byte_slice(buffer.0 as *mut pg_sys::varlena);
 
             let expected = [1, 1, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 69, 192, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 64, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50, 64, 1, 0, 0, 0, 0, 0, 0, 0, 51, 51, 51, 51, 51, 179, 54, 64, 1, 0, 0, 0, 0, 0, 0, 0, 246, 40, 92, 143, 194, 181, 67, 64, 1, 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 144, 194, 245, 40, 92, 143, 73, 64, 5, 0, 0, 0, 0, 0, 0, 0, 246, 40, 92, 143, 194, 181, 67, 64, 0, 0, 0, 0, 0, 128, 69, 192];
             assert_eq!(buffer, expected);
 
             let expected = pgx::varlena::rust_byte_slice_to_bytea(&expected);
-            let new_state = tdigest_deserialize_inner(bytea(&*expected as *const pg_sys::varlena as _));
+            let new_state = super::tdigest::deserialize(bytea(&*expected as *const pg_sys::varlena as _));
 
             control.digest();  // Serialized form is always digested
             assert_eq!(&*new_state, &*control);

--- a/extension/src/time_series.rs
+++ b/extension/src/time_series.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::identity_op)] // clippy gets confused by pg_type! enums
 
-use std::{slice};
-
 use pgx::*;
 
 use crate::{

--- a/extension/src/time_weighted_average.rs
+++ b/extension/src/time_weighted_average.rs
@@ -1,7 +1,6 @@
 #![allow(non_camel_case_types)]
 
 use serde::{Deserialize, Serialize};
-use std::slice;
 
 use crate::{
     aggregate_utils::in_aggregate_context, flatten, ron_inout_funcs, palloc::{Internal, InternalAsValue, Inner, ToInternal}, pg_type,
@@ -260,10 +259,10 @@ fn time_weight_final_inner(
             };
             state.combine_summaries();
             debug_assert!(state.summary_buffer.len() <= 1);
-            state.summary_buffer.pop().map(|st| flatten!(TimeWeightSummary {                                        
-                method: st.method,                                         
-                first: st.first,                                         
-                last: st.last,                                         
+            state.summary_buffer.pop().map(|st| flatten!(TimeWeightSummary {
+                method: st.method,
+                first: st.first,
+                last: st.last,
                 weighted_sum: st.w_sum,
             }))
         })

--- a/extension/src/topn.rs
+++ b/extension/src/topn.rs
@@ -1,6 +1,4 @@
 
-use std::slice;
-
 use pgx::*;
 
 use flat_serialize::*;

--- a/extension/src/type_builder.rs
+++ b/extension/src/type_builder.rs
@@ -376,7 +376,7 @@ macro_rules! do_deserialize {
                 let detoasted = pg_sys::pg_detoast_datum_packed(input as *mut _);
                 let len = pgx::varsize_any_exhdr(detoasted);
                 let data = pgx::vardata_any(detoasted);
-                let bytes = slice::from_raw_parts(data as *mut u8, len);
+                let bytes = std::slice::from_raw_parts(data as *mut u8, len);
                 if bytes.len() < 1 {
                     pgx::error!("deserialization error, no bytes")
                 }

--- a/extension/src/uddsketch.rs
+++ b/extension/src/uddsketch.rs
@@ -1,6 +1,4 @@
 
-use std::slice;
-
 use pgx::*;
 
 use flat_serialize::*;


### PR DESCRIPTION
This PR adds an aggregate builder to toolkit in order to

1. Prevent the possibility that someone gets the inner transition state type wrong between different functions making up and aggregate.
2. Ensure that the aggregate context is switched to in, and only in, the correct places.
3. Reduce the likelihood of errors in `CREATE AGGREGATE` statements.
4. Focus aggregate reviewers on the important semantic components of the aggregate implementation instead of the boilerplate.
5. Reduce the effort involved in writing aggregates.

The syntax we eventually settled on looks something like the following
```rust
#[aggregate] impl aggregate_name {
    type State = InternalTransitionType;

    fn transition(
        state: Option<Inner<State>>,
        #[sql_type("sql_type")] argument: RustType, // can have an arbitrary number of args
    ) -> Option<Inner<State>> {
        // transition function function body goes here
    }

    fn finally(state: Option<Inner<State>>) -> Option<ResultType> {
        // final function function body goes here
    }

    // the remaining items are optional

    // parallel-safety marker if desireable
    const PARALLEL_SAFE: bool = true;

    fn serialize(state: Inner<State>) -> bytea {
        // serialize function body goes here
    }

    fn deserialize(bytes: bytea) -> Inner<State> {
        // deserialize function body goes here
    }

    fn combine(state1: Option<Inner<State>>, state2: Option<Inner<State>>) -> Option<Inner<State>> {
        // combine function body goes here
    }
}
```
for example, the simplest aggregate, `arbitrary()`, that returns an element from the aggregated values, looks like
```rust
#[aggregate] impl arbitrary {
    type State = String;

    fn transition(
        state: Option<Inner<State>>,
        #[sql_type("text")] value: String,
    ) -> Option<Inner<State>> {
        match state {
            Some(value) => Some(value),
            None => Some(value.into()),
        }
    }

    fn finally(mut state: Option<Inner<State>>) -> Option<String> {
        match &mut state {
            None => None,
            Some(state) => Some(state.clone()),
        }
    }
}
```

This syntax has a couple of advantages compared to our earlier attemtps: it both looks reasonably familiar to rust users as well as looking like `CREATE AGGREGATE`; the semantics of items created by the macro largely behave as a rust user would expect them to; it has syntactic space for the aggregate's name; it should be easily extensible to moving-aggregates, notably the moving aggregate transition state should fit in naturally as something like `type MovingState`.

----

Related to https://github.com/zombodb/pgx/issues/194, though taking a slightly different strategy. Depending on where that ends up going, this will either be obviated by that, be upstreamed into that effort, or exist alongside it.