### PR TITLE
Specify Ubuntu 20.04 instead of 'latest' in github configuration.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   testpostgres:
     name: Test Postgres
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: timescaledev/rust-pgx:latest
     strategy:
@@ -85,7 +85,7 @@ jobs:
 
   testcrates:
     name: Test Crates
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: timescaledev/rust-pgx:latest
       env:
@@ -126,7 +126,7 @@ jobs:
 
   testupdates:
     name: Test Updates
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: timescaledev/rust-pgx:latest
       env:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   clippy:
     name: Clippy Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container:
       image: timescaledev/rust-pgx:latest
       env:

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -10,7 +10,7 @@ jobs:
   package:
     env:
       GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB_PACKAGE }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/.github/workflows/report_packaging_failures.yml
+++ b/.github/workflows/report_packaging_failures.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   on-failure:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.event.workflow_run.conclusion != 'success' && github.event.workflow_run.event != 'pull_request' }}
     steps:
       - name: slack-send


### PR DESCRIPTION
'ubuntu-latest' is currently documented as being 20.04:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on

But let's lock that in now rather than surrender our update schedule
to GitHub.
