### PR TITLE
Make some changes to support aarch64-unknown-linux-gnu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,13 +24,7 @@ members = [
 
 ]
 
-[profile.dev]
-panic = "unwind"
-lto = "thin"
-
 [profile.release]
-panic = "unwind"
-opt-level = 3
 lto = "fat"
 debug = true
 codegen-units = 1

--- a/extension/src/stats_agg.rs
+++ b/extension/src/stats_agg.rs
@@ -1627,8 +1627,8 @@ mod tests {
             check_agg_equivalence(state, &client, &pg2d_agg("regr_intercept"), &tk2d_agg("intercept"), EPS1);
             // check_agg_equivalence(&state, &client, &pg2d_agg(""), &tk2d_agg("x_intercept"), 0.0000001); !!! No postgres equivalent for x_intercept
             check_agg_equivalence(state, &client, &pg2d_agg("regr_r2"), &tk2d_agg("determination_coeff"), EPS1);
-            check_agg_equivalence(state, &client, &pg2d_agg("covar_pop"), &tk2d_agg_arg("covariance", "population"), EPS1);
-            check_agg_equivalence(state, &client, &pg2d_agg("covar_samp"), &tk2d_agg_arg("covariance", "sample"), EPS1);
+            check_agg_equivalence(state, &client, &pg2d_agg("covar_pop"), &tk2d_agg_arg("covariance", "population"), BILLIONTH);
+            check_agg_equivalence(state, &client, &pg2d_agg("covar_samp"), &tk2d_agg_arg("covariance", "sample"), BILLIONTH);
 
             // Skewness and kurtosis don't have aggregate functions in postgres, but we can compute them
             check_agg_equivalence(state, &client, &pg_moment_pop_query(3, "test_x"), &tk1d_agg_arg("skewness", "population"), BILLIONTH);


### PR DESCRIPTION
- Change `lto` back to default of `false`.
  - It became "thin" in commit d18ebe6e8fdc2d91245b3dfe6d3c07431152979a .
  - Fixes segfaults on aarch64-unknown-linux-gnu
    (https://github.com/ron-rs/ron/issues/379)
- Change stats_agg::tests::pg_stats_agg_fuzz to allow more variance.
  - aarch64 varies a lot more on "covar_pop" and "covar_samp".
    We investigated a bit and found that the postgresql equivalents
    we were comparing against varied further from amd64 behavior than
    toolkit's.  Possibly differences between gcc and llvm code-gen?
- Also drop redundant default overrides from profiles in Cargo.toml .

for issue #422
