### PR TITLE
Include both pgx 0.2.x and pgx 0.4.x in CI image and modify update-tester crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,4 +316,4 @@ jobs:
         #restore-keys: ${{ runner.os }}-test-old-versions-PREVIOUS
 
     - name: Run Update Tests
-      run: su postgres -c 'sh tools/build -pg$PGVERSION test-updates 2>&1'
+      run: su postgres -c 'sh tools/build -pg$PGVERSION --cargo-pgx /pgx/0.4/bin/cargo-pgx --cargo-pgx-old /pgx/0.2/bin/cargo-pgx test-updates 2>&1'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "control_file_reader"
 version = "0.1.0"
 
@@ -957,6 +967,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -1952,6 +1971,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
+
+[[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2446,6 +2471,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba98375fd631b83696f87c64e4ed8e29e6a1f3404d6aed95fa95163bad38e705"
+dependencies = [
+ "combine",
+ "indexmap",
+ "itertools",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2604,13 +2640,15 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "update-tester"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "colored",
  "control_file_reader",
  "postgres",
  "postgres_connection_configuration",
+ "semver 1.0.9",
+ "toml_edit",
  "xshell",
 ]
 

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -4,13 +4,18 @@ RUN apt-get update \
     && apt-get install -y clang libclang1 sudo bash cmake \
     && rm -rf /var/lib/apt/lists/*
 
+# install cargo pgx
+RUN cargo install cargo-pgx --version '^0.2' --root /pgx/0.2 \
+    && cargo install cargo-pgx --version '^0.4' --root /pgx/0.4
+
+ENV PATH "/pgx/0.2/bin/:${PATH}"
+
+# install doctester
+RUN cargo install --git https://github.com/timescale/timescaledb-toolkit.git --branch main sql-doctester
+
 RUN useradd -ms /bin/bash postgres
 USER postgres
 
-# install cargo pgx
-RUN cargo install cargo-pgx --version '^0.2'
-
-# only use pg12 for now timescaledb doesn't support 13
 RUN set -ex \
     && cargo pgx init --pg12 download --pg13 download --pg14 download \
     && cargo pgx start pg12 \
@@ -19,6 +24,7 @@ RUN set -ex \
     && cargo pgx stop  pg13 \
     && cargo pgx start pg14 \
     && cargo pgx stop  pg14
+
 
 # install timescaledb
 # TODO make seperate image from ^
@@ -49,9 +55,6 @@ RUN set -ex \
         && echo "shared_preload_libraries = 'timescaledb'" >> ~/.pgx/data-14/postgresql.conf \
     && cd ~ \
     && rm -rf ~/timescaledb
-
-# install doctester
-RUN cargo install --git https://github.com/timescale/timescaledb-toolkit.git --branch main sql-doctester
 
 # add clippy
 RUN rustup component add clippy

--- a/tools/build
+++ b/tools/build
@@ -16,7 +16,7 @@ die() {
 }
 
 usage() {
-    die 'build [ -n -pg1[234] ] ( test-crates | test-extension | test-post-install | test-doc | clippy )'
+    die 'build [ -n -pg1[234] ] ( test-crates | test-extension | test-post-install | test-doc | test-updates | clippy)'
 }
 
 require_pg_version() {
@@ -37,6 +37,15 @@ find_pg_config() {
     fi
     [ -x "$pg_config" ] || die "$pg_config not executable"
 }
+
+require_cargo_pgx() {
+    [ -n "$cargo_pgx" ] || die 'specify path to cargo-pgx (0.4 series or newer)'
+}
+
+require_cargo_pgx_old() {
+    [ -n "$cargo_pgx_old" ] || die 'specify path to cargo-pgx (0.2-0.3 series)'
+}
+
 
 [ $# -ge 1 ] || usage
 
@@ -74,6 +83,16 @@ while [ $# -gt 0 ]; do
 
         -pgconfig)
             pg_config="$1"
+            shift
+            ;;
+
+        --cargo-pgx)
+            cargo_pgx="$1"
+            shift
+            ;;
+
+        --cargo-pgx-old)
+            cargo_pgx_old="$1"
             shift
             ;;
 
@@ -139,6 +158,8 @@ while [ $# -gt 0 ]; do
         test-updates)
             require_pg_version
             find_pg_config
+	    require_cargo_pgx
+	    require_cargo_pgx_old
             (
                 export CARGO_TARGET_DIR="$top_CARGO_TARGET_DIR"
                 $nop cargo pgx start $pg
@@ -147,7 +168,9 @@ while [ $# -gt 0 ]; do
                  -p $pg_port \
                  --cache old-versions \
                  . \
-                 "$pg_config"
+                 "$pg_config" \
+		 "$cargo_pgx" \
+		 "$cargo_pgx_old"
             )
             ;;
 

--- a/tools/update-tester/Cargo.toml
+++ b/tools/update-tester/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "update-tester"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -12,4 +12,6 @@ postgres_connection_configuration = {path = "../../crates/scripting-utilities/po
 colored = "2.0.0"
 clap = { version = "2.33", features = ["wrap_help"] }
 postgres = "0.19.1"
+semver = "1.0.9"
+toml_edit = "0.14.3"
 xshell = "0.1.14"

--- a/tools/update-tester/Readme.md
+++ b/tools/update-tester/Readme.md
@@ -25,7 +25,7 @@ the current version work correctly. At a high level:
 
 ```
 USAGE:
-    update-tester [OPTIONS] <dir> <pg_config>
+    update-tester [OPTIONS] <dir> <pg_config> <cargo_pgx> <cargo_pgx_old>
 
 FLAGS:
         --help       Prints help information
@@ -41,6 +41,8 @@ OPTIONS:
     -u, --user <username>        postgres user
 
 ARGS:
-    <dir>          Path in which to find the timescaledb-toolkit repo
-    <pg_config>    Path to pg_config for the DB we are using
+    <dir>              Path in which to find the timescaledb-toolkit repo
+    <pg_config>        Path to pg_config for the DB we are using
+    <cargo_pgx>        Path to cargo-pgx (must be 0.4 series or newer)
+    <cargo_pgx_old>    Path to cargo-pgx 0.2-0.3 series
 ```

--- a/tools/update-tester/src/main.rs
+++ b/tools/update-tester/src/main.rs
@@ -48,6 +48,8 @@ fn main() {
         (@arg REINSTALL: --reinstall [versions] "comma-separated list of versions to force reinstall")
         (@arg ROOT_DIR: +required <dir> "Path in which to find the timescaledb-toolkit repo")
         (@arg PG_CONFIG: +required <pg_config> "Path to pg_config for the DB we are using")
+        (@arg CARGO_PGX: +required <cargo_pgx> "Path to cargo-pgx (must be 0.4 series or newer)")
+        (@arg CARGO_PGX_OLD: +required <cargo_pgx_old> "Path to cargo-pgx 0.2-0.3 series")
     )
     .get_matches();
 
@@ -71,8 +73,20 @@ fn main() {
         .unwrap_or_else(HashSet::new);
 
     let pg_config = matches.value_of("PG_CONFIG").expect("missing pg_config");
+    let cargo_pgx = matches.value_of("CARGO_PGX").expect("missing cargo_pgx");
+    let cargo_pgx_old = matches
+        .value_of("CARGO_PGX_OLD")
+        .expect("missing cargo_pgx_old");
 
-    let res = try_main(root_dir, cache_dir, &connection_config, pg_config, reinstall);
+    let res = try_main(
+        root_dir,
+        cache_dir,
+        &connection_config,
+        pg_config,
+        cargo_pgx,
+        cargo_pgx_old,
+        reinstall,
+    );
     if let Err(err) = res {
         eprintln!("{}", err);
         process::exit(1);
@@ -84,6 +98,8 @@ fn try_main(
     cache_dir: Option<&str>,
     db_conn: &ConnectionConfig<'_>,
     pg_config: &str,
+    cargo_pgx: &str,
+    cargo_pgx_old: &str,
     reinstall: HashSet<&str>,
 ) -> xshell::Result<()> {
     let (current_version, old_versions) = get_version_info(root_dir)?;
@@ -97,6 +113,8 @@ fn try_main(
         root_dir,
         cache_dir,
         pg_config,
+        cargo_pgx,
+        cargo_pgx_old,
         &current_version,
         &old_versions,
         &reinstall,


### PR DESCRIPTION
We're updating our pgx dependency to 0.4.3, and using `cargo-pgx install` with pgx 0.4.x inside the update-tester causes problems.

Starting in 0.4, pgx changed it's SQL generation and gives the following error when running `cargo pgx install` inside the update tester with previous versions of the toolkit checked out:
```
  found `pgx` 0.2-0.3 series SQL generation while using `cargo-pgx` 0.4 series.
```
As a solution, we're changing the docker image used in our CI setup to include 0.2 series version of pgx installed at /pgx-0.2 as well as a 0.4 series version of pgx installed at /pgx-0.4.

With both pgx versions installed, for each toolkit release that is checked out while running the update tester, we can infer the appropriate cargo pgx subcommand to use by inspecting the Cargo.toml.