### PR TITLE
Add tests that ensure old objects don't leak on update

### DIFF
--- a/tools/update-tester/src/installer.rs
+++ b/tools/update-tester/src/installer.rs
@@ -10,6 +10,7 @@ pub fn install_all_versions(
     root_dir: &str,
     cache_dir: Option<&str>,
     pg_config: &str,
+    current_version: &str,
     old_versions: &[String],
 ) -> xshell::Result<()> {
     let extension_dir = path!(root_dir / "extension");
@@ -53,10 +54,10 @@ pub fn install_all_versions(
         save_to_cache(cache_dir, pg_config)?;
     }
 
-    eprintln!("{} main", "Installing".bold().cyan());
+    eprintln!("{} {} ({})", "Installing Current".bold().cyan(), current_version, base_checkout);
     install_toolkit()?;
     post_install()?;
-    eprintln!("{} main", "Finished".bold().green());
+    eprintln!("{}", "Finished Current".bold().green());
 
     Ok(())
 }

--- a/tools/update-tester/src/main.rs
+++ b/tools/update-tester/src/main.rs
@@ -84,7 +84,13 @@ fn try_main(
 
     println!("{} [{}]", "Testing".green().bold(), old_versions.join(", "));
 
-    installer::install_all_versions(root_dir, cache_dir, pg_config, &old_versions)?;
+    installer::install_all_versions(
+        root_dir,
+        cache_dir,
+        pg_config,
+        &current_version,
+        &old_versions
+    )?;
 
     testrunner::run_update_tests(db_conn, current_version, old_versions)
 }


### PR DESCRIPTION
This commit adds and update tests that ensures that after update we there are no functions that still reference the old binary. We do this by looking for functions that reference a binary other than the one for the current version; since we version all our binaries like `$libdir/timescaledb_toolkit_x.y.z`, any old versions of the function should reference a binary other than the current one.

I've been wanting to have tests for this for a while, and now we can! ☺️ 