### PR TITLE
Create typed specialization for freq_agg and topn_agg

### DIFF
--- a/extension/src/raw.rs
+++ b/extension/src/raw.rs
@@ -8,6 +8,7 @@ extension_sql!("\n\
     name = "create_experimental_schema",
     creates=[
         Type(bytea),
+        Type(text),
         Type(TimestampTz),
         Type(AnyElement),
         Type(tstzrange),
@@ -64,6 +65,11 @@ macro_rules! raw_type {
 pub struct bytea(pub pg_sys::Datum);
 
 raw_type!(bytea, pg_sys::BYTEAOID, pg_sys::BYTEAARRAYOID);
+
+#[derive(Clone, Copy)]
+pub struct text(pub pg_sys::Datum);
+
+raw_type!(text, pg_sys::TEXTOID, pg_sys::TEXTARRAYOID);
 
 pub struct TimestampTz(pub pg_sys::Datum);
 


### PR DESCRIPTION
The `AnyElement` implementation for our various spacesaving implementations are very convenient to allow users to build them using any arbitrary type of data, but turn out to be very ugly to then try to extract data from.

This change creates a 64-bit int specialization and a text specialization of our frequency aggregates.  These can be used without providing a type argument to get data out, which ends up being much cleaner.

The existing `AnyElement` implementations have been moved to `raw_freq_agg` and `raw_topn_agg` to allow easier implicit casts to the new specializations.

The need to provide distinct types to postgres for each specialization has resulted in many similar looking data structures and functions in this code.  I'm very open to hearing suggestions on how this could be done more cleanly from any reviewers.

fixes #376