### PR TITLE
Run post-install and doc tests separate from pgx tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,22 @@ jobs:
     container:
       image: timescaledev/rust-pgx:latest
       env:
+        # Must keep in sync with `path: target` in cache entry below
+        CARGO_TARGET_DIR_NAME: target
+        # TODO Why?  Cargo default is to pass `-C incremental` to rustc; why don't we want that?
+        #   https://doc.rust-lang.org/rustc/codegen-options/index.html#incremental
+        #   Well turning it off takes the extension target size down from 3G to 2G...
         CARGO_INCREMENTAL: 0
+        # TODO Why?  If we're concerned about trouble fetching crates, why not
+        #  just fetch them once at the time we select a dependency?
+        #  Errors fetching crates are probably rare enough that we don't see the
+        #  need to bother, but then why not just let the build fail?
         CARGO_NET_RETRY: 10
+        # TODO What reads this?  It's not listed on
+        #  https://doc.rust-lang.org/cargo/reference/environment-variables.html
         CI: 1
         RUST_BACKTRACE: short
+        # TODO We don't seem to run rustup, nor does it seem like we should.
         RUSTUP_MAX_RETRIES: 10
 
     steps:
@@ -30,41 +42,50 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
+    # ~postgres/.pgx/config.toml comes in on the image.
+    # Setting HOME=~postgres (which is /home/postgres) in cargo's environment
+    # would work, but sticking with this approach for now.
     - name: chown Repository
       run: chown -R postgres .
 
+    # CARGO_HOME is /usr/local/cargo which looks like something we'd need to
+    # stay root to update, but the parts we need to update (.crates.toml,
+    # .crates2.json, .package-cache, git, registry) are already owned by
+    # `postgres` in the image.
     - name: Cache cargo directories
       uses: actions/cache@v2
       with:
         path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-        key: ${{ runner.os }}-cargo-clippy-cargo
-        restore-keys: |
-          ${{ runner.os }}-cargo-build-target-clippy-cargo-0
+          /usr/local/cargo/registry
+          /usr/local/cargo/git
+        key: TESTING6-${{ runner.os }}-clippy-cargo
 
     - name: Cache cargo target dir
       uses: actions/cache@v2
       with:
         path: target
-        key: ${{ runner.os }}-cargo-build-target-clippy-target
-        restore-keys: |
-          ${{ runner.os }}-cargo-build-target-clippy-target-0
+        key: TESTING6-${{ runner.os }}-clippy-target
 
     - name: Run Clippy
-      run: sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo clippy --workspace --features 'pg14 pg_test' -- -D warnings"
+      # Github captures stdout and stderr separately and then intermingles them
+      # in the wrong order.  We don't actually care to distinguish, so redirect
+      # stderr to stdout so we get the proper order.
+      run: su postgres -c 'sh tools/build clippy 2>&1'
 
   test12:
     name: Test PG 12
     runs-on: ubuntu-latest
     container:
       image: timescaledev/rust-pgx:latest
-      env:
-        CARGO_INCREMENTAL: 0
-        CARGO_NET_RETRY: 10
-        CI: 1
-        RUST_BACKTRACE: short
-        RUSTUP_MAX_RETRIES: 10
+
+    env:
+      PGVERSION: 12
+      CARGO_TARGET_DIR_NAME: target
+      CARGO_INCREMENTAL: 0
+      CARGO_NET_RETRY: 10
+      CI: 1
+      RUST_BACKTRACE: short
+      RUSTUP_MAX_RETRIES: 10
 
     steps:
     - name: Checkout Repository
@@ -79,50 +100,42 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-        key: ${{ runner.os }}-cargo-pg12-cargo
-        restore-keys: |
-          ${{ runner.os }}-cargo-pg12-3
-          ${{ runner.os }}-cargo-pg12-2
-          ${{ runner.os }}-cargo-pg12
+          /usr/local/cargo/registry
+          /usr/local/cargo/git
+        key: TESTING6-${{ runner.os }}-test-pg${{ env.PGVERSION }}-cargo
 
     - name: Cache cargo target dir
       uses: actions/cache@v2
       with:
         path: target
-        key: ${{ runner.os }}-cargo-build-target-pg12-4
-        restore-keys: |
-          ${{ runner.os }}-cargo-build-target-pg12-3
-          ${{ runner.os }}-cargo-build-target-pg12-2
-          ${{ runner.os }}-cargo-build-target-pg12
+        key: TESTING6-${{ runner.os }}-test-pg${{ env.PGVERSION }}-target
 
-    - name: Run PG 12 Tests
-      run: sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo test --workspace --features 'pg12 pg_test'"
+    - name: Run pgx tests
+      run: su postgres -c 'sh tools/build -pg$PGVERSION test-extension 2>&1'
 
+    # TODO post-install + doc test adds a good 90s.  We could probably put
+    # them together run serially in a separate job to shave that 90s off the
+    # long pole.
     - name: Run post-install tests
-      run: |
-        sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo pgx stop pg12 && /usr/local/cargo/bin/cargo pgx start pg12"
-        RUST_BACKTRACE=short cargo run --manifest-path ./tools/post-install/Cargo.toml /home/postgres/.pgx/12.9/pgx-install/bin/pg_config
-        cargo run --manifest-path ./tools/testrunner/Cargo.toml -- -h localhost -p 28812
+      run: su postgres -c 'sh tools/build -pg$PGVERSION test-post-install 2>&1'
 
-    - name: Run Doc Tests
-      run: |
-        sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo pgx stop pg12 && /usr/local/cargo/bin/cargo pgx start pg12"
-        sql-doctester -h localhost -s "CREATE EXTENSION timescaledb; CREATE EXTENSION timescaledb_toolkit; SET SESSION TIMEZONE TO 'UTC'" -p 28812 docs
-
+    - name: Run doc tests
+      run: su postgres -c 'sh tools/build -pg$PGVERSION test-doc 2>&1'
 
   test13:
     name: Test PG 13
     runs-on: ubuntu-latest
     container:
       image: timescaledev/rust-pgx:latest
-      env:
-        CARGO_INCREMENTAL: 0
-        CARGO_NET_RETRY: 10
-        CI: 1
-        RUST_BACKTRACE: short
-        RUSTUP_MAX_RETRIES: 10
+
+    env:
+      PGVERSION: 13
+      CARGO_TARGET_DIR_NAME: target
+      CARGO_INCREMENTAL: 0
+      CARGO_NET_RETRY: 10
+      CI: 1
+      RUST_BACKTRACE: short
+      RUSTUP_MAX_RETRIES: 10
 
     steps:
     - name: Checkout Repository
@@ -137,44 +150,79 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-        key: ${{ runner.os }}-cargo-build-cargo-pg13
-        restore-keys: |
-          ${{ runner.os }}-cargo-build-target-pg13-3
-          ${{ runner.os }}-cargo-build-target-pg13-2
-          ${{ runner.os }}-cargo-pg13
+          /usr/local/cargo/registry
+          /usr/local/cargo/git
+        key: TESTING6-${{ runner.os }}-test-pg${{ env.PGVERSION }}-cargo
 
     - name: Cache cargo target dir
       uses: actions/cache@v2
       with:
         path: target
-        key: ${{ runner.os }}-cargo-build-target-pg13-4
-        restore-keys: |
-          ${{ runner.os }}-cargo-build-target-pg13-3
-          ${{ runner.os }}-cargo-build-target-pg13-2
-          ${{ runner.os }}-cargo-build-target-pg13
+        key: TESTING6-${{ runner.os }}-test-pg${{ env.PGVERSION }}-target
 
-    - name: Run PG 13 Tests
-      run: sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo test --workspace --features 'pg13 pg_test'"
+    - name: Run pgx tests
+      run: su postgres -c "sh tools/build -pg$PGVERSION test-extension 2>&1"
 
     - name: Run post-install tests
-      run: |
-        sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo pgx stop pg13 && /usr/local/cargo/bin/cargo pgx start pg13"
-        RUST_BACKTRACE=short cargo run --manifest-path ./tools/post-install/Cargo.toml /home/postgres/.pgx/13.5/pgx-install/bin/pg_config
-        cargo run --manifest-path ./tools/testrunner/Cargo.toml -- -h localhost -p 28813
+      run: su postgres -c 'sh tools/build -pg$PGVERSION test-post-install 2>&1'
 
-    - name: Run Doc Tests
-      run: |
-        sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo pgx stop pg13 && /usr/local/cargo/bin/cargo pgx start pg13"
-        sql-doctester -h localhost -s "CREATE EXTENSION timescaledb; CREATE EXTENSION timescaledb_toolkit; SET SESSION TIMEZONE TO 'UTC'" -p 28813 docs
+    - name: Run doc tests
+      run: su postgres -c 'sh tools/build -pg$PGVERSION test-doc 2>&1'
 
   test14:
     name: Test PG 14
     runs-on: ubuntu-latest
     container:
       image: timescaledev/rust-pgx:latest
+
+    env:
+      PGVERSION: 14
+      CARGO_TARGET_DIR_NAME: target
+      CARGO_INCREMENTAL: 0
+      CARGO_NET_RETRY: 10
+      CI: 1
+      RUST_BACKTRACE: short
+      RUSTUP_MAX_RETRIES: 10
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: chown Repository
+      run: chown -R postgres .
+
+    - name: Cache cargo directories
+      uses: actions/cache@v2
+      with:
+        path: |
+          /usr/local/cargo/registry
+          /usr/local/cargo/git
+        key: TESTING6-${{ runner.os }}-test-pg${{ env.PGVERSION }}-cargo
+
+    - name: Cache cargo target dir
+      uses: actions/cache@v2
+      with:
+        path: target
+        key: TESTING6-${{ runner.os }}-test-pg${{ env.PGVERSION }}-target
+
+    - name: Run pgx tests
+      run: su postgres -c "sh tools/build -pg$PGVERSION test-extension 2>&1"
+
+    - name: Run post-install tests
+      run: su postgres -c 'sh tools/build -pg$PGVERSION test-post-install 2>&1'
+
+    - name: Run doc tests
+      run: su postgres -c 'sh tools/build -pg$PGVERSION test-doc 2>&1'
+
+  testcrates:
+    name: Test Crates
+    runs-on: ubuntu-latest
+    container:
+      image: timescaledev/rust-pgx:latest
       env:
+        CARGO_TARGET_DIR_NAME: target
         CARGO_INCREMENTAL: 0
         CARGO_NET_RETRY: 10
         CI: 1
@@ -194,34 +242,15 @@ jobs:
       uses: actions/cache@v2
       with:
         path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-        key: ${{ runner.os }}-cargo-build-cargo-pg14
-        restore-keys: |
-          ${{ runner.os }}-cargo-build-target-pg14-3
-          ${{ runner.os }}-cargo-build-target-pg14-2
-          ${{ runner.os }}-cargo-pg14
+          /usr/local/cargo/registry
+          /usr/local/cargo/git
+        key: TESTING6-${{ runner.os }}-test-crates-cargo
 
     - name: Cache cargo target dir
       uses: actions/cache@v2
       with:
         path: target
-        key: ${{ runner.os }}-cargo-build-target-pg14-4
-        restore-keys: |
-          ${{ runner.os }}-cargo-build-target-pg14-3
-          ${{ runner.os }}-cargo-build-target-pg14-2
-          ${{ runner.os }}-cargo-build-target-pg14
+        key: TESTING6-${{ runner.os }}-test-crates-target
 
-    - name: Run PG 14 Tests
-      run: sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo test --workspace --features 'pg14 pg_test'"
-
-    - name: Run post-install tests
-      run: |
-        sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo pgx stop pg14 && /usr/local/cargo/bin/cargo pgx start pg14"
-        RUST_BACKTRACE=short cargo run --manifest-path ./tools/post-install/Cargo.toml /home/postgres/.pgx/14.1/pgx-install/bin/pg_config
-        cargo run --manifest-path ./tools/testrunner/Cargo.toml -- -h localhost -p 28814
-
-    - name: Run Doc Tests
-      run: |
-        sudo -HEsu postgres sh -c "/usr/local/cargo/bin/cargo pgx stop pg14 && /usr/local/cargo/bin/cargo pgx start pg14"
-        sql-doctester -h localhost -s "CREATE EXTENSION timescaledb; CREATE EXTENSION timescaledb_toolkit; SET SESSION TIMEZONE TO 'UTC'" -p 28814 docs
+    - name: Run Crates Tests
+      run: su postgres -c 'sh tools/build test-crates 2>&1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,13 +58,13 @@ jobs:
         path: |
           /usr/local/cargo/registry
           /usr/local/cargo/git
-        key: TESTING6-${{ runner.os }}-clippy-cargo
+        key: TESTING8-${{ runner.os }}-clippy-cargo
 
     - name: Cache cargo target dir
       uses: actions/cache@v2
       with:
         path: target
-        key: TESTING6-${{ runner.os }}-clippy-target
+        key: TESTING8-${{ runner.os }}-clippy-target
 
     - name: Run Clippy
       # Github captures stdout and stderr separately and then intermingles them
@@ -72,7 +72,7 @@ jobs:
       # stderr to stdout so we get the proper order.
       run: su postgres -c 'sh tools/build clippy 2>&1'
 
-  test12:
+  testpg12:
     name: Test PG 12
     runs-on: ubuntu-latest
     container:
@@ -102,27 +102,65 @@ jobs:
         path: |
           /usr/local/cargo/registry
           /usr/local/cargo/git
-        key: TESTING6-${{ runner.os }}-test-pg${{ env.PGVERSION }}-cargo
+        key: TESTING8-${{ runner.os }}-test-pg${{ env.PGVERSION }}-cargo
 
     - name: Cache cargo target dir
       uses: actions/cache@v2
       with:
         path: target
-        key: TESTING6-${{ runner.os }}-test-pg${{ env.PGVERSION }}-target
+        key: TESTING8-${{ runner.os }}-test-pg${{ env.PGVERSION }}-target
 
     - name: Run pgx tests
       run: su postgres -c 'sh tools/build -pg$PGVERSION test-extension 2>&1'
 
-    # TODO post-install + doc test adds a good 90s.  We could probably put
-    # them together run serially in a separate job to shave that 90s off the
-    # long pole.
+  testpost12:
+    name: Test post-install and doc 12
+    runs-on: ubuntu-latest
+    container:
+      image: timescaledev/rust-pgx:latest
+
+    env:
+      PGVERSION: 12
+      CARGO_TARGET_DIR_NAME: target
+      CARGO_INCREMENTAL: 0
+      CARGO_NET_RETRY: 10
+      CI: 1
+      RUST_BACKTRACE: short
+      RUSTUP_MAX_RETRIES: 10
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: chown Repository
+      run: chown -R postgres .
+
+    - name: Cache cargo directories
+      uses: actions/cache@v2
+      with:
+        path: |
+          /usr/local/cargo/registry
+          /usr/local/cargo/git
+        key: TESTING8-${{ runner.os }}-test-post${{ env.PGVERSION }}-cargo
+
+    - name: Cache cargo target dir
+      uses: actions/cache@v2
+      with:
+        path: target
+        key: TESTING8-${{ runner.os }}-test-post${{ env.PGVERSION }}-target
+
+    - name: Install extension
+      run: su postgres -c 'sh tools/build -pg$PGVERSION install 2>&1'
+
     - name: Run post-install tests
       run: su postgres -c 'sh tools/build -pg$PGVERSION test-post-install 2>&1'
 
     - name: Run doc tests
       run: su postgres -c 'sh tools/build -pg$PGVERSION test-doc 2>&1'
 
-  test13:
+  testpg13:
     name: Test PG 13
     runs-on: ubuntu-latest
     container:
@@ -152,16 +190,57 @@ jobs:
         path: |
           /usr/local/cargo/registry
           /usr/local/cargo/git
-        key: TESTING6-${{ runner.os }}-test-pg${{ env.PGVERSION }}-cargo
+        key: TESTING8-${{ runner.os }}-test-pg${{ env.PGVERSION }}-cargo
 
     - name: Cache cargo target dir
       uses: actions/cache@v2
       with:
         path: target
-        key: TESTING6-${{ runner.os }}-test-pg${{ env.PGVERSION }}-target
+        key: TESTING8-${{ runner.os }}-test-pg${{ env.PGVERSION }}-target
 
     - name: Run pgx tests
-      run: su postgres -c "sh tools/build -pg$PGVERSION test-extension 2>&1"
+      run: su postgres -c 'sh tools/build -pg$PGVERSION test-extension 2>&1'
+
+  testpost13:
+    name: Test post-install and doc 13
+    runs-on: ubuntu-latest
+    container:
+      image: timescaledev/rust-pgx:latest
+
+    env:
+      PGVERSION: 13
+      CARGO_TARGET_DIR_NAME: target
+      CARGO_INCREMENTAL: 0
+      CARGO_NET_RETRY: 10
+      CI: 1
+      RUST_BACKTRACE: short
+      RUSTUP_MAX_RETRIES: 10
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: chown Repository
+      run: chown -R postgres .
+
+    - name: Cache cargo directories
+      uses: actions/cache@v2
+      with:
+        path: |
+          /usr/local/cargo/registry
+          /usr/local/cargo/git
+        key: TESTING8-${{ runner.os }}-test-post${{ env.PGVERSION }}-cargo
+
+    - name: Cache cargo target dir
+      uses: actions/cache@v2
+      with:
+        path: target
+        key: TESTING8-${{ runner.os }}-test-post${{ env.PGVERSION }}-target
+
+    - name: Install extension
+      run: su postgres -c 'sh tools/build -pg$PGVERSION install 2>&1'
 
     - name: Run post-install tests
       run: su postgres -c 'sh tools/build -pg$PGVERSION test-post-install 2>&1'
@@ -169,7 +248,7 @@ jobs:
     - name: Run doc tests
       run: su postgres -c 'sh tools/build -pg$PGVERSION test-doc 2>&1'
 
-  test14:
+  testpg14:
     name: Test PG 14
     runs-on: ubuntu-latest
     container:
@@ -199,16 +278,57 @@ jobs:
         path: |
           /usr/local/cargo/registry
           /usr/local/cargo/git
-        key: TESTING6-${{ runner.os }}-test-pg${{ env.PGVERSION }}-cargo
+        key: TESTING8-${{ runner.os }}-test-pg${{ env.PGVERSION }}-cargo
 
     - name: Cache cargo target dir
       uses: actions/cache@v2
       with:
         path: target
-        key: TESTING6-${{ runner.os }}-test-pg${{ env.PGVERSION }}-target
+        key: TESTING8-${{ runner.os }}-test-pg${{ env.PGVERSION }}-target
 
     - name: Run pgx tests
-      run: su postgres -c "sh tools/build -pg$PGVERSION test-extension 2>&1"
+      run: su postgres -c 'sh tools/build -pg$PGVERSION test-extension 2>&1'
+
+  testpost14:
+    name: Test post-install and doc 14
+    runs-on: ubuntu-latest
+    container:
+      image: timescaledev/rust-pgx:latest
+
+    env:
+      PGVERSION: 14
+      CARGO_TARGET_DIR_NAME: target
+      CARGO_INCREMENTAL: 0
+      CARGO_NET_RETRY: 10
+      CI: 1
+      RUST_BACKTRACE: short
+      RUSTUP_MAX_RETRIES: 10
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: chown Repository
+      run: chown -R postgres .
+
+    - name: Cache cargo directories
+      uses: actions/cache@v2
+      with:
+        path: |
+          /usr/local/cargo/registry
+          /usr/local/cargo/git
+        key: TESTING8-${{ runner.os }}-test-post${{ env.PGVERSION }}-cargo
+
+    - name: Cache cargo target dir
+      uses: actions/cache@v2
+      with:
+        path: target
+        key: TESTING8-${{ runner.os }}-test-post${{ env.PGVERSION }}-target
+
+    - name: Install extension
+      run: su postgres -c 'sh tools/build -pg$PGVERSION install 2>&1'
 
     - name: Run post-install tests
       run: su postgres -c 'sh tools/build -pg$PGVERSION test-post-install 2>&1'
@@ -244,13 +364,13 @@ jobs:
         path: |
           /usr/local/cargo/registry
           /usr/local/cargo/git
-        key: TESTING6-${{ runner.os }}-test-crates-cargo
+        key: TESTING8-${{ runner.os }}-test-crates-cargo
 
     - name: Cache cargo target dir
       uses: actions/cache@v2
       with:
         path: target
-        key: TESTING6-${{ runner.os }}-test-crates-target
+        key: TESTING8-${{ runner.os }}-test-crates-target
 
     - name: Run Crates Tests
       run: su postgres -c 'sh tools/build test-crates 2>&1'

--- a/tools/build
+++ b/tools/build
@@ -1,0 +1,128 @@
+#!/bin/sh
+
+set -ex
+
+print() {
+    printf '%s\n' "$*"
+}
+
+die() {
+    st=${?:-0}
+    if [ $st -eq 0 ]; then
+        st=2
+    fi
+    print "$*" >&2
+    exit $st
+}
+
+usage() {
+    die 'build [ -n -pg1[234] ] ( test-crates | test-extension | test-post-install | test-doc | clippy )'
+}
+
+require_pgversion() {
+    [ -n "$pgversion" ] || die 'specify one of -pg12 | -pg13 | -pg14'
+}
+
+find_pgconfig() {
+    require_pgversion
+    full_version=$(
+        cd "$HOME/.pgx"
+        set -- $pgversion.*/pgx-install
+        [ "$1" = "$pgversion.*/pgx-install" ] && die "$pgversion not installed in $HOME/.pgx"
+        set -- $(dirname $*)
+        [ $# -eq 1 ] || die "too many installations for $pgversion, found: $*"
+        echo $1)
+    pg_config="$HOME/.pgx/$full_version/pgx-install/bin/pg_config"
+}
+
+[ $# -ge 1 ] || usage
+
+# For reasons we don't yet understand, pgx prevents the cargo cache from
+# working across runs UNLESS all pgx commands are run from the 'extension'
+# subdirectory of the project.  Any cargo command we need to run from that
+# subdirectory, we use CARGO_TARGET_DIR="$extension_CARGO_TARGET_DIR", and for
+# all others, CARGO_TARGET_DIR="$top_CARGO_TARGET_DIR".
+#
+# If each entry in ci.yml `jobs` is guaranteed to be run in isolation, always
+# with the target dir freshly copied from the specified cache key, then we
+# don't need to bother with CARGO_TARGET_DIR here.
+#
+# However, this script is derived from one I was using for my local builds
+# anyway, and apparently everyone is suffering the slow build times locally,
+# so why have more than one way to build?  Why not use the same tool locally
+# as the official build uses?
+#
+# CARGO_TARGET_DIR_NAME allows me to call my target directory '.target'.
+# TODO Can we simplify and just force .target here?  It works fine, but I didn't want to surprise people...
+if [ -z "$CARGO_TARGET_DIR_NAME" ]; then
+    # No default to force us to set it in ci.yml, same place we configure the cache.
+    die CARGO_TARGET_DIR_NAME not set
+fi
+top_CARGO_TARGET_DIR="$PWD/$CARGO_TARGET_DIR_NAME/top"
+extension_CARGO_TARGET_DIR="$PWD/$CARGO_TARGET_DIR_NAME/extension"
+
+while [ $# -gt 0 ]; do
+    arg="$1"
+    shift
+    case "$arg" in
+        -n)
+            nop=:
+            ;;
+
+        -pg1[234])
+            pgversion=${arg#-pg}
+            pg=pg$pgversion
+            pgport=288$pgversion
+            ;;
+
+        clippy)
+            $nop env "CARGO_TARGET_DIR=$top_CARGO_TARGET_DIR" cargo fetch
+            # We need to pick a postgres version to clippy the timescaledb_toolkit crate, but it doesn't matter which one.
+            $nop env "CARGO_TARGET_DIR=$top_CARGO_TARGET_DIR" cargo clippy --workspace --features 'pg14 pg_test' -- -D warnings
+            ;;
+
+        test-crates)
+            # Should find no dependency crates to fetch.  If it finds any, we need to update the cache key.
+            $nop env "CARGO_TARGET_DIR=$top_CARGO_TARGET_DIR" cargo fetch
+            $nop env "CARGO_TARGET_DIR=$top_CARGO_TARGET_DIR" cargo test --workspace --exclude timescaledb_toolkit
+            ;;
+
+        test-extension)
+            cd extension
+            require_pgversion
+            $nop env "CARGO_TARGET_DIR=$extension_CARGO_TARGET_DIR" cargo fetch
+            $nop env "CARGO_TARGET_DIR=$extension_CARGO_TARGET_DIR" cargo test --features "$pg pg_test" --no-default-features
+            ;;
+
+        install)
+            cd extension
+            find_pgconfig
+            $nop env "CARGO_TARGET_DIR=$extension_CARGO_TARGET_DIR" cargo pgx install -c "$pg_config"
+            ;;
+
+        # Requires extension has been installed.  `install` or `test-extension` takes care of that.
+        test-post-install)
+            find_pgconfig
+            (
+                export CARGO_TARGET_DIR="$top_CARGO_TARGET_DIR"
+                $nop cargo pgx stop $pg
+                $nop cargo pgx start $pg
+                $nop cargo run --manifest-path tools/post-install/Cargo.toml "$pg_config"
+                $nop cargo run --manifest-path tools/testrunner/Cargo.toml -- -h localhost -p $pgport
+            )
+            ;;
+
+        test-doc)
+            require_pgversion
+            $nop sql-doctester \
+                 -h localhost \
+                 -p $pgport \
+                 -s "CREATE EXTENSION timescaledb; CREATE EXTENSION timescaledb_toolkit; SET SESSION TIMEZONE TO 'UTC'" \
+                 docs
+            ;;
+
+        *)
+            usage
+            ;;
+    esac
+done


### PR DESCRIPTION
* Timings

** serially run pg, post-install, doc

Cold cache: 18m20s
https://github.com/timescale/timescaledb-toolkit/runs/5007577229?check_suite_focus=true
Warm cache:  9m14s
https://github.com/timescale/timescaledb-toolkit/runs/5007862209?check_suite_focus=true

** serially post-install, doc in parallel to doc

Cold cache: 12m32s
https://github.com/timescale/timescaledb-toolkit/runs/5008251420?check_suite_focus=true
Warm cache:  8m16s
https://github.com/timescale/timescaledb-toolkit/runs/5008789292?check_suite_focus=true

Not sure this is worth it...
