### PR TITLE
Make serialize functions strict

### DIFF
--- a/extension/src/counter_agg.rs
+++ b/extension/src/counter_agg.rs
@@ -151,7 +151,7 @@ impl CounterSummaryTransState {
     }
 }
 
-#[pg_extern(immutable, parallel_safe)]
+#[pg_extern(immutable, parallel_safe, strict)]
 pub fn counter_summary_trans_serialize(
     state: Internal,
 ) -> bytea {

--- a/extension/src/hyperloglog.rs
+++ b/extension/src/hyperloglog.rs
@@ -106,7 +106,7 @@ pub fn hyperloglog_combine_inner(
 
 use crate::raw::bytea;
 
-#[pg_extern(immutable, parallel_safe)]
+#[pg_extern(immutable, parallel_safe, strict)]
 pub fn hyperloglog_serialize(state: Internal) -> bytea {
     let state: &mut HyperLogLogTrans = unsafe { state.get_mut().unwrap() };
     state.logger.merge_all();

--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -133,7 +133,7 @@ pub fn tdigest_combine_inner(
 
 use crate::raw::bytea;
 
-#[pg_extern(immutable, parallel_safe)]
+#[pg_extern(immutable, parallel_safe, strict)]
 pub fn tdigest_serialize(
     state: Internal,
 ) -> bytea {

--- a/extension/src/time_series.rs
+++ b/extension/src/time_series.rs
@@ -199,7 +199,7 @@ pub fn unnest(
     series.into_iter().map(|points| (points.ts.into(), points.val))
 }
 
-#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe, strict)]
 pub fn timevector_serialize(
     state: Internal,
 ) -> bytea {

--- a/extension/src/time_weighted_average.rs
+++ b/extension/src/time_weighted_average.rs
@@ -83,7 +83,7 @@ impl TimeWeightTransState {
     }
 }
 
-#[pg_extern(immutable, parallel_safe)]
+#[pg_extern(immutable, parallel_safe, strict)]
 pub fn time_weight_trans_serialize(state: Internal) -> bytea {
     let mut state: Inner<TimeWeightTransState> = unsafe { state.to_inner().unwrap() };
     state.combine_summaries();

--- a/extension/src/uddsketch.rs
+++ b/extension/src/uddsketch.rs
@@ -108,7 +108,7 @@ pub fn uddsketch_combine_inner(
 
 use crate::raw::bytea;
 
-#[pg_extern(immutable, parallel_safe)]
+#[pg_extern(immutable, parallel_safe, strict)]
 pub fn uddsketch_serialize(
     state: Internal,
 ) -> bytea {


### PR DESCRIPTION
It's possible for partitioned aggregates to have
NULL data for some partitions, serialize needs to
handle this.  Make serialize strict will do the
correct thing.  Deserialize functions are all
already strict.

Closes bug #350