### PR TITLE
Fix list of functions in aggregate_builder 'unexpected fn' error message

### DIFF
--- a/crates/aggregate_builder/src/lib.rs
+++ b/crates/aggregate_builder/src/lib.rs
@@ -185,7 +185,7 @@ impl Parse for Aggregate {
             } else {
                 error!(
                     f.ident.span(),
-                    "unexpected `fn {}`, expected one of `transition`, `final`, `serialize`, or `deserialize`",
+                    "unexpected `fn {}`, expected one of `transition`, `finally`, `serialize`, `deserialize`, or `combine`",
                     f.ident
                 )
             }


### PR DESCRIPTION
`combine` was missing and `finally` misspelled.