### PR TITLE
prepare for 1.6 cycle

### DIFF
--- a/extension/timescaledb_toolkit.control
+++ b/extension/timescaledb_toolkit.control
@@ -1,8 +1,8 @@
 comment = 'Library of analytical hyperfunctions, time-series pipelining, and other SQL utilities'
-default_version = '1.5'
+default_version = '1.6-dev'
 relocatable = false
 superuser = false
 module_pathname = '$libdir/timescaledb_toolkit' # only for testing, will be removed for real installs
 # comma-separated list of previous versions this version can be upgraded from
 # directly. This is used to generate upgrade scripts.
-# upgradeable_from = '1.0, 1.1, 1.2, 1.3, 1.3.1, 1.4'
+# upgradeable_from = '1.0, 1.1, 1.2, 1.3, 1.3.1, 1.4, 1.5'


### PR DESCRIPTION
Update control file for new version.

For this release we're going to start using a '-dev' tag on the version to indicate the version is still under development in order to better distinguish development builds from real release builds.  When preparing for release we'll have to drop this tag and change the version back to `1.6`.