### PR TITLE
Add prototype gauge_agg and a few functions.

### DIFF
--- a/crates/counter-agg/src/range.rs
+++ b/crates/counter-agg/src/range.rs
@@ -18,8 +18,14 @@ impl I64Range {
     pub fn has_infinite(&self)-> bool{
         self.left.is_none() || self.right.is_none()
     }
-    
-    pub fn is_valid(&self) -> bool{
+
+    // TODO See TODO below about range validity.  Right now we don't care
+    //  much.  If we start to care, move the caring to `new` and `extend`
+    //  methods.  That will allow this crate to protect the integrity of
+    //  MetricSummary and I64Range in the face of the extension needing to be
+    //  able to construct them from raw (and therefore potentially
+    //  corrupt) inputs.
+    fn is_valid(&self) -> bool {
         match (self.left, self.right) {
             (Some(a), Some(b)) => a <= b, 
             _ => true,

--- a/crates/counter-agg/src/tests.rs
+++ b/crates/counter-agg/src/tests.rs
@@ -1,5 +1,5 @@
-#[cfg(test)]
-pub mod tests {
+// TODO Move to ../tests/lib.rs
+
     use approx::assert_relative_eq;
     use crate::range::I64Range;
     use crate::*;
@@ -8,7 +8,7 @@ pub mod tests {
     }
     //do proper numerical comparisons on the values where that matters, use exact where it should be exact.
     #[track_caller]
-    pub fn assert_close_enough(p1:&CounterSummary, p2:&CounterSummary) {
+    pub fn assert_close_enough(p1:&MetricSummary, p2:&MetricSummary) {
         assert_eq!(p1.first, p2.first, "first");
         assert_eq!(p1.second, p2.second, "second");
         assert_eq!(p1.penultimate, p2.penultimate, "penultimate");
@@ -22,10 +22,11 @@ pub mod tests {
         assert_relative_eq!(p1.stats.sy2, p2.stats.sy2);
         assert_relative_eq!(p1.stats.sxy, p2.stats.sxy);
     }
+
     #[test]
     fn create() {
         let testpt = TSPoint{ts: 0, val:0.0};
-        let test = CounterSummary::new(&testpt, None);
+        let test = CounterSummaryBuilder::new(&testpt, None).build();
         assert_eq!(test.first, testpt);
         assert_eq!(test.second, testpt);
         assert_eq!(test.penultimate, testpt);
@@ -34,11 +35,12 @@ pub mod tests {
     }
     #[test]
     fn adding_point() {
-        let mut test = CounterSummary::new( &TSPoint{ts: 0, val:0.0}, None);
+        let mut test = CounterSummaryBuilder::new( &TSPoint{ts: 0, val:0.0}, None);
         let testpt = TSPoint{ts:5, val:10.0};
 
         test.add_point(&testpt).unwrap();
-        
+
+        let test = test.build();
         assert_eq!(test.first, TSPoint{ts: 0, val:0.0});
         assert_eq!(test.second, testpt);
         assert_eq!(test.penultimate, TSPoint{ts: 0, val:0.0});
@@ -52,15 +54,15 @@ pub mod tests {
     #[test]
     fn adding_points_to_counter() {
         let startpt = TSPoint{ts: 0, val:0.0};
-        let mut summary = CounterSummary::new( &startpt, None);
+        let mut summary = CounterSummaryBuilder::new( &startpt, None);
         
         summary.add_point(&TSPoint{ts: 5, val:10.0}).unwrap();
         summary.add_point(&TSPoint{ts: 10, val:20.0}).unwrap();
         summary.add_point(&TSPoint{ts: 15, val:20.0}).unwrap();
         summary.add_point(&TSPoint{ts: 20, val:50.0}).unwrap();
         summary.add_point(&TSPoint{ts: 25, val:10.0}).unwrap();
-        
 
+        let summary = summary.build();
         assert_eq!(summary.first, startpt);
         assert_eq!(summary.second, TSPoint{ts: 5, val:10.0});
         assert_eq!(summary.penultimate, TSPoint{ts: 20, val:50.0});
@@ -69,7 +71,7 @@ pub mod tests {
         assert_eq!(summary.num_resets, 1);
         assert_eq!(summary.num_changes, 4);
         assert_eq!(summary.stats.count(), 6);
-        assert_relative_eq!(summary.stats.sum().unwrap().x, to_seconds(75.0));
+        assert_relative_eq!(summary.stats.sum().unwrap().x, 0.000075);
         // non obvious one here, sumy should be the sum of all values including the resets at the time.
         assert_relative_eq!(summary.stats.sum().unwrap().y, 0.0 + 10.0 + 20.0 + 20.0 + 50.0 + 60.0);
     }
@@ -78,33 +80,33 @@ pub mod tests {
     #[test]
     fn adding_out_of_order_counter(){
         let startpt = TSPoint{ts: 0, val:0.0};
-        let mut summary = CounterSummary::new( &startpt, None);
+        let mut summary = CounterSummaryBuilder::new( &startpt, None);
 
         summary.add_point(&TSPoint{ts: 5, val:10.0}).unwrap();
         assert_eq!(CounterError::OrderError, summary.add_point(&TSPoint{ts: 2, val:9.0}).unwrap_err());
-    } 
+    }
 
 
     #[test]
     fn test_counter_delta(){
         let startpt = &TSPoint{ts: 0, val:10.0};
-        let mut summary = CounterSummary::new(&startpt, None);
+        let mut summary = CounterSummaryBuilder::new(&startpt, None);
 
         // with one point
-        assert_relative_eq!(summary.delta(), 0.0);
+        assert_relative_eq!(summary.clone().build().delta(), 0.0);
 
         // simple case
         summary.add_point(&TSPoint{ts: 10, val:20.0}).unwrap();
-        assert_relative_eq!(summary.delta(), 10.0);
+        assert_relative_eq!(summary.clone().build().delta(), 10.0);
 
         //now with a reset
         summary.add_point(&TSPoint{ts: 20, val:10.0}).unwrap();
-        assert_relative_eq!(summary.delta(), 20.0);
+        assert_relative_eq!(summary.clone().build().delta(), 20.0);
     }
 
     #[test]
     fn test_combine(){
-        let mut summary = CounterSummary::new( &TSPoint{ts: 0, val:0.0}, None);
+        let mut summary = CounterSummaryBuilder::new( &TSPoint{ts: 0, val:0.0}, None);
         summary.add_point(&TSPoint{ts: 5, val:10.0}).unwrap();
         summary.add_point(&TSPoint{ts: 10, val:20.0}).unwrap();
         summary.add_point(&TSPoint{ts: 15, val:30.0}).unwrap();
@@ -113,46 +115,46 @@ pub mod tests {
         summary.add_point(&TSPoint{ts: 30, val:40.0}).unwrap();
 
 
-        let mut part1 = CounterSummary::new(&TSPoint{ts: 0, val:0.0}, None);
+        let mut part1 = CounterSummaryBuilder::new(&TSPoint{ts: 0, val:0.0}, None);
         part1.add_point(&TSPoint{ts: 5, val:10.0}).unwrap();
         part1.add_point(&TSPoint{ts: 10, val:20.0}).unwrap();
 
-        let mut part2 = CounterSummary::new(&TSPoint{ts: 15, val:30.0}, None);
+        let mut part2 = CounterSummaryBuilder::new(&TSPoint{ts: 15, val:30.0}, None);
         part2.add_point(&TSPoint{ts: 20, val:50.0}).unwrap();
         part2.add_point(&TSPoint{ts: 25, val:10.0}).unwrap();
         part2.add_point(&TSPoint{ts: 30, val:40.0}).unwrap();
 
 
         let mut combined = part1.clone();
-        combined.combine(&part2).unwrap();
-        assert_close_enough(&summary, &combined);
+        combined.combine(&part2.clone().build()).unwrap();
+        assert_close_enough(&summary.build(), &combined.build());
 
         // test error in wrong direction
-        assert_eq!(part2.combine(&part1).unwrap_err(), CounterError::OrderError);
+        assert_eq!(part2.combine(&part1.build()).unwrap_err(), CounterError::OrderError);
     }
 
     #[test]
     fn test_combine_with_small_summary(){
-        let mut summary = CounterSummary::new( &TSPoint{ts: 0, val:50.0}, None);
+        let mut summary = CounterSummaryBuilder::new( &TSPoint{ts: 0, val:50.0}, None);
         summary.add_point(&TSPoint{ts: 25, val:10.0}).unwrap();
 
 
         // also tests that a reset at the boundary works correctly
-        let part1 = CounterSummary::new( &TSPoint{ts: 0, val:50.0}, None);
-        let part2 = CounterSummary::new( &TSPoint{ts: 25, val:10.0}, None);
+        let part1 = CounterSummaryBuilder::new( &TSPoint{ts: 0, val:50.0}, None);
+        let part2 = CounterSummaryBuilder::new( &TSPoint{ts: 25, val:10.0}, None);
 
         let mut combined = part1.clone();
-        combined.combine(&part2).unwrap();
-        assert_close_enough(&summary, &combined);
+        combined.combine(&part2.clone().build()).unwrap();
+        assert_close_enough(&summary.build(), &combined.build());
 
         // test error in wrong direction
         combined = part2.clone();
-        assert_eq!(combined.combine(&part1).unwrap_err(), CounterError::OrderError);
+        assert_eq!(combined.combine(&part1.build()).unwrap_err(), CounterError::OrderError);
     }
     #[test]
     fn test_multiple_resets() {
         let startpt = TSPoint{ts: 0, val:0.0};
-        let mut summary = CounterSummary::new( &startpt, None);
+        let mut summary = CounterSummaryBuilder::new( &startpt, None);
         
         summary.add_point(&TSPoint{ts: 5, val:10.0}).unwrap();
         summary.add_point(&TSPoint{ts: 10, val:20.0}).unwrap();
@@ -161,8 +163,7 @@ pub mod tests {
         summary.add_point(&TSPoint{ts: 25, val:20.0}).unwrap();
         summary.add_point(&TSPoint{ts: 30, val:40.0}).unwrap();
 
-        
-
+        let summary = summary.build();
         assert_eq!(summary.first, startpt);
         assert_eq!(summary.second, TSPoint{ts: 5, val:10.0});
         assert_eq!(summary.penultimate, TSPoint{ts: 25, val:20.0});
@@ -171,32 +172,32 @@ pub mod tests {
         assert_eq!(summary.num_resets, 2);
         assert_eq!(summary.num_changes, 6);
         assert_eq!(summary.stats.count(), 7);
-        assert_relative_eq!(summary.stats.sum().unwrap().x, to_seconds(105.0));
+        assert_relative_eq!(summary.stats.sum().unwrap().x, 0.000105);
         // non obvious one here, sy should be the sum of all values including the resets at the time they were added. 
         assert_relative_eq!(summary.stats.sum().unwrap().y, 0.0 + 10.0 + 20.0 + 30.0 + 60.0 + 80.0 + 100.0);
 
-        let mut part1 = CounterSummary::new(&TSPoint{ts: 0, val:0.0}, None);
+        let mut part1 = CounterSummaryBuilder::new(&TSPoint{ts: 0, val:0.0}, None);
         part1.add_point(&TSPoint{ts: 5, val:10.0}).unwrap();
         part1.add_point(&TSPoint{ts: 10, val:20.0}).unwrap();
 
-        let mut part2 = CounterSummary::new(&TSPoint{ts: 15, val:10.0}, None);
+        let mut part2 = CounterSummaryBuilder::new(&TSPoint{ts: 15, val:10.0}, None);
         part2.add_point(&TSPoint{ts: 20, val:40.0}).unwrap();
         part2.add_point(&TSPoint{ts: 25, val:20.0}).unwrap();
         part2.add_point(&TSPoint{ts: 30, val:40.0}).unwrap();
 
 
         let mut combined = part1.clone();
-        combined.combine(&part2).unwrap();
-        assert_close_enough(&summary, &combined);
+        combined.combine(&part2.clone().build()).unwrap();
+        assert_close_enough(&summary, &combined.build());
 
         // test error in wrong direction
-        assert_eq!(part2.combine(&part1).unwrap_err(), CounterError::OrderError);
+        assert_eq!(part2.combine(&part1.build()).unwrap_err(), CounterError::OrderError);
     }
     
     #[test]
     fn test_extraction_single_point() {
         let startpt = TSPoint{ts: 20, val:10.0};
-        let summary = CounterSummary::new( &startpt, None);
+        let summary = CounterSummaryBuilder::new( &startpt, None).build();
         assert_relative_eq!(summary.delta(), 0.0);
         assert_eq!(summary.rate(), None);
         assert_relative_eq!(summary.idelta_left(), 0.0);
@@ -209,11 +210,12 @@ pub mod tests {
 
     #[test]
     fn test_extraction_simple(){
-        let mut summary = CounterSummary::new(&TSPoint{ts: 0, val:0.0}, None);
+        let mut summary = CounterSummaryBuilder::new(&TSPoint{ts: 0, val:0.0}, None);
         summary.add_point(&TSPoint{ts: 5, val:5.0}).unwrap();
         summary.add_point(&TSPoint{ts: 10, val:20.0}).unwrap();
         summary.add_point(&TSPoint{ts: 15, val: 30.0}).unwrap();
 
+        let summary = summary.build();
         assert_relative_eq!(summary.delta(), 30.0);
         assert_relative_eq!(summary.rate().unwrap(), to_micro(2.0));
         assert_relative_eq!(summary.idelta_left(), 5.0);
@@ -226,11 +228,12 @@ pub mod tests {
 
     #[test]
     fn test_extraction_with_resets(){
-        let mut summary = CounterSummary::new(&TSPoint{ts: 0, val: 10.0}, None);
+        let mut summary = CounterSummaryBuilder::new(&TSPoint{ts: 0, val: 10.0}, None);
         summary.add_point(&TSPoint{ts: 5, val:5.0}).unwrap();
         summary.add_point(&TSPoint{ts: 10, val:30.0}).unwrap();
         summary.add_point(&TSPoint{ts: 15, val: 15.0}).unwrap();
 
+        let summary = summary.build();
         assert_relative_eq!(summary.delta(), 45.0);
         assert_relative_eq!(summary.rate().unwrap(),to_micro(3.0));
         assert_relative_eq!(summary.idelta_left(), 5.0);
@@ -243,14 +246,14 @@ pub mod tests {
 
     #[test]
     fn test_bounds(){
-        let summary = CounterSummary::new(&TSPoint{ts: 0, val: 10.0}, None);
+        let summary = CounterSummaryBuilder::new(&TSPoint{ts: 0, val: 10.0}, None);
         assert!(summary.bounds_valid()); // no bound is fine.
 
-        let summary = CounterSummary::new(&TSPoint{ts: 0, val: 10.0}, Some(I64Range{left:Some(5), right:Some(10)}));
+        let summary = CounterSummaryBuilder::new(&TSPoint{ts: 0, val: 10.0}, Some(I64Range{left:Some(5), right:Some(10)}));
         assert!(!summary.bounds_valid()); // wrong bound not
 
         // left bound inclusive
-        let mut summary = CounterSummary::new(&TSPoint{ts: 0, val: 10.0}, Some(I64Range{left:Some(0), right:Some(10)}));
+        let mut summary = CounterSummaryBuilder::new(&TSPoint{ts: 0, val: 10.0}, Some(I64Range{left:Some(0), right:Some(10)}));
         assert!(summary.bounds_valid());
         summary.add_point(&TSPoint{ts: 5, val:5.0}).unwrap();
         assert!(summary.bounds_valid());
@@ -261,78 +264,84 @@ pub mod tests {
         assert!(!summary.bounds_valid());
 
         // slightly weird case here... two invalid bounds can produce a validly bounded object once the bounds are combined, this is a bit weird, but seems like it's the correct behavior
-        let summary2 = CounterSummary::new(&TSPoint{ts: 15, val: 10.0}, Some(I64Range{left:Some(20), right:Some(30)}));
-        summary.combine(&summary2).unwrap();
+        let summary2 = CounterSummaryBuilder::new(&TSPoint{ts: 15, val: 10.0}, Some(I64Range{left:Some(20), right:Some(30)}));
+        summary.combine(&summary2.build()).unwrap();
         assert!(summary.bounds_valid());
-        assert_eq!(summary.bounds.unwrap(), I64Range{left:Some(0), right:Some(30)});
+        assert_eq!(summary.clone().build().bounds.unwrap(), I64Range{left:Some(0), right:Some(30)});
 
         // two of the same valid bounds remain the same and valid
-        let summary2 = CounterSummary::new(&TSPoint{ts: 20, val: 10.0}, Some(I64Range{left:Some(0), right:Some(30)}));
-        summary.combine(&summary2).unwrap();
+        let summary2 = CounterSummaryBuilder::new(&TSPoint{ts: 20, val: 10.0}, Some(I64Range{left:Some(0), right:Some(30)}));
+        summary.combine(&summary2.build()).unwrap();
         assert!(summary.bounds_valid());
-        assert_eq!(summary.bounds.unwrap(), I64Range{left:Some(0), right:Some(30)});
+        assert_eq!(summary.clone().build().bounds.unwrap(), I64Range{left:Some(0), right:Some(30)});
 
         // combining with unbounded ones is fine, but the bounds survive
-        let summary2 = CounterSummary::new(&TSPoint{ts: 25, val: 10.0}, None);
-        summary.combine(&summary2).unwrap();
+        let summary2 = CounterSummaryBuilder::new(&TSPoint{ts: 25, val: 10.0}, None);
+        summary.combine(&summary2.build()).unwrap();
         assert!(summary.bounds_valid());
-        assert_eq!(summary.bounds.unwrap(), I64Range{left:Some(0), right:Some(30)});
+        assert_eq!(summary.clone().build().bounds.unwrap(), I64Range{left:Some(0), right:Some(30)});
 
         // and combining bounds that do not span are still invalid
-        let summary2 = CounterSummary::new(&TSPoint{ts: 35, val: 10.0}, Some(I64Range{left:Some(0), right:Some(32)}));
-        summary.combine(&summary2).unwrap();
+        let summary2 = CounterSummaryBuilder::new(&TSPoint{ts: 35, val: 10.0}, Some(I64Range{left:Some(0), right:Some(32)}));
+        summary.combine(&summary2.build()).unwrap();
         assert!(!summary.bounds_valid());
-        assert_eq!(summary.bounds.unwrap(), I64Range{left:Some(0), right:Some(32)});
+        assert_eq!(summary.build().bounds.unwrap(), I64Range{left:Some(0), right:Some(32)});
 
         // combining unbounded with bounded ones is fine, but the bounds survive
-        let mut summary = CounterSummary::new(&TSPoint{ts: 0, val: 10.0}, None);
-        let summary2 = CounterSummary::new(&TSPoint{ts: 25, val: 10.0}, Some(I64Range{left:Some(0), right:Some(30)}));
-        summary.combine(&summary2).unwrap();
+        let mut summary = CounterSummaryBuilder::new(&TSPoint{ts: 0, val: 10.0}, None);
+        let summary2 = CounterSummaryBuilder::new(&TSPoint{ts: 25, val: 10.0}, Some(I64Range{left:Some(0), right:Some(30)}));
+        summary.combine(&summary2.build()).unwrap();
         assert!(summary.bounds_valid());
-        assert_eq!(summary.bounds.unwrap(), I64Range{left:Some(0), right:Some(30)});
+        assert_eq!(summary.build().bounds.unwrap(), I64Range{left:Some(0), right:Some(30)});
     }
 
     #[test]
     fn test_prometheus_extrapolation_simple(){
         //error on lack of bounds provided
-        let summary = CounterSummary::new(&TSPoint{ts: 5000, val:15.0}, None);
+        let summary = CounterSummaryBuilder::new(&TSPoint{ts: 5000, val:15.0}, None);
+        let summary = summary.build();
         assert_eq!(summary.prometheus_delta().unwrap_err(), CounterError::BoundsInvalid);
         assert_eq!(summary.prometheus_rate().unwrap_err(), CounterError::BoundsInvalid);
-        
-        //error on infinite bounds
-        let summary = CounterSummary::new(&TSPoint{ts: 5000, val:15.0}, Some(I64Range{left:None, right:Some(21000)}));
-        assert_eq!(summary.prometheus_delta().unwrap_err(), CounterError::BoundsInvalid);
-        assert_eq!(summary.prometheus_rate().unwrap_err(), CounterError::BoundsInvalid);
-        
-        //ranges less than 1ms are treated as zero by Prom
-        let mut summary = CounterSummary::new(&TSPoint{ts: 300, val:15.0}, Some(I64Range{left:Some(0), right:Some(900)}));
-        summary.add_point(&TSPoint{ts: 600, val:20.0}).unwrap();
-        assert_eq!(summary.prometheus_rate().unwrap(), None);
-        
-        //ranges should go out an extra 1000 so that we account for the extra duration that prom subtracts (1 ms)
-        let mut summary = CounterSummary::new(&TSPoint{ts: 5000, val:15.0}, Some(I64Range{left:Some(0), right:Some(21000)}));
-        // singletons should return none
-        assert_eq!(summary.prometheus_delta().unwrap(), None);
-        assert_eq!(summary.prometheus_rate().unwrap(), None);
 
-        summary.add_point(&TSPoint{ts: 10000, val:20.0}).unwrap();
+        //error on infinite bounds
+        let summary = CounterSummaryBuilder::new(&TSPoint{ts: 5000, val:15.0}, Some(I64Range{left:None, right:Some(21000)})).build();
+        assert_eq!(summary.prometheus_delta().unwrap_err(), CounterError::BoundsInvalid);
+        assert_eq!(summary.prometheus_rate().unwrap_err(), CounterError::BoundsInvalid);
+
+        //ranges less than 1ms are treated as zero by Prom
+        let mut summary = CounterSummaryBuilder::new(&TSPoint{ts: 300, val:15.0}, Some(I64Range{left:Some(0), right:Some(900)}));
+        summary.add_point(&TSPoint{ts: 600, val:20.0}).unwrap();
+        assert_eq!(summary.build().prometheus_rate().unwrap(), None);
+
         //ranges should go out an extra 1000 so that we account for the extra duration that prom subtracts (1 ms)
-        let mut summary = CounterSummary::new(&TSPoint{ts: 5000, val:15.0}, Some(I64Range{left:Some(0), right:Some(21000)}));
+        let mut summary = CounterSummaryBuilder::new(&TSPoint{ts: 5000, val:15.0}, Some(I64Range{left:Some(0), right:Some(21000)}));
         // singletons should return none
-        assert_eq!(summary.prometheus_delta().unwrap(), None);
-        assert_eq!(summary.prometheus_rate().unwrap(), None);
+        assert_eq!(summary.clone().build().prometheus_delta().unwrap(), None);
+        assert_eq!(summary.clone().build().prometheus_rate().unwrap(), None);
+
+        // TODO Was this intentional?  add_point and then we immediately discard!
+        summary.add_point(&TSPoint{ts: 10000, val:20.0}).unwrap();
+
+        //ranges should go out an extra 1000 so that we account for the extra duration that prom subtracts (1 ms)
+        let mut summary = CounterSummaryBuilder::new(&TSPoint{ts: 5000, val:15.0}, Some(I64Range{left:Some(0), right:Some(21000)}));
+        // singletons should return none
+        assert_eq!(summary.clone().build().prometheus_delta().unwrap(), None);
+        assert_eq!(summary.clone().build().prometheus_rate().unwrap(), None);
 
         summary.add_point(&TSPoint{ts: 10000, val:20.0}).unwrap();
         summary.add_point(&TSPoint{ts: 15000, val: 25.0}).unwrap();
-        
+
+        let summary = summary.build();
         assert_relative_eq!(summary.delta(), 10.0);
         assert_relative_eq!(summary.rate().unwrap(),to_micro(0.001));
         assert_relative_eq!(summary.prometheus_delta().unwrap().unwrap(), 20.0);
         // linear cases like this should be equal
         assert_relative_eq!(summary.prometheus_rate().unwrap().unwrap(), summary.rate().unwrap());
-        
+
         // add a point outside our bounds and make sure we error correctly
+        let mut summary = CounterSummaryBuilder::from(summary);
         summary.add_point(&TSPoint{ts: 25000, val: 35.0}).unwrap();
+        let summary = summary.build();
         assert_eq!(summary.prometheus_delta().unwrap_err(), CounterError::BoundsInvalid);
         assert_eq!(summary.prometheus_rate().unwrap_err(), CounterError::BoundsInvalid);
 
@@ -340,38 +349,43 @@ pub mod tests {
 
     #[test]
     fn test_prometheus_extrapolation_bound_size(){
-        let mut summary = CounterSummary::new(&TSPoint{ts: 20000, val:40.0}, Some(I64Range{left:Some(10000), right:Some(51000)}));
+        let mut summary = CounterSummaryBuilder::new(&TSPoint{ts: 20000, val:40.0}, Some(I64Range{left:Some(10000), right:Some(51000)}));
         summary.add_point(&TSPoint{ts: 30000, val:20.0}).unwrap();
         summary.add_point(&TSPoint{ts: 40000, val: 40.0}).unwrap();
+        let summary = summary.build();
         assert_relative_eq!(summary.delta(), 40.0);
         assert_relative_eq!(summary.rate().unwrap(),to_micro(0.002));
         //we go all the way to the edge of the bounds here because it's within 1.1 average steps (when you subtract the extra 1000 for ms it goes to 50000)
         assert_relative_eq!(summary.prometheus_delta().unwrap().unwrap(), 80.0);
         // linear cases like this should be equal
         assert_relative_eq!(summary.prometheus_rate().unwrap().unwrap(), summary.rate().unwrap());
-        
+
         // now lets push the bounds to be a bit bigger
-        summary.bounds = Some(I64Range{left:Some(8000), right:Some(53000)});
+        let mut summary = CounterSummaryBuilder::from(summary);
+        summary.set_bounds(Some(I64Range{left:Some(8000), right:Some(53000)}));
         // now because we're further than 1.1 out on each side, we end projecting out to half the avg distance on each side
-        assert_relative_eq!(summary.prometheus_delta().unwrap().unwrap(), 60.0);
+        assert_relative_eq!(summary.clone().build().prometheus_delta().unwrap().unwrap(), 60.0);
         // but the rate is still divided by the full bound duration
-        assert_relative_eq!(summary.prometheus_rate().unwrap().unwrap(), to_micro(60.0 / 44000.0));
+        assert_relative_eq!(summary.build().prometheus_rate().unwrap().unwrap(), to_micro(60.0 / 44000.0));
 
         //this should all be the same as the last one in the first part. 
         // The change occurs because we hit the zero boundary condition 
         // so things change on the second bit because of where resets occur and our starting value
-        let mut summary = CounterSummary::new(&TSPoint{ts: 20000, val:20.0}, Some(I64Range{left:Some(10000), right:Some(51000)}));
+        let mut summary = CounterSummaryBuilder::new(&TSPoint{ts: 20000, val:20.0}, Some(I64Range{left:Some(10000), right:Some(51000)}));
         summary.add_point(&TSPoint{ts: 30000, val:40.0}).unwrap();
         summary.add_point(&TSPoint{ts: 40000, val: 20.0}).unwrap();
+        let summary = summary.build();
         assert_relative_eq!(summary.delta(), 40.0);
         assert_relative_eq!(summary.rate().unwrap(),to_micro(0.002));
         //we go all the way to the edge of the bounds here because it's within 1.1 average steps
         assert_relative_eq!(summary.prometheus_delta().unwrap().unwrap(), 80.0);
         // linear cases like this should be equal
         assert_relative_eq!(summary.prometheus_rate().unwrap().unwrap(), summary.rate().unwrap());
-        
+
         // now lets push the bounds to be a bit bigger
-        summary.bounds = Some(I64Range{left:Some(8000), right:Some(53000)});
+        let mut summary = CounterSummaryBuilder::from(summary);
+        summary.set_bounds(Some(I64Range{left:Some(8000), right:Some(53000)}));
+        let summary = summary.build();
         // now because we're further than 1.1 out on the right side, 
         // we end projecting out to half the avg distance on that side, 
         // but because we hit the inferred zero point  on the left (0 in this case)
@@ -379,7 +393,4 @@ pub mod tests {
         assert_relative_eq!(summary.prometheus_delta().unwrap().unwrap(), 70.0);
         // but the rate is still divided by the full bound duration
         assert_relative_eq!(summary.prometheus_rate().unwrap().unwrap(), to_micro(70.0 / 44000.0));
-        
-    }   
-
-}
+    }

--- a/docs/gauge_agg.md
+++ b/docs/gauge_agg.md
@@ -1,0 +1,76 @@
+# Gauge Aggregates [<sup><mark>experimental</mark></sup>](/docs/README.md#tag-notes)
+
+A gauge is a metric similar to a counter, with the primary difference being
+that it measures a value that varies up and down over time, rather than an
+ever-increasing COUNT of the number of times something happened.
+Examples include resource utilization metrics, precipitation levels,
+or temperatures.
+
+`gauge_agg` currently shares implementation with `counter_agg` but without the
+resetting logic.  This means it enforces ordering even though that is not
+necessarily required for all gauge aggregates.  We may offer an additional
+unordered gauge aggregate in the future.
+
+# Test table
+
+Examples below are tested against the following table:
+
+```SQL ,non-transactional
+SET TIME ZONE 'UTC';
+CREATE TABLE gauge_test (
+    measure_id      BIGINT,
+    ts              TIMESTAMPTZ ,
+    val             DOUBLE PRECISION,
+    PRIMARY KEY (measure_id, ts)
+);
+INSERT INTO gauge_test SELECT 1, '2020-01-03 UTC'::timestamptz + make_interval(days=>v), v + 1000 FROM generate_series(1,10) v;
+INSERT INTO gauge_test SELECT 2, '2020-01-03 UTC'::timestamptz + make_interval(days=>v), v + 2000 FROM generate_series(1,10) v;
+INSERT INTO gauge_test SELECT 3, '2020-01-03 UTC'::timestamptz + make_interval(days=>v), v + 3000 FROM generate_series(1,10) v;
+```
+
+## Functions
+
+### delta
+
+```SQL
+SELECT toolkit_experimental.delta(toolkit_experimental.gauge_agg(ts, val)) FROM gauge_test;
+```
+```output
+ delta
+-------
+ -1991
+```
+
+### idelta_left
+
+```SQL
+SELECT toolkit_experimental.idelta_left(toolkit_experimental.gauge_agg(ts, val)) FROM gauge_test;
+```
+```output
+ idelta_left
+-------------
+        1002
+```
+
+### idelta_right
+
+```SQL
+SELECT toolkit_experimental.idelta_right(toolkit_experimental.gauge_agg(ts, val)) FROM gauge_test;
+```
+```output
+ idelta_right
+--------------
+         1010
+```
+
+### rollup
+
+```SQL
+WITH t as (SELECT date_trunc('minute', ts), toolkit_experimental.gauge_agg(ts, val) as agg FROM gauge_test group by 1)
+    SELECT toolkit_experimental.delta(toolkit_experimental.rollup(agg)) FROM t;
+```
+```output
+ rollup delta
+--------------
+            9
+```

--- a/extension/src/gauge_agg.rs
+++ b/extension/src/gauge_agg.rs
@@ -1,0 +1,704 @@
+use pgx::*;
+use serde::{Deserialize, Serialize};
+
+use counter_agg::{range::I64Range, GaugeSummaryBuilder, MetricSummary};
+use flat_serialize::FlatSerializable;
+use flat_serialize_macro::FlatSerializable;
+use stats_agg::stats2d::StatsSummary2D;
+use time_series::TSPoint;
+
+use crate::{
+    aggregate_utils::in_aggregate_context,
+    flatten,
+    palloc::{Inner, Internal, InternalAsValue, ToInternal},
+    pg_type,
+    range::{get_range, I64RangeWrapper},
+    raw::{bytea, tstzrange},
+    ron_inout_funcs,
+};
+
+// TODO move to share with counter_agg
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, FlatSerializable)]
+#[repr(C)]
+pub struct FlatSummary {
+    stats: StatsSummary2D,
+    first: TSPoint,
+    second: TSPoint,
+    penultimate: TSPoint,
+    last: TSPoint,
+    reset_sum: f64,
+    num_resets: u64,
+    num_changes: u64,
+    bounds: I64RangeWrapper,
+}
+
+#[pg_schema]
+mod toolkit_experimental {
+    use super::*;
+
+    pg_type! {
+        #[derive(Debug, PartialEq)]
+        struct GaugeSummary {
+            #[flat_serialize::flatten]
+            summary: FlatSummary,
+        }
+    }
+
+    ron_inout_funcs!(GaugeSummary);
+}
+
+use toolkit_experimental::*;
+
+// TODO reunify with crate::counter_agg::CounterSummaryTransSate
+// TODO move to crate::metrics::TransState (taking FnOnce()->MetricSummaryBuilder to support both)
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+struct GaugeSummaryTransState {
+    #[serde(skip)]
+    point_buffer: Vec<TSPoint>,
+    #[serde(skip)]
+    bounds: Option<I64Range>, // stores bounds until we combine points, after which, the bounds are stored in each summary
+    // We have a summary buffer here in order to deal with the fact that when the cmobine function gets called it
+    // must first build up a buffer of InternalMetricSummaries, then sort them, then call the combine function in
+    // the correct order.
+    summary_buffer: Vec<MetricSummary>,
+}
+
+impl GaugeSummaryTransState {
+    fn new() -> Self {
+        Self {
+            point_buffer: vec![],
+            bounds: None,
+            summary_buffer: vec![],
+        }
+    }
+
+    fn push_point(&mut self, value: TSPoint) {
+        self.point_buffer.push(value);
+    }
+
+    fn combine_points(&mut self) {
+        if self.point_buffer.is_empty() {
+            return;
+        }
+        self.point_buffer.sort_unstable_by_key(|p| p.ts);
+        let mut iter = self.point_buffer.iter();
+        let mut summary = GaugeSummaryBuilder::new(iter.next().unwrap(), self.bounds);
+        for p in iter {
+            summary
+                .add_point(p)
+                .unwrap_or_else(|e| pgx::error!("{}", e));
+        }
+        self.point_buffer.clear();
+        // TODO build method should check validity
+        // check bounds only after we've combined all the points, so we aren't doing it all the time.
+        if !summary.bounds_valid() {
+            panic!("counter bounds invalid")
+        }
+        self.summary_buffer.push(summary.build());
+    }
+
+    fn push_summary(&mut self, other: &Self) {
+        let sum_iter = other.summary_buffer.iter();
+        for sum in sum_iter {
+            self.summary_buffer.push(sum.clone());
+        }
+    }
+
+    fn combine_summaries(&mut self) {
+        self.combine_points();
+
+        if self.summary_buffer.len() <= 1 {
+            return;
+        }
+        self.summary_buffer.sort_unstable_by_key(|s| s.first.ts);
+        let mut sum_iter = self.summary_buffer.drain(..);
+        let first = sum_iter.next().expect("already handled empty case");
+        let mut new_summary = GaugeSummaryBuilder::from(first);
+        for sum in sum_iter {
+            new_summary
+                .combine(&sum)
+                .unwrap_or_else(|e| pgx::error!("{}", e));
+        }
+        self.summary_buffer.push(new_summary.build());
+    }
+}
+
+#[pg_extern(immutable, parallel_safe, strict, schema = "toolkit_experimental")]
+fn gauge_summary_trans_serialize(state: Internal) -> bytea {
+    let state: &mut GaugeSummaryTransState = unsafe { state.get_mut().unwrap() };
+    state.combine_summaries();
+    crate::do_serialize!(state)
+}
+
+#[pg_extern(strict, immutable, parallel_safe, schema = "toolkit_experimental")]
+fn gauge_summary_trans_deserialize(bytes: bytea, _internal: Internal) -> Internal {
+    gauge_summary_trans_deserialize_inner(bytes).internal()
+}
+fn gauge_summary_trans_deserialize_inner(bytes: bytea) -> Inner<GaugeSummaryTransState> {
+    let c: GaugeSummaryTransState = crate::do_deserialize!(bytes, GaugeSummaryTransState);
+    c.into()
+}
+
+#[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
+fn gauge_agg_trans(
+    state: Internal,
+    ts: Option<crate::raw::TimestampTz>,
+    val: Option<f64>,
+    bounds: Option<tstzrange>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Internal {
+    gauge_agg_trans_inner(unsafe { state.to_inner() }, ts, val, bounds, fcinfo).internal()
+}
+fn gauge_agg_trans_inner(
+    state: Option<Inner<GaugeSummaryTransState>>,
+    ts: Option<crate::raw::TimestampTz>,
+    val: Option<f64>,
+    bounds: Option<tstzrange>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Inner<GaugeSummaryTransState>> {
+    unsafe {
+        in_aggregate_context(fcinfo, || {
+            let p = match (ts, val) {
+                (_, None) => return state,
+                (None, _) => return state,
+                (Some(ts), Some(val)) => TSPoint { ts: ts.into(), val },
+            };
+            match state {
+                None => {
+                    let mut s = GaugeSummaryTransState::new();
+                    if let Some(r) = bounds {
+                        s.bounds = get_range(r.0 as *mut pg_sys::varlena);
+                    }
+                    s.push_point(p);
+                    Some(s.into())
+                }
+                Some(mut s) => {
+                    s.push_point(p);
+                    Some(s)
+                }
+            }
+        })
+    }
+}
+
+#[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
+fn gauge_agg_trans_no_bounds(
+    state: Internal,
+    ts: Option<crate::raw::TimestampTz>,
+    val: Option<f64>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Internal {
+    gauge_agg_trans_inner(unsafe { state.to_inner() }, ts, val, None, fcinfo).internal()
+}
+
+#[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
+fn gauge_agg_summary_trans(
+    state: Internal,
+    value: Option<GaugeSummary>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Internal {
+    gauge_agg_summary_trans_inner(unsafe { state.to_inner() }, value, fcinfo).internal()
+}
+fn gauge_agg_summary_trans_inner(
+    state: Option<Inner<GaugeSummaryTransState>>,
+    value: Option<GaugeSummary>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Inner<GaugeSummaryTransState>> {
+    unsafe {
+        in_aggregate_context(fcinfo, || match (state, value) {
+            (state, None) => state,
+            (None, Some(value)) => {
+                let mut state = GaugeSummaryTransState::new();
+                state.summary_buffer.push(value.into());
+                Some(state.into())
+            }
+            (Some(mut state), Some(value)) => {
+                state.summary_buffer.push(value.into());
+                Some(state)
+            }
+        })
+    }
+}
+
+#[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
+fn gauge_agg_combine(
+    state1: Internal,
+    state2: Internal,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Internal {
+    unsafe { gauge_agg_combine_inner(state1.to_inner(), state2.to_inner(), fcinfo).internal() }
+}
+fn gauge_agg_combine_inner(
+    state1: Option<Inner<GaugeSummaryTransState>>,
+    state2: Option<Inner<GaugeSummaryTransState>>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Inner<GaugeSummaryTransState>> {
+    unsafe {
+        in_aggregate_context(fcinfo, || {
+            match (state1, state2) {
+                (None, None) => None,
+                (None, Some(state2)) => {
+                    let mut s = state2.clone();
+                    s.combine_points();
+                    Some(s.into())
+                }
+                (Some(state1), None) => {
+                    let mut s = state1.clone();
+                    s.combine_points();
+                    Some(s.into())
+                } //should I make these return themselves?
+                (Some(state1), Some(state2)) => {
+                    let mut s1 = state1.clone(); // is there a way to avoid if it doesn't need it?
+                    s1.combine_points();
+                    let mut s2 = state2.clone();
+                    s2.combine_points();
+                    s2.push_summary(&s1);
+                    Some(s2.into())
+                }
+            }
+        })
+    }
+}
+
+#[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
+fn gauge_agg_final(
+    state: Internal,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<GaugeSummary<'static>> {
+    gauge_agg_final_inner(unsafe { state.to_inner() }, fcinfo)
+}
+fn gauge_agg_final_inner(
+    state: Option<Inner<GaugeSummaryTransState>>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<GaugeSummary<'static>> {
+    unsafe {
+        in_aggregate_context(fcinfo, || {
+            let mut state = match state {
+                None => return None,
+                Some(state) => state.clone(),
+            };
+            state.combine_summaries();
+            debug_assert!(state.summary_buffer.len() <= 1);
+            match state.summary_buffer.pop() {
+                None => None,
+                Some(st) => {
+                    // there are some edge cases that this should prevent, but I'm not sure it's necessary, we do check the bounds in the functions that use them.
+                    if !st.bounds_valid() {
+                        panic!("counter bounds invalid")
+                    }
+                    Some(GaugeSummary::from(st))
+                }
+            }
+        })
+    }
+}
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.gauge_agg( ts timestamptz, value DOUBLE PRECISION, bounds tstzrange )\n\
+    (\n\
+        sfunc = toolkit_experimental.gauge_agg_trans,\n\
+        stype = internal,\n\
+        finalfunc = toolkit_experimental.gauge_agg_final,\n\
+        combinefunc = toolkit_experimental.gauge_agg_combine,\n\
+        serialfunc = toolkit_experimental.gauge_summary_trans_serialize,\n\
+        deserialfunc = toolkit_experimental.gauge_summary_trans_deserialize,\n\
+        parallel = restricted\n\
+    );\n",
+    name = "gauge_agg",
+    requires = [
+        gauge_agg_trans,
+        gauge_agg_final,
+        gauge_agg_combine,
+        gauge_summary_trans_serialize,
+        gauge_summary_trans_deserialize
+    ],
+);
+
+// allow calling gauge agg without bounds provided.
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.gauge_agg( ts timestamptz, value DOUBLE PRECISION )\n\
+    (\n\
+        sfunc = toolkit_experimental.gauge_agg_trans_no_bounds,\n\
+        stype = internal,\n\
+        finalfunc = toolkit_experimental.gauge_agg_final,\n\
+        combinefunc = toolkit_experimental.gauge_agg_combine,\n\
+        serialfunc = toolkit_experimental.gauge_summary_trans_serialize,\n\
+        deserialfunc = toolkit_experimental.gauge_summary_trans_deserialize,\n\
+        parallel = restricted\n\
+    );\n\
+",
+    name = "gauge_agg2",
+    requires = [
+        gauge_agg_trans_no_bounds,
+        gauge_agg_final,
+        gauge_agg_combine,
+        gauge_summary_trans_serialize,
+        gauge_summary_trans_deserialize
+    ],
+);
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.rollup(gs toolkit_experimental.GaugeSummary)\n\
+    (\n\
+        sfunc = toolkit_experimental.gauge_agg_summary_trans,\n\
+        stype = internal,\n\
+        finalfunc = toolkit_experimental.gauge_agg_final,\n\
+        combinefunc = toolkit_experimental.gauge_agg_combine,\n\
+        serialfunc = toolkit_experimental.gauge_summary_trans_serialize,\n\
+        deserialfunc = toolkit_experimental.gauge_summary_trans_deserialize,\n\
+        parallel = restricted\n\
+    );\n\
+",
+    name = "gauge_rollup",
+    requires = [
+        gauge_agg_summary_trans,
+        gauge_agg_final,
+        gauge_agg_combine,
+        gauge_summary_trans_serialize,
+        gauge_summary_trans_deserialize
+    ],
+);
+
+#[pg_extern(
+    name = "delta",
+    strict,
+    immutable,
+    parallel_safe,
+    schema = "toolkit_experimental"
+)]
+fn gauge_agg_delta(summary: GaugeSummary) -> f64 {
+    MetricSummary::from(summary).delta()
+}
+
+#[pg_extern(
+    name = "idelta_left",
+    strict,
+    immutable,
+    parallel_safe,
+    schema = "toolkit_experimental"
+)]
+fn gauge_agg_idelta_left(summary: GaugeSummary) -> f64 {
+    MetricSummary::from(summary).idelta_left()
+}
+
+#[pg_extern(
+    name = "idelta_right",
+    strict,
+    immutable,
+    parallel_safe,
+    schema = "toolkit_experimental"
+)]
+fn gauge_agg_idelta_right(summary: GaugeSummary) -> f64 {
+    MetricSummary::from(summary).idelta_right()
+}
+
+impl From<GaugeSummary<'_>> for MetricSummary {
+    fn from(pg: GaugeSummary<'_>) -> Self {
+        Self {
+            first: pg.summary.first,
+            second: pg.summary.second,
+            penultimate: pg.summary.penultimate,
+            last: pg.summary.last,
+            reset_sum: pg.summary.reset_sum,
+            num_resets: pg.summary.num_resets,
+            num_changes: pg.summary.num_changes,
+            stats: pg.summary.stats,
+            bounds: pg.summary.bounds.to_i64range(),
+        }
+    }
+}
+
+impl From<MetricSummary> for GaugeSummary<'_> {
+    fn from(internal: MetricSummary) -> Self {
+        unsafe {
+            flatten!(GaugeSummary {
+                summary: FlatSummary {
+                    stats: internal.stats,
+                    first: internal.first,
+                    second: internal.second,
+                    penultimate: internal.penultimate,
+                    last: internal.last,
+                    reset_sum: internal.reset_sum,
+                    num_resets: internal.num_resets,
+                    num_changes: internal.num_changes,
+                    bounds: I64RangeWrapper::from_i64range(internal.bounds)
+                }
+            })
+        }
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use pgx_macros::pg_test;
+
+    use crate::counter_agg::testing::*;
+
+    use super::*;
+
+    macro_rules! select_one {
+        ($client:expr, $stmt:expr, $type:ty) => {
+            $client
+                .select($stmt, None, None)
+                .first()
+                .get_one::<$type>()
+                .unwrap()
+        };
+    }
+
+    #[pg_test]
+    fn round_trip() {
+        Spi::execute(|client| {
+            client.select(
+                "CREATE TABLE test(ts timestamptz, val DOUBLE PRECISION)",
+                None,
+                None,
+            );
+            client.select("SET TIME ZONE 'UTC'", None, None);
+            let stmt = "INSERT INTO test VALUES\
+                ('2020-01-01 00:00:00+00', 10.0),\
+                ('2020-01-01 00:01:00+00', 20.0),\
+                ('2020-01-01 00:02:00+00', 30.0),\
+                ('2020-01-01 00:03:00+00', 20.0),\
+                ('2020-01-01 00:04:00+00', 10.0),\
+                ('2020-01-01 00:05:00+00', 20.0),\
+                ('2020-01-01 00:06:00+00', 10.0),\
+                ('2020-01-01 00:07:00+00', 30.0),\
+                ('2020-01-01 00:08:00+00', 10.0)";
+            client.select(stmt, None, None);
+
+            let expected = "(\
+                version:1,\
+                summary:(\
+                    stats:(\
+                        n:9,\
+                        sx:5680370160,\
+                        sx2:216000,\
+                        sx3:0,\
+                        sx4:9175680000,\
+                        sy:160,\
+                        sy2:555.5555555555555,\
+                        sy3:1802.4691358024695,\
+                        sy4:59341.563786008235,\
+                        sxy:-600\
+                    ),\
+                    first:(ts:\"2020-01-01 00:00:00+00\",val:10),\
+                    second:(ts:\"2020-01-01 00:01:00+00\",val:20),\
+                    penultimate:(ts:\"2020-01-01 00:07:00+00\",val:30),\
+                    last:(ts:\"2020-01-01 00:08:00+00\",val:10),\
+                    reset_sum:0,\
+                    num_resets:0,\
+                    num_changes:8,\
+                    bounds:(\
+                        is_present:0,\
+                        has_left:0,\
+                        has_right:0,\
+                        padding:(0,0,0,0,0),\
+                        left:None,\
+                        right:None\
+                    )\
+                )\
+            )";
+
+            assert_eq!(
+                expected,
+                select_one!(
+                    client,
+                    "SELECT toolkit_experimental.gauge_agg(ts, val)::TEXT FROM test",
+                    String
+                )
+            );
+
+            assert_eq!(
+                expected,
+                select_one!(
+                    client,
+                    &format!(
+                        "SELECT '{}'::toolkit_experimental.GaugeSummary::TEXT",
+                        expected
+                    ),
+                    String
+                )
+            );
+        });
+    }
+
+    #[pg_test]
+    fn delta_after_gauge_decrease() {
+        Spi::execute(|client| {
+            decrease(&client);
+            let stmt = "SELECT toolkit_experimental.delta(toolkit_experimental.gauge_agg(ts, val)) FROM test";
+            assert_eq!(-20.0, select_one!(client, stmt, f64));
+        });
+    }
+
+    #[pg_test]
+    fn delta_after_gauge_increase() {
+        Spi::execute(|client| {
+            increase(&client);
+            let stmt = "SELECT toolkit_experimental.delta(toolkit_experimental.gauge_agg(ts, val)) FROM test";
+            assert_eq!(20.0, select_one!(client, stmt, f64));
+        });
+    }
+
+    #[pg_test]
+    fn delta_after_gauge_decrease_then_increase_to_same_value() {
+        Spi::execute(|client| {
+            decrease_then_increase_to_same_value(&client);
+            let stmt = "SELECT toolkit_experimental.delta(toolkit_experimental.gauge_agg(ts, val)) FROM test";
+            assert_eq!(0.0, select_one!(client, stmt, f64));
+        });
+    }
+
+    #[pg_test]
+    fn delta_after_gauge_increase_then_decrease_to_same_value() {
+        Spi::execute(|client| {
+            increase_then_decrease_to_same_value(&client);
+            let stmt = "SELECT toolkit_experimental.delta(toolkit_experimental.gauge_agg(ts, val)) FROM test";
+            assert_eq!(0.0, select_one!(client, stmt, f64));
+        });
+    }
+
+    #[pg_test]
+    fn idelta_left_after_gauge_decrease() {
+        Spi::execute(|client| {
+            decrease(&client);
+            let stmt = "SELECT toolkit_experimental.idelta_left(toolkit_experimental.gauge_agg(ts, val)) FROM test";
+            assert_eq!(10.0, select_one!(client, stmt, f64));
+        });
+    }
+
+    #[pg_test]
+    fn idelta_left_after_gauge_increase() {
+        Spi::execute(|client| {
+            increase(&client);
+            let stmt = "SELECT toolkit_experimental.idelta_left(toolkit_experimental.gauge_agg(ts, val)) FROM test";
+            assert_eq!(20.0, select_one!(client, stmt, f64));
+        });
+    }
+
+    #[pg_test]
+    fn idelta_left_after_gauge_increase_then_decrease_to_same_value() {
+        Spi::execute(|client| {
+            increase_then_decrease_to_same_value(&client);
+            let stmt = "SELECT toolkit_experimental.idelta_left(toolkit_experimental.gauge_agg(ts, val)) FROM test";
+            assert_eq!(20.0, select_one!(client, stmt, f64));
+        });
+    }
+
+    #[pg_test]
+    fn idelta_left_after_gauge_decrease_then_increase_to_same_value() {
+        Spi::execute(|client| {
+            decrease_then_increase_to_same_value(&client);
+            let stmt = "SELECT toolkit_experimental.idelta_left(toolkit_experimental.gauge_agg(ts, val)) FROM test";
+            assert_eq!(10.0, select_one!(client, stmt, f64));
+        });
+    }
+
+    #[pg_test]
+    fn idelta_right_after_gauge_decrease() {
+        Spi::execute(|client| {
+            decrease(&client);
+            let stmt = "SELECT toolkit_experimental.idelta_right(toolkit_experimental.gauge_agg(ts, val)) FROM test";
+            assert_eq!(10.0, select_one!(client, stmt, f64));
+        });
+    }
+
+    #[pg_test]
+    fn idelta_right_after_gauge_increase() {
+        Spi::execute(|client| {
+            increase(&client);
+            let stmt = "SELECT toolkit_experimental.idelta_right(toolkit_experimental.gauge_agg(ts, val)) FROM test";
+            assert_eq!(20.0, select_one!(client, stmt, f64));
+        });
+    }
+
+    #[pg_test]
+    fn idelta_right_after_gauge_increase_then_decrease_to_same_value() {
+        Spi::execute(|client| {
+            increase_then_decrease_to_same_value(&client);
+            let stmt = "SELECT toolkit_experimental.idelta_right(toolkit_experimental.gauge_agg(ts, val)) FROM test";
+            assert_eq!(10.0, select_one!(client, stmt, f64));
+        });
+    }
+
+    #[pg_test]
+    fn idelta_right_after_gauge_decrease_then_increase_to_same_value() {
+        Spi::execute(|client| {
+            decrease_then_increase_to_same_value(&client);
+            let stmt = "SELECT toolkit_experimental.idelta_right(toolkit_experimental.gauge_agg(ts, val)) FROM test";
+            assert_eq!(20.0, select_one!(client, stmt, f64));
+        });
+    }
+
+    // TODO 3rd copy of this...
+    #[track_caller]
+    fn assert_close_enough(p1: &MetricSummary, p2: &MetricSummary) {
+        assert_eq!(p1.first, p2.first, "first");
+        assert_eq!(p1.second, p2.second, "second");
+        assert_eq!(p1.penultimate, p2.penultimate, "penultimate");
+        assert_eq!(p1.last, p2.last, "last");
+        assert_eq!(p1.num_changes, p2.num_changes, "num_changes");
+        assert_eq!(p1.num_resets, p2.num_resets, "num_resets");
+        assert_eq!(p1.stats.n, p2.stats.n, "n");
+        use approx::assert_relative_eq;
+        assert_relative_eq!(p1.stats.sx, p2.stats.sx);
+        assert_relative_eq!(p1.stats.sx2, p2.stats.sx2);
+        assert_relative_eq!(p1.stats.sy, p2.stats.sy);
+        assert_relative_eq!(p1.stats.sy2, p2.stats.sy2);
+        assert_relative_eq!(p1.stats.sxy, p2.stats.sxy);
+    }
+
+    #[pg_test]
+    fn rollup() {
+        Spi::execute(|client| {
+            client.select(
+                "CREATE TABLE test(ts timestamptz, val DOUBLE PRECISION)",
+                None,
+                None,
+            );
+
+            // This tests GaugeSummary::single_value - the old first == last
+            // check erroneously saw 21.0 == 21.0 and called it a single value.
+            let stmt = "INSERT INTO test VALUES('2020-01-01 00:00:00+00', 10.0), ('2020-01-01 00:01:00+00', 21.0), ('2020-01-01 00:01:00+00', 22.0), ('2020-01-01 00:01:00+00', 21.0)";
+            client.select(stmt, None, None);
+
+            let stmt = "INSERT INTO test VALUES('2020-01-01 00:02:00+00', 10.0), ('2020-01-01 00:03:00+00', 20.0), ('2020-01-01 00:04:00+00', 10.0)";
+            client.select(stmt, None, None);
+
+            let stmt = "INSERT INTO test VALUES('2020-01-01 00:08:00+00', 30.0), ('2020-01-01 00:10:00+00', 30.0), ('2020-01-01 00:10:30+00', 10.0), ('2020-01-01 00:20:00+00', 40.0)";
+            client.select(stmt, None, None);
+
+            //combine function works as expected
+            let stmt = "SELECT toolkit_experimental.gauge_agg(ts, val) FROM test";
+            let a = select_one!(client, stmt, GaugeSummary);
+            let stmt = "WITH t as (SELECT date_trunc('minute', ts), toolkit_experimental.gauge_agg(ts, val) as agg FROM test group by 1 ) SELECT toolkit_experimental.rollup(agg) FROM t";
+            let b = select_one!(client, stmt, GaugeSummary);
+            assert_close_enough(&a.into(), &b.into());
+        });
+    }
+
+    // TODO https://github.com/timescale/timescaledb-toolkit/issues/362
+    // TODO why doesn't this catch the error under github actions?
+    // #[pg_test(error = "returned Datum was NULL")]
+    #[allow(dead_code)]
+    fn nulls() {
+        Spi::execute(|client| {
+            client.select(
+                "CREATE TABLE test(ts timestamptz, val DOUBLE PRECISION)",
+                None,
+                None,
+            );
+
+            let stmt = "INSERT INTO test VALUES (NULL, NULL)";
+            client.select(stmt, None, None);
+
+            let stmt = "SELECT toolkit_experimental.gauge_agg(ts, val) FROM test";
+            let _ = select_one!(client, stmt, GaugeSummary);
+        });
+    }
+}

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -9,6 +9,7 @@ pub mod time_weighted_average;
 pub mod asap;
 pub mod lttb;
 pub mod counter_agg;
+pub mod gauge_agg;
 pub mod range;
 pub mod state_aggregate;
 pub mod stats_agg;


### PR DESCRIPTION
The primary difference between a counter and a gauge is that counters
only increase, so apparent decreases are treated as resets followed by
continued increments from the pre-reset value.

To facilitate this, we move the reset accounting into a new
`CounterSummaryBuilder` and add a `GaugeSummaryBuilder` which does not
handle resets specially.

Functions:
- delta
- idelta_left
- idelta_right
- rollup

Also expand counter_agg's minimal tests just a bit.  Both aggregates
still need much more thorough testing.

TODO:
- consider deeper changes to `CounterSummary` and its Builders to
  protect invariants (currently bug-prone as innards are exposed)

Resolves issue #375.