### PR TITLE
Start on testrunner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,5 +308,12 @@ jobs:
         key: ${{ runner.os }}-test-updates-target-1.6_a
         #restore-keys: ${{ runner.os }}-test-crates-target-PREVIOUS
 
+    - name: Cache old versions dir
+      uses: actions/cache@v2
+      with:
+        path: old-versions
+        key: ${{ runner.os }}-test-old-versions-1.6_a
+        #restore-keys: ${{ runner.os }}-test-old-versions-PREVIOUS
+
     - name: Run Update Tests
       run: su postgres -c 'sh tools/build -pg$PGVERSION test-updates 2>&1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,3 +267,46 @@ jobs:
 
     - name: Run Crates Tests
       run: su postgres -c 'sh tools/build test-crates 2>&1'
+
+  testupdates:
+    name: Test Updates
+    runs-on: ubuntu-latest
+    container:
+      image: timescaledev/rust-pgx:latest
+      env:
+        PGVERSION: 14
+        CARGO_TARGET_DIR_NAME: target
+
+        CARGO_INCREMENTAL: 0
+        CARGO_NET_RETRY: 10
+        CI: 1
+        RUST_BACKTRACE: short
+        RUSTUP_MAX_RETRIES: 10
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: chown Repository
+      run: chown -R postgres .
+
+    - name: Cache cargo directories
+      uses: actions/cache@v2
+      with:
+        path: |
+          /usr/local/cargo/registry
+          /usr/local/cargo/git
+        key: ${{ runner.os }}-test-updates-cargo-1.6_a
+        #restore-keys: ${{ runner.os }}-test-crates-cargo-PREVIOUS
+
+    - name: Cache cargo target dir
+      uses: actions/cache@v2
+      with:
+        path: target
+        key: ${{ runner.os }}-test-updates-target-1.6_a
+        #restore-keys: ${{ runner.os }}-test-crates-target-PREVIOUS
+
+    - name: Run Update Tests
+      run: su postgres -c 'sh tools/build -pg$PGVERSION test-updates 2>&1'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "control_file_reader"
+version = "0.1.0"
+
+[[package]]
 name = "cortex-m"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,6 +1480,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres_connection_configuration"
+version = "0.1.0"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,6 +2466,18 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "update-tester"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "colored",
+ "control_file_reader",
+ "postgres",
+ "postgres_connection_configuration",
+ "xshell",
+]
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,14 @@ members = [
     "tools/post-install",
     "tools/sql-doctester",
     "tools/testrunner",
+    "tools/update-tester",
     "crates/asap",
     "crates/counter-agg",
     "crates/time-series",
     "crates/stats-agg",
-    "crates/aggregate_builder"
+    "crates/aggregate_builder",
+    "crates/scripting-utilities/*",
+
 ]
 
 [profile.dev]

--- a/crates/scripting-utilities/Readme.md
+++ b/crates/scripting-utilities/Readme.md
@@ -1,0 +1,12 @@
+# Scripting Utilities #
+
+Small helper crates for writing scripty code, such as found in tools.
+Contains code that's _just_ complicated or irritating enough that it's worth
+deduplicating instead of copy/pasting, but still simple enough to be appropriate
+for scripty code.
+
+We care about compile times for this code, so in general try to keep the crates
+small, simple, and easy to understand. In accordance with this, this dir
+contains a bunch of micro crates instead of one medium utility crate in hopes
+that this will keep them more focused and prevent them from metastasizing, and
+take advantage of compiler parallelism.

--- a/crates/scripting-utilities/control_file_reader/Cargo.toml
+++ b/crates/scripting-utilities/control_file_reader/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "control_file_reader"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/scripting-utilities/control_file_reader/src/lib.rs
+++ b/crates/scripting-utilities/control_file_reader/src/lib.rs
@@ -1,0 +1,64 @@
+/// Code to extract info from `timescaledb_toolkit.control`
+/// This crate exists so we have a single source of truth for the format.
+use std::fmt;
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// extract the current version from the control file
+pub fn get_current_version(control_file: &str) -> Result<String> {
+    get_field_val(control_file, "default_version").map(|v| v.to_string())
+}
+
+/// extract the list of versions we're upgradeable-from from the control file
+pub fn get_upgradeable_from(control_file: &str) -> Result<Vec<String>> {
+    // versions is a comma-delimited list of versions
+    let versions = get_field_val(control_file, "upgradeable_from")?;
+    let versions = versions
+        .split_terminator(',')
+        .map(|version| version.trim().to_string())
+        .collect();
+    Ok(versions)
+}
+
+/// find a `<field name> = '<field value>'` in `file` and extract `<field value>`
+pub fn get_field_val<'a>(file: &'a str, field_name: &str) -> Result<&'a str> {
+    file.lines()
+        .filter(|line| line.contains(field_name))
+        .map(get_quoted_field)
+        .next()
+        .ok_or(Error::FieldNotFound)
+        .and_then(|e| e) // flatten the nested results
+}
+
+// given a `<field name> = '<field value>'` extract `<field value>`
+pub fn get_quoted_field(line: &str) -> Result<&str> {
+    let quoted = line.split('=').nth(1).ok_or(Error::NoValue)?;
+
+    quoted
+        .trim_start()
+        .split_terminator('\'')
+        .find(|s| !s.is_empty())
+        .ok_or(Error::UnquotedValue)
+}
+
+pub enum Error {
+    FieldNotFound,
+    NoValue,
+    UnquotedValue,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self {
+            Self::FieldNotFound => write!(f, "cannot read field"),
+            Self::NoValue => write!(f, "cannot find value"),
+            Self::UnquotedValue => write!(f, "unquoted value"),
+        }
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}

--- a/crates/scripting-utilities/postgres_connection_configuration/Cargo.toml
+++ b/crates/scripting-utilities/postgres_connection_configuration/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "postgres_connection_configuration"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/crates/scripting-utilities/postgres_connection_configuration/src/lib.rs
+++ b/crates/scripting-utilities/postgres_connection_configuration/src/lib.rs
@@ -1,0 +1,56 @@
+/// Config utility for connecting to multiple DBs in the same cluster
+// JOSH - I'm not sure if this really warrants a crate, but it seems like if we
+//        ever change this it'll be annoying to hunt down everything ¯\_(ツ)_/¯
+
+#[derive(Copy, Clone)]
+pub struct ConnectionConfig<'s> {
+    pub host: Option<&'s str>,
+    pub port: Option<&'s str>,
+    pub user: Option<&'s str>,
+    pub password: Option<&'s str>,
+    pub database: Option<&'s str>,
+}
+
+impl<'s> ConnectionConfig<'s> {
+    pub fn with_db<'d>(&self, database: &'d str) -> ConnectionConfig<'d>
+    where
+        's: 'd,
+    {
+        ConnectionConfig {
+            database: Some(database),
+            ..*self
+        }
+    }
+
+    /// get a config string we can use to connect to the db
+    pub fn config_string(&self) -> String {
+        use std::fmt::Write;
+
+        let ConnectionConfig {
+            host,
+            port,
+            user,
+            password,
+            database,
+        } = self;
+
+        let mut config = String::new();
+        if let Some(host) = host {
+            let _ = write!(&mut config, "host={} ", host);
+        }
+        if let Some(port) = port {
+            let _ = write!(&mut config, "port={} ", port);
+        }
+        let _ = match user {
+            Some(user) => write!(&mut config, "user={} ", user),
+            None => write!(&mut config, "user=postgres "),
+        };
+        if let Some(password) = password {
+            let _ = write!(&mut config, "password={} ", password);
+        }
+        if let Some(database) = database {
+            let _ = write!(&mut config, "dbname={} ", database);
+        }
+        config
+    }
+}

--- a/extension/timescaledb_toolkit.control
+++ b/extension/timescaledb_toolkit.control
@@ -5,4 +5,4 @@ superuser = false
 module_pathname = '$libdir/timescaledb_toolkit' # only for testing, will be removed for real installs
 # comma-separated list of previous versions this version can be upgraded from
 # directly. This is used to generate upgrade scripts.
-# upgradeable_from = '1.0, 1.1, 1.2, 1.3, 1.3.1, 1.4, 1.5'
+# upgradeable_from = '1.4, 1.5'

--- a/tools/build
+++ b/tools/build
@@ -121,6 +121,20 @@ while [ $# -gt 0 ]; do
                  docs
             ;;
 
+        test-updates)
+            require_pgversion
+            find_pgconfig
+            (
+                export CARGO_TARGET_DIR="$top_CARGO_TARGET_DIR"
+                $nop cargo pgx start $pg
+                $nop cargo run --manifest-path tools/update-tester/Cargo.toml -- \
+                 -h localhost \
+                 -p $pgport \
+                 . \
+                 "$pg_config"
+            )
+            ;;
+
         *)
             usage
             ;;

--- a/tools/build
+++ b/tools/build
@@ -130,6 +130,7 @@ while [ $# -gt 0 ]; do
                 $nop cargo run --manifest-path tools/update-tester/Cargo.toml -- \
                  -h localhost \
                  -p $pgport \
+                 --cache old-versions \
                  . \
                  "$pg_config"
             )

--- a/tools/update-tester/Cargo.toml
+++ b/tools/update-tester/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "update-tester"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+control_file_reader = {path = "../../crates/scripting-utilities/control_file_reader"}
+postgres_connection_configuration = {path = "../../crates/scripting-utilities/postgres_connection_configuration"}
+
+colored = "2.0.0"
+clap = { version = "2.33", features = ["wrap_help"] }
+postgres = "0.19.1"
+xshell = "0.1.14"

--- a/tools/update-tester/Readme.md
+++ b/tools/update-tester/Readme.md
@@ -1,0 +1,46 @@
+# Update Tester #
+
+Runs update tests. It'll install every version of the extension marked as
+`upgradeable_from` in `timescaledb_toolkit.control` and test that updates to
+the current version work correctly. At a high level:
+
+1. For each version in `upgradeable_from`
+    1. Checkout the corresponding tag in git,
+    2. Build and install the extension at that tag,
+    3. Set git back to the original state.
+2. Build and install the extension at the original git state.
+3. For each version in `upgradeable_from`
+    1. create a database,
+    2. install the old version of the extension,
+    3. install some `timescaledb_toolkit` objects,
+    4. update the extension,
+    5. validate the extension is in the expected state.
+
+**NOTE:** Running this _will_ move git's `HEAD`. Though git will warn on
+          conflicts, and we do our best to reset the tree state before the
+          script exits, we recommend only using it on a clean tree.
+
+
+
+
+```
+USAGE:
+    update-tester [OPTIONS] <dir> <pg_config>
+
+FLAGS:
+        --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -d, --database <database>    postgres database the root connection should use. By
+                                 default this DB will only be used to spawn the individual
+                                 test databases; no tests will run against it.
+    -h, --host <hostname>        postgres host
+    -a, --password <password>    postgres password
+    -p, --port <portnumber>      postgres port
+    -u, --user <username>        postgres user
+
+ARGS:
+    <dir>          Path in which to find the timescaledb-toolkit repo
+    <pg_config>    Path to pg_config for the DB we are using
+```

--- a/tools/update-tester/src/installer.rs
+++ b/tools/update-tester/src/installer.rs
@@ -1,0 +1,71 @@
+use std::path::Path;
+
+use colored::Colorize;
+
+use xshell::{cmd, pushd, pushenv};
+
+use crate::{defer, quietly_run};
+
+pub fn install_all_versions(
+    root_dir: &str,
+    pg_config: &str,
+    old_versions: &[String],
+) -> xshell::Result<()> {
+    let extension_dir = path!(root_dir / "extension");
+    let install_toolkit = || -> xshell::Result<()> {
+        let _d = pushd(&extension_dir)?;
+        let _e = pushenv("CARGO_TARGET_DIR", "../target/extension");
+        quietly_run(cmd!("cargo pgx install -c {pg_config}"))
+    };
+    let post_install = || -> xshell::Result<()> {
+        let _d = pushd(root_dir)?;
+        let _e = pushenv("CARGO_TARGET_DIR", "target/top");
+        quietly_run(cmd!(
+            "cargo run --manifest-path ./tools/post-install/Cargo.toml -- {pg_config}"
+        ))
+    };
+
+    let base_checkout = get_current_checkout()?;
+    // TODO only fetch the tags we actually need
+    quietly_run(cmd!("git fetch --tags"))?;
+    // Install the versions in reverse-time order.
+    // Since later versions tend to be supersets of old versions,
+    // I expect compilation to be faster this way - Josh
+    for version in old_versions.iter().rev() {
+        // TODO add flag to only install versions we don't have already
+        eprintln!("{} {}", "Installing".bold().cyan(), version);
+        let tag_version = tag_version(version);
+        quietly_run(cmd!("git checkout tags/{tag_version}"))?;
+        let _d = defer(|| quietly_run(cmd!("git checkout {base_checkout}")));
+        install_toolkit()?;
+        post_install()?;
+        eprintln!("{} {}", "Finished".bold().green(), version);
+    }
+    eprintln!("{} main", "Installing".bold().cyan());
+    install_toolkit()?;
+    post_install()?;
+    eprintln!("{} main", "Finished".bold().green());
+
+    Ok(())
+}
+
+fn get_current_checkout() -> xshell::Result<String> {
+    let current_branch = cmd!("git rev-parse --abbrev-ref --symbolic-full-name HEAD").read()?;
+
+    if current_branch != "HEAD" {
+        return Ok(current_branch);
+    }
+
+    cmd!("git rev-parse --verify HEAD").read()
+}
+
+// We were unprincipled with some of our old versions, so the version from
+// the control file is `x.y`, while the tag is `x.y.0`. This function translates
+// from the control file version to the tag version (in a rather hacky way)
+fn tag_version(version: &str) -> String {
+    if version.matches('.').count() >= 2 {
+        return version.into();
+    }
+
+    format!("{}.0", version)
+}

--- a/tools/update-tester/src/installer.rs
+++ b/tools/update-tester/src/installer.rs
@@ -2,12 +2,13 @@ use std::path::Path;
 
 use colored::Colorize;
 
-use xshell::{cmd, pushd, pushenv};
+use xshell::{cmd, cp, mkdir_p, pushd, pushenv, read_dir};
 
 use crate::{defer, quietly_run};
 
 pub fn install_all_versions(
     root_dir: &str,
+    cache_dir: Option<&str>,
     pg_config: &str,
     old_versions: &[String],
 ) -> xshell::Result<()> {
@@ -25,22 +26,33 @@ pub fn install_all_versions(
         ))
     };
 
+    if let Some(cache_dir) = cache_dir {
+        restore_from_cache(cache_dir, pg_config)?
+    }
+
     let base_checkout = get_current_checkout()?;
-    // TODO only fetch the tags we actually need
-    quietly_run(cmd!("git fetch --tags"))?;
     // Install the versions in reverse-time order.
     // Since later versions tend to be supersets of old versions,
     // I expect compilation to be faster this way - Josh
     for version in old_versions.iter().rev() {
-        // TODO add flag to only install versions we don't have already
+        if version_is_installed(pg_config, version)? {
+            eprintln!("{} {}", "Already Installed".blue(), version);
+            continue
+        }
         eprintln!("{} {}", "Installing".bold().cyan(), version);
         let tag_version = tag_version(version);
+        quietly_run(cmd!("git fetch origin tag {tag_version}"))?;
         quietly_run(cmd!("git checkout tags/{tag_version}"))?;
         let _d = defer(|| quietly_run(cmd!("git checkout {base_checkout}")));
         install_toolkit()?;
         post_install()?;
         eprintln!("{} {}", "Finished".bold().green(), version);
     }
+
+    if let Some(cache_dir) = cache_dir {
+        save_to_cache(cache_dir, pg_config)?;
+    }
+
     eprintln!("{} main", "Installing".bold().cyan());
     install_toolkit()?;
     post_install()?;
@@ -68,4 +80,81 @@ fn tag_version(version: &str) -> String {
     }
 
     format!("{}.0", version)
+}
+
+//-----------------------//
+//-- Cache Maintenance --//
+//-----------------------//
+
+fn version_is_installed(pg_config: &str, version: &str) -> xshell::Result<bool> {
+    let binary_name = format!("timescaledb_toolkit-{}.so", version);
+    let bin_dir = cmd!("{pg_config} --pkglibdir").read()?;
+    let installed_files = read_dir(bin_dir)?;
+    let installed = installed_files.into_iter().any(|file| {
+        file.file_name()
+            .map(|name| name.to_string_lossy() == binary_name)
+            .unwrap_or(false)
+    });
+    Ok(installed)
+}
+
+fn restore_from_cache(cache_dir: &str, pg_config: &str) -> xshell::Result<()> {
+    if !path!(cache_dir).exists() {
+        eprintln!("{}", "Cache does not exist".yellow());
+        return Ok(());
+    }
+
+    eprintln!("{} {}", "Restoring from Cache".bold().blue(), cache_dir);
+    let bin_dir = cmd!("{pg_config} --pkglibdir").read()?;
+
+    let share_dir = cmd!("{pg_config} --sharedir").read()?;
+    let script_dir = path!(share_dir / "extension");
+
+    let cached_bin_dir = path!(cache_dir / "bin");
+    let cached_script_dir = path!(cache_dir / "extension");
+
+    cp_dir(cached_bin_dir, bin_dir, |_| true)?;
+    cp_dir(cached_script_dir, script_dir, |_| true)
+}
+
+fn save_to_cache(cache_dir: &str, pg_config: &str) -> xshell::Result<()> {
+    eprintln!("{} {}", "Saving to Cache".blue(), cache_dir);
+
+    let cached_bin_dir = path!(cache_dir / "bin");
+    let cached_script_dir = path!(cache_dir / "extension");
+
+    if !cached_bin_dir.exists() {
+        mkdir_p(&cached_bin_dir)?
+    }
+
+    if !cached_script_dir.exists() {
+        mkdir_p(&cached_script_dir)?
+    }
+
+    let bin_dir = cmd!("{pg_config} --pkglibdir").read()?;
+
+    let share_dir = cmd!("{pg_config} --sharedir").read()?;
+    let script_dir = path!(share_dir / "extension");
+
+    let is_toolkit_file = |file: &Path| {
+        file.file_name()
+            .map(|f| f.to_string_lossy().starts_with("timescaledb_toolkit"))
+            .unwrap_or(false)
+    };
+    cp_dir(bin_dir, cached_bin_dir, is_toolkit_file)?;
+    cp_dir(script_dir, cached_script_dir, is_toolkit_file)
+}
+
+fn cp_dir(
+    src: impl AsRef<Path>,
+    dst: impl AsRef<Path>,
+    mut filter: impl FnMut(&Path) -> bool,
+) -> xshell::Result<()> {
+    let dst = dst.as_ref();
+    for file in read_dir(src)? {
+        if filter(&file) {
+            cp(file, dst)?;
+        }
+    }
+    Ok(())
 }

--- a/tools/update-tester/src/main.rs
+++ b/tools/update-tester/src/main.rs
@@ -1,0 +1,134 @@
+use std::{
+    io::{self, Write},
+    path::Path,
+    process,
+};
+
+use clap::clap_app;
+
+use colored::Colorize;
+
+use xshell::{read_file, Cmd};
+
+use control_file_reader::{get_current_version, get_upgradeable_from};
+use postgres_connection_configuration::ConnectionConfig;
+
+// macro for literate path joins
+macro_rules! path {
+    ($start:ident $(/ $segment: literal)*) => {
+        {
+            let root: &Path = $start.as_ref();
+            root $(.join($segment))*
+        }
+    };
+    ($start:ident / $segment: expr) => {
+        {
+            let root: &Path = $start.as_ref();
+            root.join($segment)
+        }
+    }
+}
+
+mod installer;
+mod testrunner;
+
+fn main() {
+    let matches = clap_app!(("update-tester") =>
+        (@arg HOST: -h --host [hostname] conflicts_with[URL] "postgres host")
+        (@arg PORT: -p --port [portnumber] conflicts_with[URL] "postgres port")
+        (@arg USER: -u --user [username] conflicts_with[URL] "postgres user")
+        (@arg PASSWORD: -a --password [password] conflicts_with[URL] "postgres password")
+        (@arg DB: -d --database [database] conflicts_with[URL] "postgres database the root \
+            connection should use. By default this DB will only be used \
+            to spawn the individual test databases; no tests will run against \
+            it.")
+        (@arg ROOT_DIR: +required <dir> "Path in which to find the timescaledb-toolkit repo")
+        (@arg PG_CONFIG: +required <pg_config> "Path to pg_config for the DB we are using")
+    ).get_matches();
+
+    let connection_config = ConnectionConfig {
+        host: matches.value_of("HOST"),
+        port: matches.value_of("PORT"),
+        user: matches.value_of("USER"),
+        password: matches.value_of("PASSWORD"),
+        database: matches.value_of("DB"),
+    };
+
+    let root_dir = matches
+        .value_of("ROOT_DIR")
+        .expect("missing path to root of the toolkit repo");
+
+    let pg_config = matches.value_of("PG_CONFIG").expect("missing pg_config");
+
+    if let Err(err) = try_main(root_dir, &connection_config, pg_config) {
+        eprintln!("{}", err);
+        process::exit(1);
+    }
+}
+
+fn try_main(root_dir: &str, db_conn: &ConnectionConfig<'_>, pg_config: &str) -> xshell::Result<()> {
+    let (current_version, old_versions) = get_version_info(root_dir)?;
+    if old_versions.is_empty() {
+        panic!("no old versions to upgrade from")
+    }
+
+    installer::install_all_versions(root_dir, pg_config, &old_versions)?;
+
+    testrunner::run_update_tests(db_conn, current_version, old_versions)
+}
+
+fn get_version_info(root_dir: &str) -> xshell::Result<(String, Vec<String>)> {
+    let extension_dir = path!(root_dir / "extension");
+    let control_file = path!(extension_dir / "timescaledb_toolkit.control");
+
+    let control_contents = read_file(control_file)?;
+
+    let current_version = get_current_version(&control_contents)
+        .unwrap_or_else(|e| panic!("{} in control file {}", e, control_contents));
+
+    let upgradable_from = get_upgradeable_from(&control_contents)
+        .unwrap_or_else(|e| panic!("{} in control file {}", e, control_contents));
+
+    Ok((current_version, upgradable_from))
+}
+
+//-------------//
+//- Utilities -//
+//-------------//
+
+// run a command, only printing the output on failure
+fn quietly_run(cmd: Cmd) -> xshell::Result<()> {
+    let display = format!("{}", cmd);
+    let output = cmd.ignore_status().output()?;
+    if !output.status.success() {
+        io::stdout()
+            .write_all(&output.stdout)
+            .expect("cannot write to stdout");
+        io::stdout()
+            .write_all(&output.stderr)
+            .expect("cannot write to stdout");
+        panic!(
+            "{} `{}` exited with a non-zero error code {}",
+            "ERROR".bold().red(),
+            display,
+            output.status
+        )
+    }
+    Ok(())
+}
+
+// run a command on `drop()`
+fn defer<T>(f: impl FnMut() -> T) -> Deferred<T, impl FnMut() -> T> {
+    Deferred(f)
+}
+
+struct Deferred<T, F: FnMut() -> T>(F);
+
+impl<F, T> Drop for Deferred<T, F>
+where
+    F: FnMut() -> T,
+{
+    fn drop(&mut self) {
+        self.0();
+    }
+}

--- a/tools/update-tester/src/testrunner.rs
+++ b/tools/update-tester/src/testrunner.rs
@@ -1,0 +1,253 @@
+use colored::Colorize;
+
+use postgres::{Client, NoTls, SimpleQueryMessage};
+
+use postgres_connection_configuration::ConnectionConfig;
+
+use crate::{defer, Deferred};
+
+pub fn run_update_tests(
+    root_config: &ConnectionConfig,
+    current_version: String,
+    old_versions: Vec<String>,
+) -> Result<(), xshell::Error> {
+    for old_version in old_versions {
+        eprintln!(
+            " {} {} -> {}",
+            "Testing".bold().cyan(),
+            old_version,
+            current_version
+        );
+
+        let test_db_name = format!("tsdb_toolkit_test_{}--{}", old_version, current_version);
+        let test_config = root_config.with_db(&test_db_name);
+        with_temporary_db(&test_db_name, root_config, || {
+            let mut test_client = connect_to(&test_config);
+
+            test_client.install_toolkit_at_version(&old_version);
+            let installed_version = test_client.get_installed_extension_version();
+            assert_eq!(
+                installed_version, old_version,
+                "installed unexpected version"
+            );
+
+            let validation_values = test_client.create_test_objects_for(&old_version);
+
+            // TODO old versions require a new connection for updates.
+            //      we can fix this by dropping our guc,
+            //      at which point this can be deleted
+            drop(test_client);
+            test_client = connect_to(&test_config);
+
+            test_client.update_to_current_version();
+            let new_version = test_client.get_installed_extension_version();
+            assert_eq!(
+                new_version, current_version,
+                "updated to unexpected version"
+            );
+
+            test_client.validate_test_objects(validation_values);
+        });
+        eprintln!(
+            "{} {} -> {}",
+            "Finished".bold().green(),
+            old_version,
+            current_version
+        );
+    }
+    Ok(())
+}
+
+fn connect_to(config: &ConnectionConfig<'_>) -> TestClient {
+    let client = Client::connect(&config.config_string(), NoTls).unwrap_or_else(|e| {
+        panic!(
+            "could not connect to postgres DB {} due to {}",
+            config.database.unwrap_or(""),
+            e,
+        )
+    });
+    TestClient(client)
+}
+
+//---------------//
+//- DB creation -//
+//---------------//
+
+fn with_temporary_db<T>(
+    db_name: impl AsRef<str>,
+    root_config: &ConnectionConfig<'_>,
+    f: impl FnOnce() -> T,
+) -> T {
+    let _db_dropper = create_db(root_config, db_name.as_ref());
+    let res = f();
+    drop(_db_dropper);
+    res
+}
+
+// create a database returning an guard that will DROP the db on `drop()`
+#[must_use]
+fn create_db<'a>(
+    root_config: &'a ConnectionConfig<'_>,
+    new_db_name: &'a str,
+) -> Deferred<(), impl FnMut() + 'a> {
+    let mut client = connect_to(root_config).0;
+    let create = format!(r#"CREATE DATABASE "{}""#, new_db_name);
+    client
+        .simple_query(&create)
+        .unwrap_or_else(|e| panic!("could not create db {} due to {}", new_db_name, e));
+
+    defer(move || {
+        let mut client = connect_to(root_config).0;
+        let drop = format!(r#"DROP DATABASE "{}""#, new_db_name);
+        client
+            .simple_query(&drop)
+            .unwrap_or_else(|e| panic!("could not drop db {} due to {}", new_db_name, e));
+    })
+}
+
+//-------------------//
+//- Test Components -//
+//-------------------//
+
+struct TestClient(Client);
+
+#[must_use]
+type QueryValues = Vec<Vec<Option<String>>>;
+
+impl TestClient {
+    fn install_toolkit_at_version(&mut self, old_version: &str) {
+        let create = format!(
+            r#"CREATE EXTENSION timescaledb_toolkit VERSION "{}""#,
+            old_version
+        );
+        self.simple_query(&create).unwrap_or_else(|e| {
+            panic!(
+                "could not install extension at version {} due to {}",
+                old_version, e,
+            )
+        });
+    }
+
+    #[must_use]
+    fn create_test_objects_for(&mut self, _old_version: &str) -> QueryValues {
+        let create_data_table = "\
+            CREATE TABLE test_data(ts timestamptz, val DOUBLE PRECISION);\
+            INSERT INTO test_data \
+                SELECT '2020-01-01 00:00:00+00'::timestamptz + i * '1 hour'::interval, \
+                100 + i % 100\
+            FROM generate_series(0, 10000) i;\
+        ";
+        self.simple_query(create_data_table)
+            .unwrap_or_else(|e| panic!("could create the data table due to {}", e));
+
+        // TODO JOSH - I want to have additional stuff for newer versions,
+        //             but it's not ready yet
+        let create_test_view = "\
+            CREATE VIEW regression_view AS \
+                SELECT \
+                    counter_agg(ts, val) AS countagg, \
+                    hyperloglog(32, val) AS hll, \
+                    time_weight('locf', ts, val) AS twa, \
+                    uddsketch(100, 0.001, val) as udd, \
+                    tdigest(100, val) as tdig, \
+                    stats_agg(val) as stats \
+                FROM test_data;\
+        ";
+        self.simple_query(create_test_view)
+            .unwrap_or_else(|e| panic!("could create the regression view due to {}", e));
+
+        let query_test_view = "\
+            SET TIME ZONE 'UTC'; \
+            SELECT \
+                num_resets(countagg), \
+                distinct_count(hll), \
+                average(twa), \
+                approx_percentile(0.1, udd), \
+                approx_percentile(0.1, tdig), \
+                kurtosis(stats) \
+            FROM regression_view;\
+        ";
+        let view_output = self
+            .simple_query(query_test_view)
+            .unwrap_or_else(|e| panic!("could query the regression view due to {}", e));
+        get_values(view_output)
+    }
+
+    fn update_to_current_version(&mut self) {
+        let update = "ALTER EXTENSION timescaledb_toolkit UPDATE";
+        self.simple_query(update)
+            .unwrap_or_else(|e| panic!("could not update extension due to {}", e));
+    }
+
+    fn validate_test_objects(&mut self, validation_values: QueryValues) {
+        let query_test_view = "\
+            SET TIME ZONE 'UTC'; \
+            SELECT \
+                num_resets(countagg), \
+                distinct_count(hll), \
+                average(twa), \
+                approx_percentile(0.1, udd), \
+                approx_percentile(0.1, tdig), \
+                kurtosis(stats) \
+            FROM regression_view;\
+        ";
+        let view_output = self
+            .simple_query(query_test_view)
+            .unwrap_or_else(|e| panic!("could query the regression view due to {}", e));
+        let new_values = get_values(view_output);
+        assert_eq!(
+            new_values, validation_values,
+            "values returned by the view changed on update",
+        );
+    }
+
+    #[must_use]
+    fn get_installed_extension_version(&mut self) -> String {
+        let get_extension_version = "\
+            SELECT extversion \
+            FROM pg_extension \
+            WHERE extname = 'timescaledb_toolkit'";
+        let updated_version = self
+            .simple_query(get_extension_version)
+            .unwrap_or_else(|e| panic!("could get updated extension version due to {}", e));
+
+        get_values(updated_version)
+            .pop() // should have 1 row
+            .expect("no timescaledb_toolkit version")
+            .pop() // row should have one value
+            .expect("no timescaledb_toolkit version")
+            .expect("no timescaledb_toolkit version")
+    }
+}
+
+impl std::ops::Deref for TestClient {
+    type Target = Client;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for TestClient {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+// translate a messages into their contained values
+fn get_values(query_results: Vec<SimpleQueryMessage>) -> QueryValues {
+    query_results
+        .into_iter()
+        .filter_map(|msg| match msg {
+            SimpleQueryMessage::CommandComplete(_) => None,
+            SimpleQueryMessage::Row(row) => {
+                let mut values = Vec::with_capacity(row.len());
+                for i in 0..row.len() {
+                    values.push(row.get(i).map(|s| s.to_string()))
+                }
+                Some(values)
+            }
+            _ => unreachable!(),
+        })
+        .collect()
+}


### PR DESCRIPTION
Add a update testrunner. It'll install every version of the extension marked as `upgradeable_from` in `timescaledb_toolkit.control` and test that updates to the current version work correctly. At a high level:

1. For each version in `upgradeable_from`
    1. Checkout the corresponding tag in git,
    2. Build and install the extension at that tag,
    3. Set git back to the original state.
2. Build and install the extension at the original git state.
3. For each version in `upgradeable_from`
    1. create a database,
    2. install the old version of the extension,
    3. install some `timescaledb_toolkit` objects,
    4. update the extension,
    5. validate the extension is in the expected state.

**NOTE:** This version of the update testrunner _will_ move git's `HEAD`. Though git will warn on conflicts, and we do our best to reset the tree state before the script exits, we recommend only using it on a clean tree.

---

Some future work I'd like to do:
 - [ ] per-version update tests.
 - [ ] cache the old binaries and install scripts in CI so we don't have to rebuild them each time