### PR TITLE
Stop auto building `nightly` image

### DIFF
--- a/.github/workflows/patch_build.yml
+++ b/.github/workflows/patch_build.yml
@@ -1,14 +1,11 @@
-name: nightly
+name: patch
 
 on:
   pull_request:
     paths:
-      - 'docker/nightly/**'
-      - '.github/workflows/nightly_build.yml'
+      - 'docker/patch/**'
+      - '.github/workflows/patch_build.yml'
   workflow_dispatch:
-  schedule:
-    # we build at 8am UTC, 3am Eastern, midnight Pacific
-    - cron:  '0 8 * * 1-4'
 
 jobs:
   build:
@@ -43,7 +40,7 @@ jobs:
           push: false
           load: true
           context: .
-          file: ./docker/nightly/Dockerfile
+          file: ./docker/patch/Dockerfile
           tags: timescaledev/timescale-analytics:nightly
 
       - name: Run Doc Tests
@@ -58,7 +55,7 @@ jobs:
         with:
           push: true
           context: .
-          file: ./docker/nightly/Dockerfile
+          file: ./docker/patch/Dockerfile
           tags: timescaledev/timescale-analytics:nightly,timescaledev/timescaledb-toolkit:nightly
 
       - name: Image digest

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/timescale/timescaledb-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/timescale/timescaledb-toolkit/actions/workflows/ci.yml) [![nightly](https://github.com/timescale/timescaledb-toolkit/actions/workflows/nightly_build.yml/badge.svg)](https://github.com/timescale/timescaledb-toolkit/actions/workflows/nightly_build.yml)
+[![CI](https://github.com/timescale/timescaledb-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/timescale/timescaledb-toolkit/actions/workflows/ci.yml)
 
 
 # TimescaleDB Toolkit #
@@ -16,9 +16,7 @@ in this repository at [`docs`](https://github.com/timescale/timescaledb-toolkit/
 
 ## 🖥 Try It Out ##
 
-The extension comes pre-installed on all [Timescale Cloud](https://www.timescale.com/products#timescale-cloud) instances, and also on our full-featured [`timescale/timescaledb-ha` docker image](https://hub.docker.com/r/timescale/timescaledb-ha).
-
-We also provide nightly builds as a docker images in `timescaledev/timescaledb-toolkit:nightly`.
+The extension comes pre-installed on all [Timescale Cloud](https://www.timescale.com/products#timescale-cloud) instances and also on our full-featured [`timescale/timescaledb-ha` docker image](https://hub.docker.com/r/timescale/timescaledb-ha).
 
 All versions of the extension contain experimental features in the `toolkit_experimental`, schema see [our docs section on experimental features](/docs/README.md#tag-notes) for
 more details.

--- a/docker/patch/Dockerfile
+++ b/docker/patch/Dockerfile
@@ -24,7 +24,7 @@ ENV PATH="/build/.cargo/bin:${PATH}"
 RUN set -ex \
     && rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" \
     && chown postgres:postgres -R "${CARGO_HOME}" \
-    && cargo install cargo-pgx \
+    && cargo install cargo-pgx --version '^0.2' \
     # initdb fails as root so generate the correct config ourselves
     # && cargo pgx init --pg13 /usr/lib/postgresql/13/bin/pg_config
     && mkdir -p /root/.pgx \


### PR DESCRIPTION
The nightly docker image is sporadically useful for debugging purposes, but not really something we should advertise as a first-call installation platform.

This commit stops advertising the build, and also removes the auto-build; we can trigger the build manually when we need a version.

Supersedes PR #366 