### PR TITLE
Adding serialization for FrequencyTransState

### DIFF
--- a/extension/src/frequency.rs
+++ b/extension/src/frequency.rs
@@ -1,96 +1,51 @@
 //! Based on the paper: https://cs.ucsb.edu/sites/default/files/documents/2005-23.pdf
 
-use std::{
-    collections::HashMap,
-    hash::{Hash, Hasher},
-};
+use std::fmt;
 
 use pgx::*;
 
 use pg_sys::{Datum, Oid};
 
+use serde::{
+    de::{SeqAccess, Visitor},
+    ser::SerializeSeq,
+    Deserialize, Serialize,
+};
+
 use flat_serialize::*;
 
 use crate::{
-    aggregate_utils::{get_collation, in_aggregate_context},
-    datum_utils::{DatumHashBuilder, DatumStore, deep_copy_datum},
-    ron_inout_funcs,
+    aggregate_utils::get_collation,
     build,
-    palloc::{Internal, InternalAsValue, Inner, ToInternal}, 
+    datum_utils::{
+        deep_copy_datum, DatumFromSerializedTextReader, DatumHashBuilder, DatumStore,
+        TextSerializableDatumWriter,
+    },
+    palloc::{Inner, Internal, InternalAsValue},
+    pg_any_element::{PgAnyElement, PgAnyElementHashMap},
     pg_type,
+    raw::bytea,
+    ron_inout_funcs,
 };
 
-use crate::frequency::toolkit_experimental::{FrequencyAggregate};
+use aggregate_builder::aggregate;
 
-// Unable to implement PartialEq for AnyElement, so creating a local copy
-struct LocalAnyElement {
-    datum: Datum,
-    typoid: Oid,
-}
+use crate::frequency::toolkit_experimental::FrequencyAggregate;
 
-impl PartialEq for LocalAnyElement {
-    // JOSH TODO should probably store the fn pointer instead of the OID (OID or another fn ptr will also be needed for serialization)
-    #[allow(clippy::field_reassign_with_default)]
-    fn eq(&self, other: &Self) -> bool {
-        unsafe {
-            if self.typoid != other.typoid {
-                false
-            } else {
-                let typ = self.typoid;
-                let tentry =
-                    pg_sys::lookup_type_cache(typ, pg_sys::TYPECACHE_EQ_OPR_FINFO as _);
-            
-                let flinfo = if (*tentry).eq_opr_finfo.fn_addr.is_some() {
-                    &(*tentry).eq_opr_finfo
-                } else {
-                    pgx::error!("no equality function");
-                };
-
-                let mut info = pg_sys::FunctionCallInfoBaseData::default();
-        
-                info.flinfo = flinfo as *const pg_sys::FmgrInfo as *mut pg_sys::FmgrInfo;
-                info.context = std::ptr::null_mut();
-                info.resultinfo = std::ptr::null_mut();
-                info.fncollation = (*tentry).typcollation;
-                info.isnull = false;
-                info.nargs = 2;
-
-                info.args.as_mut_slice(2)[0] = pg_sys::NullableDatum {
-                    value: self.datum,
-                    isnull: false,
-                };
-                info.args.as_mut_slice(2)[1] = pg_sys::NullableDatum {
-                    value: other.datum,
-                    isnull: false,
-                };
-                (*info.flinfo).fn_addr.unwrap()(&mut info) != 0
-            }
-        }
-    }
-}
-
-impl Eq for LocalAnyElement {}
-
-impl Hash for LocalAnyElement {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.datum.hash(state);
-    }
-}
-
-impl From<AnyElement> for LocalAnyElement {
-    fn from(other: AnyElement) -> Self {
-        LocalAnyElement {
-            datum: other.datum(),
-            typoid: other.oid(),
-        }
-    }
-}
-
-#[derive(Clone)]
-struct FrequencyEntry{
+struct FrequencyEntry {
     value: Datum,
     count: u64,
     overcount: u64,
+}
+
+impl FrequencyEntry {
+    fn clone(&self, typoid: Oid) -> FrequencyEntry {
+        FrequencyEntry {
+            value: unsafe { deep_copy_datum(self.value, typoid) },
+            count: self.count,
+            overcount: self.overcount,
+        }
+    }
 }
 
 const MIN_SIZE: usize = 10;
@@ -98,26 +53,138 @@ const MAX_NOISE_RATIO: f64 = 0.9;
 
 pub struct FrequencyTransState {
     entries: Vec<FrequencyEntry>,
-    indicies: HashMap<LocalAnyElement, usize, DatumHashBuilder>,
+    indicies: PgAnyElementHashMap<usize>,
     total_vals: u64,
     min_freq: f64,
-    typ: Oid, // JOSH TODO redundant with the DatumHashBuilder?
-    complete: bool,  // true if all seen values in entries
+    complete: bool, // true if all seen values in entries
+}
+
+impl Clone for FrequencyTransState {
+    fn clone(&self) -> Self {
+        let mut new_state = Self {
+            entries: vec![],
+            indicies: PgAnyElementHashMap::with_hasher(self.indicies.hasher().clone()),
+            total_vals: self.total_vals,
+            min_freq: self.min_freq,
+            complete: self.complete,
+        };
+
+        let typoid = self.type_oid();
+        for entry in &self.entries {
+            new_state.entries.push(FrequencyEntry {
+                value: unsafe { deep_copy_datum(entry.value, typoid) },
+                count: entry.count,
+                overcount: entry.overcount,
+            })
+        }
+        new_state.update_all_map_indicies();
+        new_state
+    }
+}
+
+// FrequencyTransState is a little tricky to serialize due to needing the typ oid to serialize the Datums.
+// This sort of requirement doesn't play nicely with the serde framework, so as a workaround we simply
+// serialize the object as one big sequence.  The serialized sequence should look like this:
+//   total_vals as u64
+//   min_freq as f64
+//   complete as bool
+//   indicies.hasher as DatumHashBuilder
+//   entries as repeated (str, u64, u64) tuples
+impl Serialize for FrequencyTransState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.entries.len() + 4))?;
+        seq.serialize_element(&self.total_vals)?;
+        seq.serialize_element(&self.min_freq)?;
+        seq.serialize_element(&self.complete)?;
+        seq.serialize_element(&self.indicies.hasher())?;
+
+        // TODO JOSH use a writer that switches based on whether we want binary or not
+        let mut writer = TextSerializableDatumWriter::from_oid(self.type_oid());
+
+        for entry in &self.entries {
+            seq.serialize_element(&(
+                writer.make_serializable(entry.value),
+                entry.count,
+                entry.overcount,
+            ))?;
+        }
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for FrequencyTransState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct FrequencyTransStateVisitor();
+
+        impl<'de> Visitor<'de> for FrequencyTransStateVisitor {
+            type Value = FrequencyTransState;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a sequence encoding a FrequencyTransState object")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let total_vals = seq.next_element::<u64>()?.unwrap();
+                let min_freq = seq.next_element::<f64>()?.unwrap();
+                let complete = seq.next_element::<bool>()?.unwrap();
+                let hasher = seq.next_element::<DatumHashBuilder>()?.unwrap();
+
+                let mut state = FrequencyTransState {
+                    entries: vec![],
+                    indicies: PgAnyElementHashMap::with_hasher(hasher),
+                    total_vals,
+                    min_freq,
+                    complete,
+                };
+
+                let typid = state.type_oid();
+                let mut reader = DatumFromSerializedTextReader::from_oid(typid);
+
+                while let Some((datum_str, count, overcount)) =
+                    seq.next_element::<(&str, u64, u64)>()?
+                {
+                    let datum = reader.read_datum(datum_str);
+
+                    state.entries.push(FrequencyEntry {
+                        value: unsafe { deep_copy_datum(datum, typid) },
+                        count,
+                        overcount,
+                    });
+                }
+                state.update_all_map_indicies();
+                Ok(state)
+            }
+        }
+
+        deserializer.deserialize_seq(FrequencyTransStateVisitor())
+    }
 }
 
 impl FrequencyTransState {
     unsafe fn from_type_id(min_freq: f64, typ: pg_sys::Oid, collation: Option<Oid>) -> Self {
         FrequencyTransState {
             entries: vec![],
-            indicies: HashMap::with_hasher(DatumHashBuilder::from_type_id(typ, collation)),
+            indicies: PgAnyElementHashMap::new(typ, collation),
             total_vals: 0,
             min_freq,
-            typ,
             complete: true,
         }
     }
 
-    fn add(&mut self, element: LocalAnyElement) {
+    fn type_oid(&self) -> Oid {
+        self.indicies.typoid()
+    }
+
+    fn add(&mut self, element: PgAnyElement) {
         self.total_vals += 1;
         if let Some(idx) = self.indicies.get(&element) {
             let idx = *idx;
@@ -127,40 +194,48 @@ impl FrequencyTransState {
             // TODO: might be inefficient to call should_grow on every iteration
             if self.entries.len() < MIN_SIZE || self.should_grow() {
                 let new_idx = self.entries.len();
-                let overcount = if self.complete { 0 } else { self.entries.last().unwrap().overcount };
-                unsafe {
-                    self.entries.push(
-                        FrequencyEntry {
-                            value: deep_copy_datum(element.datum, element.typoid),
-                            count: 1 + overcount,
-                            overcount,
-                        }
-                    );
-                }
+                let overcount = if self.complete {
+                    0
+                } else {
+                    self.entries.last().unwrap().overcount
+                };
+                self.entries.push(FrequencyEntry {
+                    value: element.deep_copy_datum(),
+                    count: 1 + overcount,
+                    overcount,
+                });
+
                 // Important to create the indices entry using the datum in the local context
-                self.indicies.insert(LocalAnyElement{ datum: self.entries[new_idx].value, typoid: self.typ }, new_idx);
+                self.indicies.insert(
+                    (self.entries[new_idx].value, self.type_oid()).into(),
+                    new_idx,
+                );
             } else {
                 self.complete = false;
-                let new_value = unsafe { deep_copy_datum(element.datum, element.typoid) };
+                let new_value = element.deep_copy_datum();
 
                 // TODO: might be more efficient to replace the lowest indexed tail value (count matching last) and not call move_up
+                let typoid = self.type_oid();
                 let entry = self.entries.last_mut().unwrap();
-                self.indicies.remove(&LocalAnyElement { datum: entry.value, typoid: self.typ });
+                self.indicies.remove(&(entry.value, typoid).into());
                 entry.value = new_value; // JOSH FIXME should we pfree() old value if by-ref?
                 entry.overcount = entry.count;
                 entry.count += 1;
-                self.indicies.insert(LocalAnyElement{ datum: new_value, typoid: self.typ }, self.entries.len() - 1);
+                self.indicies
+                    .insert((new_value, typoid).into(), self.entries.len() - 1);
                 self.move_left(self.entries.len() - 1);
             }
         }
     }
 
     fn should_grow(&self) -> bool {
-        let mut used_count = 0;  // This will be the sum of the counts of elements that occur more than min_freq
+        let mut used_count = 0; // This will be the sum of the counts of elements that occur more than min_freq
 
         let mut i = 0;
-        while i < self.entries.len() && self.entries[i].count as f64 / self.total_vals as f64 > self.min_freq {
-            used_count += self.entries[i].count - self.entries[i].overcount;  // Would just using count here introduce too much error?
+        while i < self.entries.len()
+            && self.entries[i].count as f64 / self.total_vals as f64 > self.min_freq
+        {
+            used_count += self.entries[i].count - self.entries[i].overcount; // Would just using count here introduce too much error?
             i += 1
         }
 
@@ -197,44 +272,85 @@ impl FrequencyTransState {
 
     // Adds the 'indicies' lookup entry for the value at 'entries' index i
     fn update_map_index(&mut self, i: usize) {
-        let element_for_i = LocalAnyElement{ datum: self.entries[i].value, typoid: self.typ };
-        *self.indicies.get_mut(&element_for_i).unwrap() = i;
+        let element_for_i = (self.entries[i].value, self.type_oid()).into();
+        if let Some(entry) = self.indicies.get_mut(&element_for_i) {
+            *entry = i;
+        } else {
+            self.indicies.insert(element_for_i, i);
+        }
     }
-}
 
-#[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
-pub fn freq_trans(
-    state: Internal,
-    freq: f64,
-    value: Option<AnyElement>,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
-    freq_trans_inner(unsafe{ state.to_inner() }, freq, value, fcinfo).internal()
-}
-pub fn freq_trans_inner(
-    state: Option<Inner<FrequencyTransState>>,
-    freq: f64,
-    value: Option<AnyElement>,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<Inner<FrequencyTransState>> {
-    unsafe {
-        in_aggregate_context(fcinfo, || {
-            let value = match value {
-                None => return state,
-                Some(value) => value
-            };
-            let mut state = match state {
+    fn update_all_map_indicies(&mut self) {
+        for i in 0..self.entries.len() {
+            self.update_map_index(i);
+        }
+    }
+
+    fn combine(one: &FrequencyTransState, two: &FrequencyTransState) -> FrequencyTransState {
+        // This takes an entry from a TransState, updates it with any state from the other TransState, and adds the result into the map
+        fn new_entry(
+            entry: &FrequencyEntry,
+            other: &FrequencyTransState,
+            map: &mut PgAnyElementHashMap<FrequencyEntry>,
+        ) {
+            let typoid = other.type_oid();
+
+            let mut new_ent = entry.clone(typoid);
+            let new_dat = (new_ent.value, typoid).into();
+            match other.indicies.get(&new_dat) {
+                Some(&idx) => {
+                    new_ent.count += other.entries[idx].count;
+                    new_ent.overcount += other.entries[idx].overcount;
+                }
                 None => {
-                    let typ = value.oid();
-                    let collation = get_collation(fcinfo);
-                    FrequencyTransState::from_type_id(freq, typ, collation).into()
-                },
-                Some(state) => state,
-            };
+                    // If the entry value isn't present in the other state, we have to assume that it was recently bumped (unless the other state is complete).
+                    let min = if other.complete {
+                        0
+                    } else {
+                        other.entries.last().unwrap().count
+                    };
+                    new_ent.count += min;
+                    new_ent.overcount += min;
+                }
+            }
+            map.insert(new_dat, new_ent);
+        }
 
-            state.add(value.into());
-            Some(state)
-        })
+        let hasher = one.indicies.hasher().clone();
+        let mut temp = PgAnyElementHashMap::with_hasher(hasher);
+
+        // First go through the first state, and add all entries (updated with other other state) to our temporary hashmap
+        for entry in &one.entries {
+            new_entry(entry, two, &mut temp);
+        }
+
+        // Next add in anything in the second state that isn't already in the map.
+        // TODO JOSH does filter make this easier to read
+        for entry in &two.entries {
+            if !temp.contains_key(&(entry.value, one.type_oid()).into()) {
+                new_entry(entry, one, &mut temp);
+            }
+        }
+
+        // TODO: get this into_iter working without making temp.0 public
+        let mut entries: Vec<FrequencyEntry> = temp.0.into_iter().map(|(_, v)| v).collect();
+        entries.sort_by(|a, b| b.count.partial_cmp(&a.count).unwrap()); // swap a and b for descending
+
+        // TODO: mimic should_grow logic to determine how many elements are actually worth retaining
+        let max_size = (1. / one.min_freq / MAX_NOISE_RATIO) as usize;
+        let truncated = entries.len() <= max_size;
+        entries.truncate(max_size);
+
+        let mut result = FrequencyTransState {
+            entries,
+            indicies: PgAnyElementHashMap::with_hasher(one.indicies.hasher().clone()),
+            total_vals: one.total_vals + two.total_vals,
+            min_freq: one.min_freq,
+            complete: one.complete && two.complete && !truncated,
+        };
+
+        result.update_all_map_indicies();
+        result
     }
 }
 
@@ -255,33 +371,59 @@ pub mod toolkit_experimental {
         }
     }
 
-    impl <'input> From<Internal> for FrequencyAggregate<'input> {
+    impl<'input> From<Internal> for FrequencyAggregate<'input> {
         fn from(trans: Internal) -> Self {
-            Self::from(unsafe { trans.to_inner().unwrap() } )
+            Self::from(unsafe { trans.to_inner().unwrap() })
         }
     }
 
-    impl <'input> From<Inner<FrequencyTransState>> for FrequencyAggregate<'input> {
-        fn from(trans: Inner<FrequencyTransState>) -> Self {
+    impl<'input> From<&mut FrequencyTransState> for FrequencyAggregate<'input> {
+        fn from(trans: &mut FrequencyTransState) -> Self {
             let mut values = Vec::new();
             let mut counts = Vec::new();
             let mut overcounts = Vec::new();
-            
+
             for entry in &trans.entries {
                 values.push(entry.value);
                 counts.push(entry.count);
                 overcounts.push(entry.overcount);
             }
 
-            build!{
+            build! {
                 FrequencyAggregate {
-                    type_oid: trans.typ as _,
+                    type_oid: trans.type_oid() as _,
                     num_values: trans.entries.len() as _,
                     values_seen: trans.total_vals,
                     min_freq: trans.min_freq,
                     counts: counts.into(),
                     overcounts: overcounts.into(),
-                    datums: DatumStore::from((trans.typ, values)),
+                    datums: DatumStore::from((trans.type_oid(), values)),
+                }
+            }
+        }
+    }
+
+    impl<'input> From<Inner<FrequencyTransState>> for FrequencyAggregate<'input> {
+        fn from(trans: Inner<FrequencyTransState>) -> Self {
+            let mut values = Vec::new();
+            let mut counts = Vec::new();
+            let mut overcounts = Vec::new();
+
+            for entry in &trans.entries {
+                values.push(entry.value);
+                counts.push(entry.count);
+                overcounts.push(entry.overcount);
+            }
+
+            build! {
+                FrequencyAggregate {
+                    type_oid: trans.type_oid() as _,
+                    num_values: trans.entries.len() as _,
+                    values_seen: trans.total_vals,
+                    min_freq: trans.min_freq,
+                    counts: counts.into(),
+                    overcounts: overcounts.into(),
+                    datums: DatumStore::from((trans.type_oid(), values)),
                 }
             }
         }
@@ -290,55 +432,86 @@ pub mod toolkit_experimental {
     ron_inout_funcs!(FrequencyAggregate);
 }
 
-// PG function to generate a user-facing TopN object from a InternalTopN.
-#[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
-fn freq_final(
-    state: Internal,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<toolkit_experimental::FrequencyAggregate<'static>> {
-    unsafe {
-        freq_final_inner(state.to_inner(), fcinfo)
+#[aggregate]
+impl toolkit_experimental::freq_agg {
+    type State = FrequencyTransState;
+
+    const PARALLEL_SAFE: bool = true;
+
+    fn transition(
+        state: Option<State>,
+        #[sql_type("double precision")] freq: f64,
+        #[sql_type("AnyElement")] value: Option<AnyElement>,
+        fcinfo: pg_sys::FunctionCallInfo,
+    ) -> Option<State> {
+        let value = match value {
+            None => return state,
+            Some(value) => value,
+        };
+        let mut state = match state {
+            None => unsafe {
+                let typ = value.oid();
+                let collation = if fcinfo.is_null() {
+                    Some(100) // TODO: default OID, there should be a constant for this
+                } else {
+                    get_collation(fcinfo)
+                };
+                FrequencyTransState::from_type_id(freq, typ, collation)
+            },
+            Some(state) => state,
+        };
+
+        state.add(value.into());
+        Some(state)
+    }
+
+    fn finally(
+        state: Option<&mut State>,
+    ) -> Option<toolkit_experimental::FrequencyAggregate<'static>> {
+        state.map(FrequencyAggregate::from)
+    }
+
+    fn serialize(state: &State) -> bytea {
+        crate::do_serialize!(state)
+    }
+
+    fn deserialize(bytes: crate::raw::bytea) -> State {
+        crate::do_deserialize!(bytes, FrequencyTransState)
+    }
+
+    fn combine(a: Option<&State>, b: Option<&State>) -> Option<State> {
+        match (a, b) {
+            (Some(a), Some(b)) => Some(FrequencyTransState::combine(a, b)),
+            (Some(a), None) => Some(a.clone()),
+            (None, Some(b)) => Some(b.clone()),
+            (None, None) => None,
+        }
     }
 }
-fn freq_final_inner(
-    state: Option<Inner<FrequencyTransState>>,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<toolkit_experimental::FrequencyAggregate<'static>> {
-    unsafe {
-        in_aggregate_context(fcinfo, || {
-            let state = match state {
-                None => return None,
-                Some(state) => state,
-            };
 
-            Some(FrequencyAggregate::from(state))
-        })
-    }
-}
-
-// TODO: add combinefunc, serialfunc, deserialfunc, and make this parallel safe
-extension_sql!("\n\
-    CREATE AGGREGATE toolkit_experimental.freq_agg(size double precision, value AnyElement)\n\
-    (\n\
-        sfunc = toolkit_experimental.freq_trans,\n\
-        stype = internal,\n\
-        finalfunc = toolkit_experimental.freq_final\n\
-    );\n\
-    ",
-name = "freq_agg"); // TODO requires
-
-#[pg_extern(immutable, parallel_safe, name="values", schema = "toolkit_experimental")]
-pub fn freq_iter (
+#[pg_extern(
+    immutable,
+    parallel_safe,
+    name = "values",
+    schema = "toolkit_experimental"
+)]
+pub fn freq_iter(
     agg: FrequencyAggregate<'_>,
-    ty: AnyElement
-) -> impl std::iter::Iterator<Item = (name!(value,AnyElement),name!(min_freq,f64),name!(max_freq,f64))> + '_ {
+    ty: AnyElement,
+) -> impl std::iter::Iterator<
+    Item = (
+        name!(value, AnyElement),
+        name!(min_freq, f64),
+        name!(max_freq, f64),
+    ),
+> + '_ {
     unsafe {
         if ty.oid() != agg.type_oid {
             pgx::error!("mischatched types")
         }
         let counts = agg.counts.slice().iter().zip(agg.overcounts.slice().iter());
-        agg.datums.clone().into_iter().zip(counts)
-            .map_while(move |(value, (&count, &overcount))| {
+        agg.datums.clone().into_iter().zip(counts).map_while(
+            move |(value, (&count, &overcount))| {
                 let total = agg.values_seen as f64;
                 if count as f64 / total < agg.min_freq {
                     None
@@ -348,29 +521,34 @@ pub fn freq_iter (
                     let max_freq = count as f64 / total;
                     Some((value, min_freq, max_freq))
                 }
-            })
+            },
+        )
     }
 }
 
 #[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
-pub fn topn (
+pub fn topn(
     agg: FrequencyAggregate<'_>,
     n: i32,
-    ty: AnyElement
+    ty: AnyElement,
 ) -> impl std::iter::Iterator<Item = AnyElement> + '_ {
     unsafe {
         if ty.oid() != agg.type_oid {
             pgx::error!("mischatched types")
         }
-        let iter = agg.datums.clone().into_iter().zip(agg.counts.slice().iter());
+        let iter = agg
+            .datums
+            .clone()
+            .into_iter()
+            .zip(agg.counts.slice().iter());
         iter.enumerate().map_while(move |(i, (value, &count))| {
-                let total = agg.values_seen as f64;
-                if i >= n as usize || count as f64 / total < agg.min_freq {
-                    None
-                } else {
-                    AnyElement::from_datum(value, false, agg.type_oid)
-                }
-            })
+            let total = agg.values_seen as f64;
+            if i >= n as usize || count as f64 / total < agg.min_freq {
+                None
+            } else {
+                AnyElement::from_datum(value, false, agg.type_oid)
+            }
+        })
     }
 }
 
@@ -384,12 +562,28 @@ mod tests {
     fn test_freq_aggregate() {
         Spi::execute(|client| {
             // using the search path trick for this test to make it easier to stabilize later on
-            let sp = client.select("SELECT format(' %s, toolkit_experimental',current_setting('search_path'))", None, None).first().get_one::<String>().unwrap();
+            let sp = client
+                .select(
+                    "SELECT format(' %s, toolkit_experimental',current_setting('search_path'))",
+                    None,
+                    None,
+                )
+                .first()
+                .get_one::<String>()
+                .unwrap();
             client.select(&format!("SET LOCAL search_path TO {}", sp), None, None);
-            client.select("SET timescaledb_toolkit_acknowledge_auto_drop TO 'true'", None, None);
+            client.select(
+                "SET timescaledb_toolkit_acknowledge_auto_drop TO 'true'",
+                None,
+                None,
+            );
 
             client.select("SET TIMEZONE to UTC", None, None);
-            client.select("CREATE TABLE test (data INTEGER, time TIMESTAMPTZ)", None, None);
+            client.select(
+                "CREATE TABLE test (data INTEGER, time TIMESTAMPTZ)",
+                None,
+                None,
+            );
 
             for i in (0..100).rev() {
                 client.select(&format!("INSERT INTO test SELECT i, '2020-1-1'::TIMESTAMPTZ + ('{} days, ' || i::TEXT || ' seconds')::INTERVAL FROM generate_series({}, 99, 1) i", 100 - i, i), None, None);
@@ -401,5 +595,206 @@ mod tests {
             let expected = "(version:1,type_oid:23,num_values:78,values_seen:5050,min_freq:0.015,counts:[100,99,98,97,96,95,94,93,92,91,90,89,88,87,86,85,84,84,83,82,81,81,80,80,79,78,78,77,76,76,76,75,75,75,75,75,75,75,75,75,75,75,75,75,75,75,75,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74],overcounts:[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,2,1,1,1,3,2,4,3,3,6,3,5,7,5,5,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,74,73,73,73,73,73,73,73,73,73,73,73,73,73,73,73,73,73,73,73,73,73,73,73,73,73,73,73,73,73,73,73],datums:[23,\"99\",\"98\",\"97\",\"96\",\"95\",\"94\",\"93\",\"92\",\"91\",\"90\",\"89\",\"88\",\"87\",\"86\",\"85\",\"84\",\"81\",\"82\",\"83\",\"80\",\"77\",\"78\",\"75\",\"76\",\"79\",\"73\",\"74\",\"71\",\"69\",\"70\",\"72\",\"53\",\"54\",\"55\",\"56\",\"57\",\"58\",\"59\",\"60\",\"61\",\"62\",\"63\",\"64\",\"65\",\"66\",\"67\",\"68\",\"22\",\"23\",\"24\",\"25\",\"26\",\"27\",\"28\",\"29\",\"30\",\"31\",\"32\",\"33\",\"34\",\"35\",\"36\",\"37\",\"38\",\"39\",\"40\",\"41\",\"42\",\"43\",\"44\",\"45\",\"46\",\"47\",\"48\",\"49\",\"50\",\"51\",\"21\"])";
             assert_eq!(test, expected);
         });
+    }
+
+    #[pg_test]
+    fn explicit_aggregate_test() {
+        let freq = 0.0625;
+        let fcinfo = std::ptr::null_mut(); // dummy value, will use default collation
+        let mut state = None;
+
+        for i in 11..=20 {
+            for j in i..=20 {
+                let value =
+                    unsafe { AnyElement::from_datum(j as pg_sys::Datum, false, pg_sys::INT4OID) };
+                state = super::freq_agg::transition(state, freq, value, fcinfo);
+            }
+        }
+
+        let first = super::freq_agg::serialize(&state.unwrap());
+
+        let bytes = unsafe {
+            std::slice::from_raw_parts(
+                vardata_any(first.0 as *const pg_sys::varlena) as *const u8,
+                varsize_any_exhdr(first.0 as *const pg_sys::varlena),
+            )
+        };
+        let expected = [
+            1, 1, // versions
+            14, 0, 0, 0, 0, 0, 0, 0, // size hint for sequence
+            55, 0, 0, 0, 0, 0, 0, 0, // elements seen
+            0, 0, 0, 0, 0, 0, 176, 63, // frequency (f64 encoding of 0.0625)
+            1,  // complete
+            7, 0, 0, 0, 1, 1, 10, 0, 0, 0, 0, 0, 0, 0, 112, 103, 95, 99, 97, 116, 97, 108, 111,
+            103, 11, 0, 0, 0, 0, 0, 0, 0, 101, 110, 95, 85, 83, 46, 85, 84, 70, 45,
+            56, // INT4 hasher
+            2, 0, 0, 0, 0, 0, 0, 0, 50, 48, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 20, count 10, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 57, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 19, count 9, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 56, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 18, count 8, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 55, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 17, count 7, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 54, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 16, count 6, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 53, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 15, count 5, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 52, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 14, count 4, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 51, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 13, count 3, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 50, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 12, count 2, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 49, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 11, count 1, overcount 0
+        ];
+        // encoding of hasher can vary on platform and across postgres version (even in length), ignore it and check the other fields
+        let prefix_len = 8 * 3 + 3;
+        let suffix_len = (8 + 2 + 16) * 10;
+        assert_eq!(bytes[..prefix_len], expected[..prefix_len]);
+        assert_eq!(
+            bytes[bytes.len() - suffix_len..],
+            expected[expected.len() - suffix_len..]
+        );
+
+        state = None;
+
+        for i in (1..=10).rev() {
+            // reverse here introduces less error in the aggregate
+            for j in i..=20 {
+                let value =
+                    unsafe { AnyElement::from_datum(j as pg_sys::Datum, false, pg_sys::INT4OID) };
+                state = super::freq_agg::transition(state, freq, value, fcinfo);
+            }
+        }
+
+        let second = super::freq_agg::serialize(&state.unwrap());
+
+        let bytes = unsafe {
+            std::slice::from_raw_parts(
+                vardata_any(second.0 as *const pg_sys::varlena) as *const u8,
+                varsize_any_exhdr(second.0 as *const pg_sys::varlena),
+            )
+        };
+        let expected = [
+            1, 1, // versions
+            21, 0, 0, 0, 0, 0, 0, 0, // size hint for sequence
+            155, 0, 0, 0, 0, 0, 0, 0, // elements seen
+            0, 0, 0, 0, 0, 0, 176, 63, // frequency (f64 encoding of 0.0625)
+            0,  // complete
+            7, 0, 0, 0, 1, 1, 10, 0, 0, 0, 0, 0, 0, 0, 112, 103, 95, 99, 97, 116, 97, 108, 111,
+            103, 11, 0, 0, 0, 0, 0, 0, 0, 101, 110, 95, 85, 83, 46, 85, 84, 70, 45,
+            56, // INT4 hasher
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 48, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 10, count 10, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 49, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 11, count 10, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 50, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 12, count 10, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 51, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 13, count 10, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 52, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 14, count 10, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 53, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 15, count 10, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 54, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 16, count 10, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 55, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 17, count 10, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 56, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 18, count 10, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 57, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 19, count 10, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 50, 48, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 20, count 10, overcount 0
+            1, 0, 0, 0, 0, 0, 0, 0, 55, 9, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0,
+            0, // string 7, count 9, overcount 5
+            1, 0, 0, 0, 0, 0, 0, 0, 57, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 9, count 9, overcount 0
+            1, 0, 0, 0, 0, 0, 0, 0, 52, 8, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0,
+            0, // string 4, count 8, overcount 4
+            1, 0, 0, 0, 0, 0, 0, 0, 53, 8, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0,
+            0, // string 5, count 8, overcount 4
+            1, 0, 0, 0, 0, 0, 0, 0, 56, 8, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0,
+            0, // string 8, count 8, overcount 7
+            1, 0, 0, 0, 0, 0, 0, 0, 51, 7, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0,
+            0, // string 3, count 7, overcount 6
+        ];
+        // encoding of hasher can vary on platform and across postgres version (even in length), ignore it and check the other fields
+        let prefix_len = 8 * 3 + 3;
+        let suffix_len = (8 + 2 + 16) * 11 + (8 + 1 + 16) * 6;
+        assert_eq!(bytes[..prefix_len], expected[..prefix_len]);
+        assert_eq!(
+            bytes[bytes.len() - suffix_len..],
+            expected[expected.len() - suffix_len..]
+        );
+
+        let combined = super::freq_agg::serialize(
+            &super::freq_agg::combine(
+                Some(&super::freq_agg::deserialize(first)),
+                Some(&super::freq_agg::deserialize(second)),
+            )
+            .unwrap(),
+        );
+
+        let bytes = unsafe {
+            std::slice::from_raw_parts(
+                vardata_any(combined.0 as *const pg_sys::varlena) as *const u8,
+                varsize_any_exhdr(combined.0 as *const pg_sys::varlena),
+            )
+        };
+        let expected = [
+            1, 1, // versions
+            21, 0, 0, 0, 0, 0, 0, 0, // size hint for sequence
+            210, 0, 0, 0, 0, 0, 0, 0, // elements seen
+            0, 0, 0, 0, 0, 0, 176, 63, // frequency (f64 encoding of 0.0625)
+            0,  // complete
+            7, 0, 0, 0, 1, 1, 10, 0, 0, 0, 0, 0, 0, 0, 112, 103, 95, 99, 97, 116, 97, 108, 111,
+            103, 11, 0, 0, 0, 0, 0, 0, 0, 101, 110, 95, 85, 83, 46, 85, 84, 70, 45,
+            56, // INT4 hasher
+            2, 0, 0, 0, 0, 0, 0, 0, 50, 48, 20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 20, count 20, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 57, 19, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 19, count 19, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 56, 18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 18, count 18, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 55, 17, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 17, count 17, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 54, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 16, count 16, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 53, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 15, count 15, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 52, 14, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 14, count 14, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 51, 13, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 13, count 13, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 50, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 12, count 12, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 49, 11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 11, count 11, overcount 0
+            2, 0, 0, 0, 0, 0, 0, 0, 49, 48, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 10, count 10, overcount 0
+            1, 0, 0, 0, 0, 0, 0, 0, 57, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, // string 9, count 9, overcount 0
+            1, 0, 0, 0, 0, 0, 0, 0, 55, 9, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0,
+            0, // string 7, count 9, overcount 5
+            1, 0, 0, 0, 0, 0, 0, 0, 56, 8, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0,
+            0, // string 8, count 8, overcount 7
+            1, 0, 0, 0, 0, 0, 0, 0, 52, 8, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0,
+            0, // string 4, count 8, overcount 4
+            1, 0, 0, 0, 0, 0, 0, 0, 53, 8, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0,
+            0, // string 5, count 8, overcount 4
+            1, 0, 0, 0, 0, 0, 0, 0, 51, 7, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0,
+            0, // string 3, count 7, overcount 6
+        ];
+        // encoding of hasher can vary on platform and across postgres version (even in length), ignore it and check the other fields
+        let prefix_len = 8 * 3 + 3;
+        let suffix_len = (8 + 2 + 16) * 11 + (8 + 1 + 16) * 6;
+        assert_eq!(bytes[..prefix_len], expected[..prefix_len]);
+        assert_eq!(
+            bytes[bytes.len() - suffix_len..],
+            expected[expected.len() - suffix_len..]
+        );
     }
 }

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -23,6 +23,7 @@ mod serialization;
 mod schema_test;
 mod raw;
 mod datum_utils;
+mod pg_any_element;
 
 #[cfg(any(test, feature = "pg_test"))]
 mod aggregate_builder_tests;

--- a/extension/src/pg_any_element.rs
+++ b/extension/src/pg_any_element.rs
@@ -1,0 +1,134 @@
+use std::{
+    collections::HashMap,
+    hash::{Hash, Hasher},
+    mem::size_of,
+};
+
+use pgx::*;
+
+use pg_sys::{Datum, Oid};
+
+use crate::datum_utils::{deep_copy_datum, DatumHashBuilder};
+
+// Unable to implement PartialEq for AnyElement, so creating a local copy
+pub struct PgAnyElement {
+    datum: Datum,
+    typoid: Oid,
+}
+
+impl PgAnyElement {
+    // pub fn from_datum_clone(datum : Datum, typoid : Oid) -> PgAnyElement {
+    //     PgAnyElement {
+    //         datum : unsafe{deep_copy_datum(datum, typoid)},
+    //         typoid
+    //     }
+    // }
+
+    pub fn deep_copy_datum(&self) -> Datum {
+        unsafe { deep_copy_datum(self.datum, self.typoid) }
+    }
+}
+
+impl PartialEq for PgAnyElement {
+    #[allow(clippy::field_reassign_with_default)]
+    fn eq(&self, other: &Self) -> bool {
+        unsafe {
+            if self.typoid != other.typoid {
+                false
+            } else {
+                // TODO JOSH can we avoid the type cache lookup here
+                let typ = self.typoid;
+                let tentry = pg_sys::lookup_type_cache(typ, pg_sys::TYPECACHE_EQ_OPR_FINFO as _);
+
+                let flinfo = if (*tentry).eq_opr_finfo.fn_addr.is_some() {
+                    &(*tentry).eq_opr_finfo
+                } else {
+                    pgx::error!("no equality function");
+                };
+
+                let size = size_of::<pg_sys::FunctionCallInfoBaseData>()
+                    + size_of::<pg_sys::NullableDatum>() * 2;
+                let mut info = pg_sys::palloc0(size) as pg_sys::FunctionCallInfo;
+
+                (*info).flinfo = flinfo as *const pg_sys::FmgrInfo as *mut pg_sys::FmgrInfo;
+                (*info).context = std::ptr::null_mut();
+                (*info).resultinfo = std::ptr::null_mut();
+                (*info).fncollation = (*tentry).typcollation;
+                (*info).isnull = false;
+                (*info).nargs = 2;
+
+                (*info).args.as_mut_slice(2)[0] = pg_sys::NullableDatum {
+                    value: self.datum,
+                    isnull: false,
+                };
+                (*info).args.as_mut_slice(2)[1] = pg_sys::NullableDatum {
+                    value: other.datum,
+                    isnull: false,
+                };
+                (*(*info).flinfo).fn_addr.unwrap()(info) != 0
+            }
+        }
+    }
+}
+
+impl Eq for PgAnyElement {}
+
+impl Hash for PgAnyElement {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.datum.hash(state);
+    }
+}
+
+impl From<(Datum, Oid)> for PgAnyElement {
+    fn from(other: (Datum, Oid)) -> Self {
+        let (datum, typoid) = other;
+        PgAnyElement { datum, typoid }
+    }
+}
+
+impl From<AnyElement> for PgAnyElement {
+    fn from(other: AnyElement) -> Self {
+        PgAnyElement {
+            datum: other.datum(),
+            typoid: other.oid(),
+        }
+    }
+}
+
+pub struct PgAnyElementHashMap<V>(pub(crate) HashMap<PgAnyElement, V, DatumHashBuilder>);
+
+impl<V> PgAnyElementHashMap<V> {
+    pub fn new(typoid: Oid, collation: Option<Oid>) -> Self {
+        PgAnyElementHashMap(HashMap::with_hasher(unsafe {
+            DatumHashBuilder::from_type_id(typoid, collation)
+        }))
+    }
+
+    pub(crate) fn with_hasher(hasher: DatumHashBuilder) -> Self {
+        PgAnyElementHashMap(HashMap::with_hasher(hasher))
+    }
+
+    pub fn typoid(&self) -> Oid {
+        self.0.hasher().type_id
+    }
+
+    // Passthroughs
+    pub fn contains_key(&self, k: &PgAnyElement) -> bool {
+        self.0.contains_key(k)
+    }
+    pub fn get(&self, k: &PgAnyElement) -> Option<&V> {
+        self.0.get(k)
+    }
+    pub fn get_mut(&mut self, k: &PgAnyElement) -> Option<&mut V> {
+        self.0.get_mut(k)
+    }
+    pub(crate) fn hasher(&self) -> &DatumHashBuilder {
+        self.0.hasher()
+    }
+    pub fn insert(&mut self, k: PgAnyElement, v: V) -> Option<V> {
+        self.0.insert(k, v)
+    }
+    pub fn remove(&mut self, k: &PgAnyElement) -> Option<V> {
+        self.0.remove(k)
+    }
+}


### PR DESCRIPTION
This change packages up the Datum serialization in datum_utils
and uses to serialize the trans state for frequency aggregates.

It also refactors the LocalAnyElement struct from frequency.rs
into it's own PgAnyElement under pg_any_element.rs.