### PR TITLE
Specify pgx version in installation instructions.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,7 +39,7 @@ sudo apt-get install make gcc pkg-config clang postgresql-server-dev-13 libssl-d
 ```
 and finally, [pgx](https://github.com/zombodb/pgx), which can be installed with
 ```bash
-cargo install cargo-pgx && cargo pgx init --pg13 pg_config
+cargo install --version 0.2.4 cargo-pgx && cargo pgx init --pg13 pg_config
 ```
 
 ### 💾 Building and Installing the extension ###

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -16,6 +16,7 @@ pg14 = ["pgx/pg14", "pgx-tests/pg14"]
 pg_test = ["approx"]
 
 [dependencies]
+# Keep synchronized with `cargo install --version N.N.N cargo-pgx` in Readme.md.
 pgx = "0.2.4"
 pgx-macros = "0.2.4"
 encodings = {path="../crates/encodings"}


### PR DESCRIPTION
If we don't, we pull the latest, which may not be compatible, as just happened
2022-02-09 with pgx 0.3 release.

Closes bug #347.