### PR TITLE
Don't install pgx as root or under `/`

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -4,17 +4,14 @@ RUN apt-get update \
     && apt-get install -y clang libclang1 sudo bash cmake \
     && rm -rf /var/lib/apt/lists/*
 
-# install cargo pgx
-RUN cargo install cargo-pgx --version '^0.2' --root /pgx/0.2 \
-    && cargo install cargo-pgx --version '^0.4' --root /pgx/0.4
-
-ENV PATH "/pgx/0.2/bin/:${PATH}"
-
-# install doctester
-RUN cargo install --git https://github.com/timescale/timescaledb-toolkit.git --branch main sql-doctester
-
 RUN useradd -ms /bin/bash postgres
 USER postgres
+
+# install cargo pgx
+RUN cargo install cargo-pgx --version '^0.2' --root /home/postgres/pgx/0.2 \
+    && cargo install cargo-pgx --version '^0.4' --root /home/postgres/pgx/0.4
+
+ENV PATH "/home/postgres/pgx/0.2/bin/:${PATH}"
 
 RUN set -ex \
     && cargo pgx init --pg12 download --pg13 download --pg14 download \
@@ -55,6 +52,9 @@ RUN set -ex \
         && echo "shared_preload_libraries = 'timescaledb'" >> ~/.pgx/data-14/postgresql.conf \
     && cd ~ \
     && rm -rf ~/timescaledb
+
+# install doctester
+RUN cargo install --git https://github.com/timescale/timescaledb-toolkit.git --branch main sql-doctester
 
 # add clippy
 RUN rustup component add clippy


### PR DESCRIPTION
In #408, almost all of the CI tests are failing with permission denied errors,  e.g. [here](https://github.com/timescale/timescaledb-toolkit/runs/6415824754?check_suite_focus=true#step:7:188), when trying to compile crates after running `cargo test`.
This PR changes the CI Docker image to:
 - run all cargo commands as the "postgres" user (instead of "root")
 - move the pgx installations from `/pgx/0.X` to `/home/postgres/pgx/0.X`