### PR TITLE
use three-digit versions

### DIFF
--- a/extension/timescaledb_toolkit.control
+++ b/extension/timescaledb_toolkit.control
@@ -1,5 +1,5 @@
 comment = 'Library of analytical hyperfunctions, time-series pipelining, and other SQL utilities'
-default_version = '1.6-dev'
+default_version = '1.6.0-dev'
 relocatable = false
 superuser = false
 module_pathname = '$libdir/timescaledb_toolkit' # only for testing, will be removed for real installs


### PR DESCRIPTION
We've been inconsistent between github and the control file about whether non-patch versions have 3 digits `x.y.0` or two digits `x.y`. This commit starts having the control file version match the github convention.