### PR TITLE
Switch stabilization tests to new info

### DIFF
--- a/extension/src/hyperloglog.rs
+++ b/extension/src/hyperloglog.rs
@@ -194,7 +194,7 @@ fn hyperloglog_final_inner(
 }
 
 extension_sql!("\n\
-    CREATE AGGREGATE hyperloglog(size int, value AnyElement)\n\
+    CREATE AGGREGATE hyperloglog(size integer, value AnyElement)\n\
     (\n\
         stype = internal,\n\
         sfunc = hyperloglog_trans,\n\

--- a/extension/src/lttb.rs
+++ b/extension/src/lttb.rs
@@ -94,7 +94,7 @@ pub fn lttb_final_inner(
 }
 
 extension_sql!("\n\
-CREATE AGGREGATE toolkit_experimental.lttb(ts TIMESTAMPTZ, value DOUBLE PRECISION, resolution INT) (\n\
+CREATE AGGREGATE toolkit_experimental.lttb(ts TIMESTAMPTZ, value DOUBLE PRECISION, resolution integer) (\n\
     sfunc = toolkit_experimental.lttb_trans,\n\
     stype = internal,\n\
     finalfunc = toolkit_experimental.lttb_final\n\

--- a/extension/src/stabilization_info.rs
+++ b/extension/src/stabilization_info.rs
@@ -158,6 +158,7 @@ crate::functions_stabilized_at! {
         variance_x(statssummary2d,text),
         variance_y(statssummary2d,text),
         x_intercept(statssummary2d),
+        distinct_count(hyperloglog),
     }
 }
 

--- a/extension/src/stabilization_tests.rs
+++ b/extension/src/stabilization_tests.rs
@@ -1,6 +1,163 @@
 #[cfg(any(test, feature = "pg_test"))]
 use pgx::*;
 
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use std::collections::HashSet;
+
+    use pgx::*;
+    use pgx_macros::pg_test;
+
+    // Test that any new features are added to the the experimental schema
+    #[pg_test]
+    fn test_schema_qualification() {
+        Spi::execute(|client| {
+            let stable_functions: HashSet<String> = stable_functions();
+            let stable_types: HashSet<String> = stable_types();
+            let stable_operators: HashSet<String> = stable_operators();
+            let unexpected_features: Vec<_> = client
+                .select(
+                    "SELECT pg_catalog.pg_describe_object(classid, objid, 0) \
+                    FROM pg_catalog.pg_extension e, pg_catalog.pg_depend d \
+                    WHERE e.extname='timescaledb_toolkit' \
+                    AND refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass \
+                    AND d.refobjid = e.oid \
+                    AND deptype = 'e'
+                    ORDER BY 1",
+                    None,
+                    None,
+                )
+                .filter_map(|row| {
+                    let val: String = row.by_ordinal(1).unwrap().value().unwrap();
+
+                    if let Some(schema) = val.strip_prefix("schema ") {
+                        // the only schemas we should define are
+                        // `toolkit_experimental` our experimental schema, and
+                        // `tests` which contains our pgx-style regression tests
+                        // (including the function currently running)
+                        match schema {
+                            "toolkit_experimental" => return None,
+                            "tests" => return None,
+                            _ => return Some(val),
+                        }
+                    }
+
+                    if let Some(ty) = val.strip_prefix("type ") {
+                        // types in the experimental schema are experimental
+                        if ty.starts_with("toolkit_experimental.") {
+                            return None;
+                        }
+
+                        if stable_types.contains(ty) {
+                            return None;
+                        }
+
+                        return Some(val);
+                    }
+
+                    if let Some(function) = val.strip_prefix("function ") {
+                        // functions in the experimental schema are experimental
+                        if function.starts_with("toolkit_experimental.") {
+                            return None;
+                        }
+
+                        // functions in test schema only exist for tests and
+                        // won't be in release versions of the extension
+                        if function.starts_with("tests.") {
+                            return None;
+                        }
+
+                        // arrow functions outside the experimental schema are
+                        // considered experimental as long as one of their argument
+                        // types are experimental (`#[pg_operator]` doesn't allow
+                        // us to declare these in a schema and the operator using
+                        // them not in the schema). We use name-based resolution
+                        // to tell if a function exists to implement an arrow
+                        // operator because we didn't have a better method
+                        let is_arrow =
+                            function.starts_with("arrow_") || function.starts_with("finalize_with");
+                        if is_arrow && function.contains("toolkit_experimental.") {
+                            return None;
+                        }
+
+                        if stable_functions.contains(function) {
+                            return None;
+                        }
+
+                        return Some(val);
+                    }
+
+                    if let Some(operator) = val.strip_prefix("operator ") {
+                        // we generally don't put operators in the experimental
+                        // schema if we can avoid it because we consider the
+                        // `OPERATOR(schema.<op>)` syntax to be to much a
+                        // usability hazard. Instead we rely on one of the input
+                        // types being experimental and the cascading nature of
+                        // drop. This means that we consider an operator
+                        // unstable if either of its arguments or the operator
+                        // itself are in the experimental schema
+                        if operator.contains("toolkit_experimental.") {
+                            return None;
+                        }
+
+                        // we special-case operator
+                        // `->>(regproc,regproc) returns pipeline` since it
+                        // doesn't take in any experimental type and relies on
+                        // returning one
+                        // TODO JOSH - is this operator even a good idea?
+                        if operator == "->>(regproc,regproc)" {
+                            return None;
+                        }
+
+                        if stable_operators.contains(operator) {
+                            return None;
+                        }
+
+                        return Some(val);
+                    }
+
+                    if let Some(cast) = val.strip_prefix("cast ") {
+                        // casts cannot be schema-qualified, so we rely on one
+                        // of the types involved being experimental and the
+                        // cascading nature of drop. This means that we consider
+                        // a cast unstable if and only if one of the types
+                        // involved are in the experimental schema
+                        if cast.contains("toolkit_experimental.") {
+                            return None;
+                        }
+
+                        return Some(val);
+                    }
+
+                    Some(val)
+                })
+                .collect();
+
+            if unexpected_features.is_empty() {
+                return;
+            }
+
+            panic!("unexpectedly released features: {:#?}", unexpected_features)
+        });
+    }
+
+    fn stable_functions() -> HashSet<String> {
+        crate::stabilization_info::STABLE_FUNCTIONS()
+    }
+
+    fn stable_types() -> HashSet<String> {
+        crate::stabilization_info::STABLE_TYPES()
+    }
+
+    fn stable_operators() -> HashSet<String> {
+        crate::stabilization_info::STABLE_OPERATORS
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+}
+
 #[macro_export]
 macro_rules! functions_stabilized_at {
     (
@@ -11,6 +168,27 @@ macro_rules! functions_stabilized_at {
             }
         )*
     ) => {
+        #[cfg(any(test, feature = "pg_test"))]
+        #[allow(non_snake_case)]
+        // we do this instead of just stringifying everything b/c stringify adds
+        // whitespace in places we don't want
+        pub fn $export_symbol() -> std::collections::HashSet<String> {
+            static FUNCTIONS: &[(&str, &[&str])] = &[
+                $(
+                    $(
+                        (
+                            stringify!($fn_name),
+                            &[
+                                $( stringify!($($fn_type)+) ),*
+                            ]
+                        ),
+                    )*
+                )*
+            ];
+            FUNCTIONS.iter().map(|(name, types)| {
+                format!("{}({})", name, types.join(","))
+            }).collect()
+        }
 
     };
 }
@@ -25,7 +203,18 @@ macro_rules! types_stabilized_at {
             }
         )*
     ) => {
-
+        #[cfg(any(test, feature = "pg_test"))]
+        #[allow(non_snake_case)]
+        // we do this instead of just stringifying everything b/c stringify adds
+        // whitespace in places we don't want
+        pub fn $export_symbol() -> std::collections::HashSet<String> {
+            pub static TYPES: &[&str] = &[
+                $(
+                    $(stringify!($type_name),)*
+                )*
+            ];
+            TYPES.iter().map(|s| s.to_ascii_lowercase()).collect()
+        }
     };
 }
 
@@ -39,268 +228,12 @@ macro_rules! operators_stabilized_at {
             }
         )*
     ) => {
-
+        #[cfg(any(test, feature = "pg_test"))]
+         // TODO JOSH - this may not be right
+         pub static $export_symbol: &[&str] = &[
+            $(
+                $(concat!($operator_name, "(", stringify!( $($fn_type),+ ) ")"),)*
+            )*
+        ];
     };
-}
-
-
-#[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
-mod tests {
-    use std::collections::HashSet;
-
-    use pgx::*;
-    use pgx_macros::pg_test;
-
-    // Test that any new features are added to the the experimental schema
-    #[pg_test]
-    fn test_schema_qualification() {
-        Spi::execute(|client| {
-            let released_features: HashSet<_> = RELEASED_FEATURES.iter().cloned().collect();
-            let unexpected_features: Vec<_> = client
-                .select(
-                    "SELECT pg_catalog.pg_describe_object(classid, objid, 0) \
-                    FROM pg_catalog.pg_extension e, pg_catalog.pg_depend d \
-                    WHERE e.extname='timescaledb_toolkit' \
-                    AND refclassid = 'pg_catalog.pg_extension'::pg_catalog.regclass \
-                    AND d.refobjid = e.oid \
-                    AND deptype = 'e'
-                    ORDER BY 1",
-                    None,
-                    None,
-                ).filter_map(|row| {
-                    let val: String = row.by_ordinal(1).unwrap().value().unwrap();
-
-                    if released_features.contains(&*val) {
-                        return None
-                    }
-
-                    if val.starts_with("schema")
-                        && val.strip_prefix("schema ") == Some("toolkit_experimental") {
-                        return None
-                    }
-
-                    if val.starts_with("schema")
-                        && val.strip_prefix("schema ") == Some("tests") {
-                        return None
-                    }
-
-                    let type_prefix = "type toolkit_experimental.";
-                    if val.starts_with(type_prefix)
-                        && val.strip_prefix(type_prefix).is_some() {
-                            return None
-                    }
-
-                    let function_prefix = "function toolkit_experimental.";
-                    if val.starts_with(function_prefix)
-                        && val.strip_prefix(function_prefix).is_some() {
-                            return None
-                    }
-
-                    let operator_prefix = "operator toolkit_experimental.";
-                    if val.starts_with(operator_prefix)
-                        && val.strip_prefix(operator_prefix).is_some() {
-                            return None
-                    }
-
-                    // Allow all `->` operators for now; it's the accessor that
-                    // will be unstable.
-                    if val.starts_with("operator ->(") {
-                        return None
-                    }
-                    if val.starts_with("function arrow_") {
-                        return None
-                    }
-
-                    // Allow all casts now, it's the types that'll be unstable
-                    if val.starts_with("cast from toolkit_experimental.") {
-                        return None
-                    }
-
-                    // ignore the pgx test schema
-                    let test_prefix = "function tests.";
-                    if val.starts_with(test_prefix)
-                        && val.strip_prefix(test_prefix).is_some() {
-                            return None
-                    }
-
-                    Some(val)
-                }).collect();
-
-            if unexpected_features.is_empty() {
-                return
-            }
-
-            panic!("unexpectedly released features: {:#?}", unexpected_features)
-        });
-    }
-
-    // list of features that are released and can be in places other than the
-    // experimental schema
-    // TODO it may pay to auto-discover this list based on the previous version of
-    //      the extension, once we have a released extension
-    static RELEASED_FEATURES: &[&str] = &[
-        "function approx_percentile(double precision,uddsketch)",
-        "function approx_percentile_rank(double precision,uddsketch)",
-        "function error(uddsketch)",
-        "function mean(uddsketch)",
-        "function num_vals(uddsketch)",
-        "function percentile_agg(double precision)",
-        "function percentile_agg(uddsketch)",
-        "function percentile_agg_trans(internal,double precision)",
-        "function uddsketch(integer,double precision,double precision)",
-        "function rollup(uddsketch)",
-        "function uddsketch_combine(internal,internal)",
-        "function uddsketch_compound_trans(internal,uddsketch)",
-        "function uddsketch_deserialize(bytea,internal)",
-        "function uddsketch_final(internal)",
-        "function uddsketch_in(cstring)",
-        "function uddsketch_out(uddsketch)",
-        "function uddsketch_serialize(internal)",
-        "function uddsketch_trans(internal,integer,double precision,double precision)",
-        "type uddsketch",
-        "function approx_percentile(double precision,tdigest)",
-        "function approx_percentile_rank(double precision,tdigest)",
-        "function max_val(tdigest)",
-        "function min_val(tdigest)",
-        "function mean(tdigest)",
-        "function num_vals(tdigest)",
-        "function tdigest(integer,double precision)",
-        "function rollup(tdigest)",
-        "function tdigest_combine(internal,internal)",
-        "function tdigest_compound_combine(internal,internal)",
-        "function tdigest_compound_deserialize(bytea,internal)",
-        "function tdigest_compound_final(internal)",
-        "function tdigest_compound_serialize(internal)",
-        "function tdigest_compound_trans(internal,tdigest)",
-        "function tdigest_deserialize(bytea,internal)",
-        "function tdigest_final(internal)",
-        "function tdigest_in(cstring)",
-        "function tdigest_out(tdigest)",
-        "function tdigest_serialize(internal)",
-        "function tdigest_trans(internal,integer,double precision)",
-        "type tdigest",
-        "function average(timeweightsummary)",
-        "function time_weight(text,timestamp with time zone,double precision)",
-        "function rollup(timeweightsummary)",
-        "function time_weight_combine(internal,internal)",
-        "function time_weight_final(internal)",
-        "function time_weight_summary_trans(internal,timeweightsummary)",
-        "function time_weight_trans(internal,text,timestamp with time zone,double precision)",
-        "function time_weight_trans_deserialize(bytea,internal)",
-        "function time_weight_trans_serialize(internal)",
-        "function timeweightsummary_in(cstring)",
-        "function timeweightsummary_out(timeweightsummary)",
-        "type timeweightsummary",
-        "operator ->(toolkit_experimental.timevector,toolkit_experimental.unstabletimevectorpipeline)",
-        "operator ->(toolkit_experimental.unstabletimevectorpipeline,toolkit_experimental.unstabletimevectorpipeline)",
-        "operator ->>(regproc,regproc)",
-        "operator ->>(regproc,toolkit_experimental.unstabletimevectorpipeline)",
-        "operator ->>(toolkit_experimental.timevector,regproc)",
-        "operator ->>(toolkit_experimental.unstabletimevectorpipeline,regproc)",
-        "operator ->(toolkit_experimental.timevector,toolkit_experimental.pipelinethenstatsagg)",
-        "operator ->(toolkit_experimental.unstabletimevectorpipeline,toolkit_experimental.pipelinethenstatsagg)",
-        "function corr(countersummary)",
-        "function counter_agg(timestamp with time zone,double precision)",
-        "function counter_agg(timestamp with time zone,double precision,tstzrange)",
-        "function counter_agg_combine(internal,internal)",
-        "function counter_agg_final(internal)",
-        "function counter_agg_summary_trans(internal,countersummary)",
-        "function counter_agg_trans(internal,timestamp with time zone,double precision,tstzrange)",
-        "function counter_agg_trans_no_bounds(internal,timestamp with time zone,double precision)",
-        "function counter_summary_trans_deserialize(bytea,internal)",
-        "function counter_summary_trans_serialize(internal)",
-        "function counter_zero_time(countersummary)",
-        "function countersummary_in(cstring)",
-        "function countersummary_out(countersummary)",
-        "function delta(countersummary)",
-        "function extrapolated_delta(countersummary,text)",
-        "function extrapolated_rate(countersummary,text)",
-        "function idelta_left(countersummary)",
-        "function idelta_right(countersummary)",
-        "function intercept(countersummary)",
-        "function irate_left(countersummary)",
-        "function irate_right(countersummary)",
-        "function num_changes(countersummary)",
-        "function num_elements(countersummary)",
-        "function num_resets(countersummary)",
-        "function rate(countersummary)",
-        "function rollup(countersummary)",
-        "function slope(countersummary)",
-        "function time_delta(countersummary)",
-        "function with_bounds(countersummary,tstzrange)",
-        "type countersummary",
-        "function distinct_count(hyperloglog)",
-        "function hyperloglog(integer,anyelement)",
-        "function hyperloglog_combine(internal,internal)",
-        "function hyperloglog_deserialize(bytea,internal)",
-        "function hyperloglog_final(internal)",
-        "function hyperloglog_in(cstring)",
-        "function hyperloglog_out(hyperloglog)",
-        "function hyperloglog_serialize(internal)",
-        "function hyperloglog_trans(internal,integer,anyelement)",
-        "function hyperloglog_union(internal,hyperloglog)",
-        "function rollup(hyperloglog)",
-        "function stderror(hyperloglog)",
-        "type hyperloglog",
-        "function average(statssummary1d)",
-        "function average_x(statssummary2d)",
-        "function average_y(statssummary2d)",
-        "function corr(statssummary2d)",
-        "function covariance(statssummary2d,text)",
-        "function determination_coeff(statssummary2d)",
-        "function intercept(statssummary2d)",
-        "function kurtosis(statssummary1d,text)",
-        "function kurtosis_x(statssummary2d,text)",
-        "function kurtosis_y(statssummary2d,text)",
-        "function num_vals(statssummary1d)",
-        "function num_vals(statssummary2d)",
-        "function rolling(statssummary1d)",
-        "function rolling(statssummary2d)",
-        "function rollup(statssummary1d)",
-        "function rollup(statssummary2d)",
-        "function skewness(statssummary1d,text)",
-        "function skewness_x(statssummary2d,text)",
-        "function skewness_y(statssummary2d,text)",
-        "function slope(statssummary2d)",
-        "function stats1d_combine(internal,internal)",
-        "function stats1d_final(internal)",
-        "function stats1d_inv_trans(internal,double precision)",
-        "function stats1d_summary_inv_trans(internal,statssummary1d)",
-        "function stats1d_summary_trans(internal,statssummary1d)",
-        "function stats1d_trans(internal,double precision)",
-        "function stats1d_trans_deserialize(bytea,internal)",
-        "function stats1d_trans_serialize(internal)",
-        "function stats2d_combine(internal,internal)",
-        "function stats2d_final(internal)",
-        "function stats2d_inv_trans(internal,double precision,double precision)",
-        "function stats2d_summary_inv_trans(internal,statssummary2d)",
-        "function stats2d_summary_trans(internal,statssummary2d)",
-        "function stats2d_trans(internal,double precision,double precision)",
-        "function stats2d_trans_deserialize(bytea,internal)",
-        "function stats2d_trans_serialize(internal)",
-        "function stats_agg(double precision)",
-        "function stats_agg(double precision,double precision)",
-        "function stats_agg_no_inv(double precision)",
-        "function stats_agg_no_inv(double precision,double precision)",
-        "function statssummary1d_in(cstring)",
-        "function statssummary1d_out(statssummary1d)",
-        "function statssummary2d_in(cstring)",
-        "function statssummary2d_out(statssummary2d)",
-        "function stddev(statssummary1d,text)",
-        "function stddev_x(statssummary2d,text)",
-        "function stddev_y(statssummary2d,text)",
-        "function sum(statssummary1d)",
-        "function sum_x(statssummary2d)",
-        "function sum_y(statssummary2d)",
-        "function variance(statssummary1d,text)",
-        "function variance_x(statssummary2d,text)",
-        "function variance_y(statssummary2d,text)",
-        "function x_intercept(statssummary2d)",
-        "type statssummary1d",
-        "type statssummary2d",
-        "function finalize_with_average(toolkit_experimental.unstabletimevectorpipeline,toolkit_experimental.pipelinethenaverage)",
-        "function finalize_with_num_vals(toolkit_experimental.unstabletimevectorpipeline,toolkit_experimental.pipelinethennumvals)",
-        "function finalize_with_sum(toolkit_experimental.unstabletimevectorpipeline,toolkit_experimental.pipelinethensum)",
-    ];
 }

--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -227,7 +227,7 @@ fn tdigest_final(
 
 
 extension_sql!("\n\
-    CREATE AGGREGATE tdigest(size int, value DOUBLE PRECISION)\n\
+    CREATE AGGREGATE tdigest(size integer, value DOUBLE PRECISION)\n\
     (\n\
         sfunc = tdigest_trans,\n\
         stype = internal,\n\

--- a/extension/src/uddsketch.rs
+++ b/extension/src/uddsketch.rs
@@ -445,7 +445,7 @@ fn decompress_counts<'b>(
 
 extension_sql!("\n\
     CREATE AGGREGATE uddsketch(\n\
-        size int, max_error DOUBLE PRECISION, value DOUBLE PRECISION\n\
+        size integer, max_error DOUBLE PRECISION, value DOUBLE PRECISION\n\
     ) (\n\
         sfunc = uddsketch_trans,\n\
         stype = internal,\n\


### PR DESCRIPTION
This commit switches the stabilization tests to the new stabilization info file, meaning there's exactly one central location that decides if things are stable. It also cleans the actual stabilization test code, and documents what invariants we're trying to maintain.