### PR TITLE
Allow building CI image in Actions

### DIFF
--- a/.github/workflows/ci_image_build.yml
+++ b/.github/workflows/ci_image_build.yml
@@ -1,0 +1,56 @@
+name: Build CI Image
+
+on:
+  pull_request:
+    paths:
+      - 'docker/ci/**'
+      - '.github/workflows/ci_image_build.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-ci-buildx-debian-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-ci-buildx-debian
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          push: false
+          load: true
+          context: .
+          file: ./docker/ci/Dockerfile
+          tags: timescaledev/rust-pgx:latest
+
+      - name: Push
+        id: image_build
+        uses: docker/build-push-action@v2
+        with:
+          push: ${{ github.event_name == 'workflow_dispatch' }}
+          context: .
+          file: ./docker/ci/Dockerfile
+          tags: timescaledev/rust-pgx:latest
+
+      - name: Image digest
+        run: echo ${{ steps.image_build.outputs.digest }}


### PR DESCRIPTION
This commit adds a GitHub action to build and deploy our CI image. This will any of us to rebuild and deploy the CI image, and test it better before deployment.