### PR TITLE
Updating CI to rust 1.60

### DIFF
--- a/crates/aggregate_builder/src/lib.rs
+++ b/crates/aggregate_builder/src/lib.rs
@@ -21,7 +21,7 @@ pub fn aggregate(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as Aggregate);
     let expanded = expand(input);
     if cfg!(feature = "print-generated") {
-        println!("{}", expanded.to_string());
+        println!("{}", expanded);
     }
     expanded.into()
 }

--- a/crates/asap/src/fft.rs
+++ b/crates/asap/src/fft.rs
@@ -33,7 +33,7 @@ use std::f64::consts::PI;
  * Computes the discrete Fourier transform (DFT) of the given complex vector, storing the result back into the vector.
  * The vector can have any length. This is a wrapper function.
  */
-pub fn transform(real: &mut Vec<f64>, imag: &mut Vec<f64>) {
+pub fn transform(real: &mut [f64], imag: &mut [f64]) {
     assert_eq!(real.len(), imag.len());
 
     let n = real.len();
@@ -52,7 +52,7 @@ pub fn transform(real: &mut Vec<f64>, imag: &mut Vec<f64>) {
  * Computes the inverse discrete Fourier transform (IDFT) of the given complex vector, storing the result back into the vector.
  * The vector can have any length. This is a wrapper function. This transform does not perform scaling, so the inverse is not a true inverse.
  */
-pub fn inverse_transform(real: &mut Vec<f64>, imag: &mut Vec<f64>) {
+pub fn inverse_transform(real: &mut [f64], imag: &mut [f64]) {
     transform(imag, real);
 }
 
@@ -61,7 +61,7 @@ pub fn inverse_transform(real: &mut Vec<f64>, imag: &mut Vec<f64>) {
  * Computes the discrete Fourier transform (DFT) of the given complex vector, storing the result back into the vector.
  * The vector's length must be a power of 2. Uses the Cooley-Tukey decimation-in-time radix-2 algorithm.
  */
-fn transform_radix2(real: &mut Vec<f64>, imag: &mut Vec<f64>) {
+fn transform_radix2(real: &mut [f64], imag: &mut [f64]) {
     // Initialization
     let n = real.len();
     if n == 1 {  // Trivial transform
@@ -130,7 +130,7 @@ fn transform_radix2(real: &mut Vec<f64>, imag: &mut Vec<f64>) {
  * The vector can have any length. This requires the convolution function, which in turn requires the radix-2 FFT function.
  * Uses Bluestein's chirp z-transform algorithm.
  */
-fn transform_bluestein(real: &mut Vec<f64>, imag: &mut Vec<f64>) {
+fn transform_bluestein(real: &mut [f64], imag: &mut [f64]) {
     // Find a power-of-2 convolution length m such that m >= n * 2 + 1
     let n = real.len();
     let mut m = 1;
@@ -203,7 +203,7 @@ fn transform_bluestein(real: &mut Vec<f64>, imag: &mut Vec<f64>) {
 // /*
 //  * Computes the circular convolution of the given complex vectors. Each vector's length must be the same.
 //  */
-fn convolve_complex(xreal: &mut Vec<f64>, ximag: &mut Vec<f64>, yreal: &mut Vec<f64>, yimag: &mut Vec<f64>, outreal: &mut Vec<f64>, outimag: &mut Vec<f64>) {
+fn convolve_complex(xreal: &mut [f64], ximag: &mut [f64], yreal: &mut [f64], yimag: &mut [f64], outreal: &mut [f64], outimag: &mut [f64]) {
     let n = xreal.len();
 
     transform(xreal, ximag);

--- a/crates/flat_serialize/flat_serialize/src/lib.rs
+++ b/crates/flat_serialize/flat_serialize/src/lib.rs
@@ -180,11 +180,10 @@ where T: FlatSerializable<'i> + 'i {
     }
 
     fn into_owned(self) -> Self::OWNED {
-        use std::array::IntoIter;
         let mut output: [MaybeUninit<T::OWNED>; N] = unsafe {
             MaybeUninit::uninit().assume_init()
         };
-        for (i, t) in IntoIter::new(self).map(|s| s.into_owned()).enumerate() {
+        for (i, t) in self.into_iter().map(|s| s.into_owned()).enumerate() {
             output[i] = MaybeUninit::new(t)
         }
 

--- a/crates/flat_serialize/flat_serialize_macro/src/lib.rs
+++ b/crates/flat_serialize/flat_serialize_macro/src/lib.rs
@@ -18,7 +18,7 @@ pub fn flat_serialize(input: TokenStream) -> TokenStream {
         FlatSerialize::Enum(input) => flat_serialize_enum(input),
     };
     if cfg!(feature = "print-generated") {
-        println!("{}", expanded.to_string());
+        println!("{}", expanded);
     }
     expanded.into()
 }

--- a/crates/t-digest/src/lib.rs
+++ b/crates/t-digest/src/lib.rs
@@ -347,7 +347,7 @@ impl TDigest {
         result
     }
 
-    fn external_merge(centroids: &mut Vec<Centroid>, first: usize, middle: usize, last: usize) {
+    fn external_merge(centroids: &mut [Centroid], first: usize, middle: usize, last: usize) {
         let mut result: Vec<Centroid> = Vec::with_capacity(centroids.len());
 
         let mut i = first;

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.57 AS pgx_builder
+FROM rust:1.60 AS pgx_builder
 
 RUN apt-get update \
     && apt-get install -y clang libclang1 sudo bash cmake \

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::modulo_one)]   // flat_serialize! alignment checks hit this for any single byte field (of which all pg_types! have two by default)
 #![allow(clippy::extra_unused_lifetimes)]  // some disagreement between clippy and the rust compiler about when lifetime are and are not needed
+#![allow(clippy::not_unsafe_ptr_arg_deref)]  // every function calling in_aggregate_context should be unsafe
 
 pub mod accessors;
 pub mod tdigest;

--- a/extension/src/state_aggregate.rs
+++ b/extension/src/state_aggregate.rs
@@ -184,8 +184,7 @@ impl StateAggTransState {
 #[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
 pub fn duration_in(state: String, aggregate: Option<StateAgg>) -> crate::raw::Interval {
     let time: i64 = aggregate
-        .map(|aggregate| aggregate.get(&state))
-        .flatten()
+        .and_then(|aggregate| aggregate.get(&state))
         .unwrap_or(0);
     let interval = pg_sys::Interval {
         time,

--- a/extension/src/time_series/pipeline/lambda/parser.rs
+++ b/extension/src/time_series/pipeline/lambda/parser.rs
@@ -403,7 +403,7 @@ static PREC_CLIMBER: once_cell::sync::Lazy<PrecClimber<Rule>> = once_cell::sync:
 // Maps function name to a tuple (num arguments, function identifier)
 static BUILTIN_FUNCTION: once_cell::sync::Lazy<HashMap<&str, (usize, Function)>> =  once_cell::sync::Lazy::new(|| {
     use Function::*;
-    std::array::IntoIter::new([
+    [
         ("abs",   (1, Abs)),
         ("cbrt",  (1, Cbrt)),
         ("ceil",  (1, Ceil)),
@@ -429,5 +429,5 @@ static BUILTIN_FUNCTION: once_cell::sync::Lazy<HashMap<&str, (usize, Function)>>
         ("asinh", (1, Asinh)),
         ("acosh", (1, Acosh)),
         ("atanh", (1, Atanh)),
-    ]).collect()
+    ].into_iter().collect()
 });


### PR DESCRIPTION
This PR updates the rust version and fixes some new clippy warnings.