### PR TITLE
Handle NULL output from our aggregates

### DIFF
--- a/crates/aggregate_builder/Readme.md
+++ b/crates/aggregate_builder/Readme.md
@@ -98,7 +98,7 @@ pub mod aggregate_name {
         __inner: pgx::Internal,
         value: RustType,
         __fcinfo: pg_sys::FunctionCallInfo,
-    ) -> Internal {
+    ) -> Option<Internal> {
         use crate::palloc::{Inner, InternalAsValue, ToInternal};
         unsafe {
             // Translate from the SQL type to the rust one
@@ -189,7 +189,7 @@ pub mod aggregate_name {
     pub fn aggregate_name_deserialize_fn_outer(
         bytes: crate::raw::bytea,
         _internal: Internal,
-    ) -> Internal {
+    ) -> Option<Internal> {
         use crate::palloc::ToInternal;
         let result = deserialize(bytes);
         let state: State = result;
@@ -209,7 +209,7 @@ pub mod aggregate_name {
         a: Internal,
         b: Internal,
         __fcinfo: pg_sys::FunctionCallInfo,
-    ) -> Internal {
+    ) -> Option<Internal> {
         use crate::palloc::{Inner, InternalAsValue, ToInternal};
         unsafe {
             // Switch to the aggregate memory context. This ensures that the

--- a/crates/aggregate_builder/src/lib.rs
+++ b/crates/aggregate_builder/src/lib.rs
@@ -675,7 +675,7 @@ impl AggregateFn {
             pub fn #outer_ident(
                 #input_var: pgx::Internal,
                 #(#arg_signatures,)*
-            ) -> Internal {
+            ) -> Option<Internal> {
                 use crate::palloc::{Inner, InternalAsValue, ToInternal};
                 unsafe {
                     let mut #input_var: Option<Inner<Option<State>>> = #input_var.to_inner();
@@ -863,7 +863,7 @@ impl AggregateFn {
             pub fn #outer_ident(
                 bytes: crate::raw::bytea,
                 _internal: Internal
-            ) -> Internal {
+            ) -> Option<Internal> {
                 use crate::palloc::ToInternal;
                 let #result_var = #ident(bytes);
                 #result_type_check
@@ -926,7 +926,7 @@ impl AggregateFn {
                 #a_name: Internal,
                 #b_name: Internal,
                 __fcinfo: pg_sys::FunctionCallInfo
-            ) -> Internal {
+            ) -> Option<Internal> {
                 use crate::palloc::{Inner, InternalAsValue, ToInternal};
                 unsafe {
                     crate::aggregate_utils::in_aggregate_context(__fcinfo, || {

--- a/extension/src/asap.rs
+++ b/extension/src/asap.rs
@@ -39,7 +39,7 @@ pub fn asap_trans(
     val: Option<f64>,
     resolution: i32,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     asap_trans_internal(unsafe{ state.to_inner() }, ts, val, resolution, fcinfo).internal()
 }
 pub fn asap_trans_internal(

--- a/extension/src/counter_agg.rs
+++ b/extension/src/counter_agg.rs
@@ -176,7 +176,7 @@ pub fn counter_summary_trans_serialize(
 pub fn counter_summary_trans_deserialize(
     bytes: bytea,
     _internal: Internal,
-) -> Internal {
+) -> Option<Internal> {
     counter_summary_trans_deserialize_inner(bytes).internal()
 }
 pub fn counter_summary_trans_deserialize_inner(
@@ -193,7 +193,7 @@ pub fn counter_agg_trans(
     val: Option<f64>,
     bounds: Option<tstzrange>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     counter_agg_trans_inner(unsafe { state.to_inner() }, ts, val, bounds, fcinfo).internal()
 }
 pub fn counter_agg_trans_inner(
@@ -231,7 +231,7 @@ pub fn counter_agg_trans_no_bounds(
     ts: Option<crate::raw::TimestampTz>,
     val: Option<f64>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     counter_agg_trans_inner(unsafe{ state.to_inner() }, ts, val, None, fcinfo).internal()
 }
 
@@ -241,7 +241,7 @@ pub fn counter_agg_summary_trans(
     state: Internal,
     value: Option<CounterSummary>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     counter_agg_summary_trans_inner(unsafe{ state.to_inner() }, value, fcinfo).internal()
 }
 pub fn counter_agg_summary_trans_inner(
@@ -272,7 +272,7 @@ pub fn counter_agg_combine(
     state1: Internal,
     state2: Internal,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     unsafe {
         counter_agg_combine_inner(state1.to_inner(), state2.to_inner(), fcinfo).internal()
     }
@@ -982,7 +982,7 @@ mod tests {
             let state = counter_agg_trans_inner(state, Some((BASE + 5 * MIN).into()), Some(30.0), None, ptr::null_mut());
 
             let mut control = state.unwrap();
-            let buffer = counter_summary_trans_serialize(Inner::from(control.clone()).internal());
+            let buffer = counter_summary_trans_serialize(Inner::from(control.clone()).internal().unwrap());
             let buffer = pgx::varlena::varlena_to_byte_slice(buffer.0 as *mut pg_sys::varlena);
 
             let expected = [1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 96, 194, 134, 7, 62, 2, 0, 0, 0, 0, 0, 0, 0, 36, 64, 0, 231, 85, 138, 7, 62, 2, 0, 0, 0, 0, 0, 0, 0, 52, 64, 0, 124, 16, 149, 7, 62, 2, 0, 0, 0, 0, 0, 0, 0, 52, 64, 0, 3, 164, 152, 7, 62, 2, 0, 0, 0, 0, 0, 0, 0, 62, 64, 0, 0, 0, 0, 0, 0, 62, 64, 1, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 144, 246, 54, 236, 65, 0, 0, 0, 0, 0, 195, 238, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 24, 32, 17, 209, 65, 0, 0, 0, 0, 0, 64, 106, 64, 0, 0, 0, 0, 0, 88, 155, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 76, 248, 42, 65, 0, 0, 0, 0, 0, 130, 196, 64, 0];

--- a/extension/src/gauge_agg.rs
+++ b/extension/src/gauge_agg.rs
@@ -131,7 +131,7 @@ fn gauge_summary_trans_serialize(state: Internal) -> bytea {
 }
 
 #[pg_extern(strict, immutable, parallel_safe, schema = "toolkit_experimental")]
-fn gauge_summary_trans_deserialize(bytes: bytea, _internal: Internal) -> Internal {
+fn gauge_summary_trans_deserialize(bytes: bytea, _internal: Internal) -> Option<Internal> {
     gauge_summary_trans_deserialize_inner(bytes).internal()
 }
 fn gauge_summary_trans_deserialize_inner(bytes: bytea) -> Inner<GaugeSummaryTransState> {
@@ -146,7 +146,7 @@ fn gauge_agg_trans(
     val: Option<f64>,
     bounds: Option<tstzrange>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     gauge_agg_trans_inner(unsafe { state.to_inner() }, ts, val, bounds, fcinfo).internal()
 }
 fn gauge_agg_trans_inner(
@@ -187,7 +187,7 @@ fn gauge_agg_trans_no_bounds(
     ts: Option<crate::raw::TimestampTz>,
     val: Option<f64>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     gauge_agg_trans_inner(unsafe { state.to_inner() }, ts, val, None, fcinfo).internal()
 }
 
@@ -196,7 +196,7 @@ fn gauge_agg_summary_trans(
     state: Internal,
     value: Option<GaugeSummary>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     gauge_agg_summary_trans_inner(unsafe { state.to_inner() }, value, fcinfo).internal()
 }
 fn gauge_agg_summary_trans_inner(
@@ -225,7 +225,7 @@ fn gauge_agg_combine(
     state1: Internal,
     state2: Internal,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     unsafe { gauge_agg_combine_inner(state1.to_inner(), state2.to_inner(), fcinfo).internal() }
 }
 fn gauge_agg_combine_inner(

--- a/extension/src/lttb.rs
+++ b/extension/src/lttb.rs
@@ -23,7 +23,7 @@ pub fn lttb_trans(
     val: Option<f64>,
     resolution: i32,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     lttb_trans_inner(unsafe{ state.to_inner() }, time, val, resolution, fcinfo).internal()
 }
 pub fn lttb_trans_inner(

--- a/extension/src/palloc.rs
+++ b/extension/src/palloc.rs
@@ -50,7 +50,7 @@ unsafe impl InternalAsValue for Internal {
 /// # Safety
 /// The value input must live as long as postgres expects. TODO more info
 pub unsafe trait ToInternal {
-    fn internal(self) -> Internal;
+    fn internal(self) -> Option<Internal>;
 }
 
 pub struct Inner<T>(pub NonNull<T>);
@@ -70,14 +70,14 @@ impl<T> DerefMut for Inner<T> {
 }
 
 unsafe impl<T> ToInternal for Option<Inner<T>> {
-    fn internal(self) -> Internal {
-        self.map(|p| p.0.as_ptr() as pg_sys::Datum).into()
+    fn internal(self) -> Option<Internal> {
+        self.map(|p| Internal::from(Some(p.0.as_ptr() as pg_sys::Datum)))
     }
 }
 
 unsafe impl<T> ToInternal for Inner<T> {
-    fn internal(self) -> Internal {
-        Some(self.0.as_ptr() as pg_sys::Datum).into()
+    fn internal(self) -> Option<Internal> {
+        Some(Internal::from(Some(self.0.as_ptr() as pg_sys::Datum)))
     }
 }
 
@@ -91,14 +91,14 @@ impl<T> From<T> for Inner<T> {
 
 // TODO these last two should probably be `unsafe`
 unsafe impl<T> ToInternal for *mut T {
-    fn internal(self) -> Internal {
-        Internal::from(Some(self as pg_sys::Datum))
+    fn internal(self) -> Option<Internal> {
+        Some(Internal::from(Some(self as pg_sys::Datum)))
     }
 }
 
 unsafe impl<T> ToInternal for *const T {
-    fn internal(self) -> Internal {
-        Internal::from(Some(self as pg_sys::Datum))
+    fn internal(self) -> Option<Internal> {
+        Some(Internal::from(Some(self as pg_sys::Datum)))
     }
 }
 

--- a/extension/src/stats_agg.rs
+++ b/extension/src/stats_agg.rs
@@ -126,7 +126,7 @@ pub fn stats1d_trans_serialize(
 pub fn stats1d_trans_deserialize(
     bytes: bytea,
     _internal: Internal,
-) -> Internal {
+) -> Option<Internal> {
     stats1d_trans_deserialize_inner(bytes).internal()
 }
 pub fn stats1d_trans_deserialize_inner(
@@ -148,7 +148,7 @@ pub fn stats2d_trans_serialize(
 pub fn stats2d_trans_deserialize(
     bytes: bytea,
     _internal: Internal,
-) -> Internal {
+) -> Option<Internal> {
     stats2d_trans_deserialize_inner(bytes).internal()
 }
 pub fn stats2d_trans_deserialize_inner(
@@ -163,7 +163,7 @@ pub fn stats1d_trans<'s>(
     state: Internal,
     val: Option<f64>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     stats1d_trans_inner(unsafe{ state.to_inner() }, val, fcinfo).internal()
 }
 pub fn stats1d_trans_inner(
@@ -199,7 +199,7 @@ pub fn stats2d_trans(
     y: Option<f64>,
     x: Option<f64>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     stats2d_trans_inner(unsafe{ state.to_inner() }, y, x, fcinfo).internal()
 }
 pub fn stats2d_trans_inner(
@@ -240,7 +240,7 @@ pub fn stats1d_inv_trans(
     state: Internal,
     val: Option<f64>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     stats1d_inv_trans_inner(unsafe{ state.to_inner()}, val, fcinfo).internal()
 }
 pub fn stats1d_inv_trans_inner(
@@ -269,7 +269,7 @@ pub fn stats2d_inv_trans(
     y: Option<f64>,
     x: Option<f64>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     stats2d_inv_trans_inner(unsafe{ state.to_inner()}, y, x, fcinfo).internal()
 }
 pub fn stats2d_inv_trans_inner(
@@ -304,7 +304,7 @@ pub fn stats1d_summary_trans(
     state: Internal,
     value: Option<StatsSummary1D>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     stats1d_summary_trans_inner(unsafe{ state.to_inner() }, value, fcinfo).internal()
 }
 pub fn stats1d_summary_trans_inner<'s>(
@@ -336,7 +336,7 @@ pub fn stats2d_summary_trans(
     state: Internal,
     value: Option<StatsSummary2D>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     stats2d_summary_trans_inner(unsafe{ state.to_inner() }, value, fcinfo).internal()
 }
 pub fn stats2d_summary_trans_inner<'s>(
@@ -366,7 +366,7 @@ pub fn stats1d_summary_inv_trans(
     state: Internal,
     value: Option<StatsSummary1D>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     stats1d_summary_inv_trans_inner(unsafe{ state.to_inner() }, value, fcinfo).internal()
 }
 pub fn stats1d_summary_inv_trans_inner<'s>(
@@ -395,7 +395,7 @@ pub fn stats2d_summary_inv_trans(
     state: Internal,
     value: Option<StatsSummary2D>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     stats2d_summary_inv_trans_inner(unsafe {state.to_inner()}, value, fcinfo).internal()
 }
 pub fn stats2d_summary_inv_trans_inner<'s>(
@@ -424,7 +424,7 @@ pub fn stats1d_combine(
     state1: Internal,
     state2: Internal,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     unsafe {
         stats1d_combine_inner(state1.to_inner(), state2.to_inner(), fcinfo).internal()
     }
@@ -462,7 +462,7 @@ pub fn stats2d_combine(
     state1: Internal,
     state2: Internal,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     unsafe {
         stats2d_combine_inner(state1.to_inner(), state2.to_inner(), fcinfo).internal()
     }
@@ -1409,7 +1409,7 @@ mod tests {
             let state = stats1d_trans_inner(state, Some(-43.0), ptr::null_mut());
 
             let control = state.unwrap();
-            let buffer = stats1d_trans_serialize(Inner::from(control.clone()).internal());
+            let buffer = stats1d_trans_serialize(Inner::from(control.clone()).internal().unwrap());
             let buffer = pgx::varlena::varlena_to_byte_slice(buffer.0 as *mut pg_sys::varlena);
 
             let expected = [1, 1, 1, 5, 0, 0, 0, 0, 0, 0, 0, 144, 194, 245, 40, 92, 143, 73, 64, 100, 180, 142, 170, 38, 151, 174, 64, 72, 48, 180, 190, 189, 33, 254, 192, 119, 78, 30, 195, 209, 190, 96, 65];

--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -57,7 +57,7 @@ pub fn tdigest_trans(
     size: i32,
     value: Option<f64>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     tdigest_trans_inner(unsafe{ state.to_inner() }, size, value, fcinfo).internal()
 }
 pub fn tdigest_trans_inner(
@@ -92,7 +92,7 @@ pub fn tdigest_combine(
     state1: Internal,
     state2: Internal,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     unsafe {
         tdigest_combine_inner(state1.to_inner(), state2.to_inner(), fcinfo).internal()
     }
@@ -146,7 +146,7 @@ pub fn tdigest_serialize(
 pub fn tdigest_deserialize(
     bytes: bytea,
     _internal: Internal,
-) -> Internal {
+) -> Option<Internal> {
     tdigest_deserialize_inner(bytes).internal()
 }
 pub fn tdigest_deserialize_inner(
@@ -247,7 +247,7 @@ pub fn tdigest_compound_trans(
     state: Internal,
     value: Option<TDigest<'static>>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     tdigest_compound_trans_inner(unsafe{ state.to_inner() }, value, fcinfo).internal()
 }
 pub fn tdigest_compound_trans_inner(
@@ -276,7 +276,7 @@ pub fn tdigest_compound_combine(
     state1: Internal,
     state2: Internal,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     unsafe {
         tdigest_compound_combine_inner(state1.to_inner(), state2.to_inner(), fcinfo).internal()
     }
@@ -325,7 +325,7 @@ fn tdigest_compound_serialize(
 pub fn tdigest_compound_deserialize(
     bytes: bytea,
     _internal: Internal,
-) -> Internal {
+) -> Option<Internal> {
     let i: InternalTDigest = crate::do_deserialize!(bytes, InternalTDigest);
     Inner::from(i).internal()
 }
@@ -642,7 +642,7 @@ mod tests {
             let state = tdigest_trans_inner(state, 100, Some(-43.0), ptr::null_mut());
 
             let mut control = state.unwrap();
-            let buffer = tdigest_serialize(Inner::from(control.clone()).internal());
+            let buffer = tdigest_serialize(Inner::from(control.clone()).internal().unwrap());
             let buffer = pgx::varlena::varlena_to_byte_slice(buffer.0 as *mut pg_sys::varlena);
 
             let expected = [1, 1, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 69, 192, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 44, 64, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 50, 64, 1, 0, 0, 0, 0, 0, 0, 0, 51, 51, 51, 51, 51, 179, 54, 64, 1, 0, 0, 0, 0, 0, 0, 0, 246, 40, 92, 143, 194, 181, 67, 64, 1, 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 144, 194, 245, 40, 92, 143, 73, 64, 5, 0, 0, 0, 0, 0, 0, 0, 246, 40, 92, 143, 194, 181, 67, 64, 0, 0, 0, 0, 0, 128, 69, 192];

--- a/extension/src/time_series.rs
+++ b/extension/src/time_series.rs
@@ -212,7 +212,7 @@ pub fn timevector_serialize(
 pub fn timevector_deserialize(
     bytes: bytea,
     _internal: Internal,
-) -> Internal {
+) -> Option<Internal> {
     let data: Timevector<'static> = crate::do_deserialize!(bytes, TimevectorData);
     Inner::from(data).internal()
 }
@@ -223,7 +223,7 @@ pub fn timevector_trans(
     time: Option<crate::raw::TimestampTz>,
     value: Option<f64>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     unsafe {
         timevector_trans_inner(state.to_inner(), time, value, fcinfo).internal()
     }
@@ -290,7 +290,7 @@ pub fn timevector_compound_trans(
     state: Internal,
     series: Option<toolkit_experimental::Timevector>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     inner_compound_trans(unsafe { state.to_inner() }, series, fcinfo).internal()
 }
 
@@ -351,7 +351,7 @@ pub fn timevector_combine (
     state1: Internal,
     state2: Internal,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     unsafe {
         inner_combine(state1.to_inner(), state2.to_inner(), fcinfo).internal()
     }

--- a/extension/src/time_weighted_average.rs
+++ b/extension/src/time_weighted_average.rs
@@ -94,7 +94,7 @@ pub fn time_weight_trans_serialize(state: Internal) -> bytea {
 pub fn time_weight_trans_deserialize(
     bytes: bytea,
     _internal: Internal,
-) -> Internal {
+) -> Option<Internal> {
     time_weight_trans_deserialize_inner(bytes).internal()
 }
 pub fn time_weight_trans_deserialize_inner(
@@ -112,7 +112,7 @@ pub fn time_weight_trans(
     ts: Option<crate::raw::TimestampTz>,
     val: Option<f64>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     unsafe {
         time_weight_trans_inner(state.to_inner(), method, ts, val, fcinfo).internal()
     }
@@ -162,7 +162,7 @@ pub fn time_weight_summary_trans(
     state: Internal,
     next: Option<TimeWeightSummary>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     time_weight_summary_trans_inner(unsafe{ state.to_inner() }, next, fcinfo).internal()
 }
 
@@ -201,7 +201,7 @@ pub fn time_weight_combine(
     state1: Internal,
     state2: Internal,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Internal {
+) -> Option<Internal> {
     unsafe {
         time_weight_combine_inner(state1.to_inner(), state2.to_inner(), fcinfo).internal()
     }
@@ -496,7 +496,7 @@ mod tests {
             let state = time_weight_trans_inner(state, "linear".to_string(), Some((BASE + 5 * MIN).into()), Some(30.0), ptr::null_mut());
 
             let mut control = state.unwrap();
-            let buffer = time_weight_trans_serialize(Inner::from(control.clone()).internal());
+            let buffer = time_weight_trans_serialize(Inner::from(control.clone()).internal().unwrap());
             let buffer = pgx::varlena::varlena_to_byte_slice(buffer.0 as *mut pg_sys::varlena);
 
             let expected = [1, 1, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 96, 194, 134, 7, 62, 2, 0, 0, 0, 0, 0, 0, 0, 36, 64, 0, 3, 164, 152, 7, 62, 2, 0, 0, 0, 0, 0, 0, 0, 62, 64, 0, 0, 0, 192, 11, 90, 246, 65];


### PR DESCRIPTION
`pgx::Internal` is inconsistent in that a NULL input to a function taking `Internal` works fine and results in an `Internal` containing `None` while returning an Internal containing `None` results in an error. This commit works around the issue by making our functions return an `Option<Internal>` if they can return a SQL NULL.

fixes #362