### PR TITLE
Build timescaledev/rust-pgx image for linux/arm64 (aarch64).

### DIFF
--- a/.github/workflows/ci_image_build.yml
+++ b/.github/workflows/ci_image_build.yml
@@ -10,12 +10,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    # aarch64 build seems to have been almost done at the default 6 hour
+    # timeout: it had gotten all the way to the doctester build which is
+    # almost the last step (and probably the last compiler run?)
+    # We're emulating a CPU; cut it some slack:
+    timeout-minutes: 720
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -37,8 +44,8 @@ jobs:
       - name: Build
         uses: docker/build-push-action@v2
         with:
+          platforms: linux/amd64,linux/arm64
           push: false
-          load: true
           context: .
           file: ./docker/ci/Dockerfile
           tags: timescaledev/rust-pgx:latest
@@ -47,6 +54,7 @@ jobs:
         id: image_build
         uses: docker/build-push-action@v2
         with:
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name == 'workflow_dispatch' }}
           context: .
           file: ./docker/ci/Dockerfile

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -55,9 +55,6 @@ RUN set -ex \
     && cd ~ \
     && rm -rf ~/timescaledb
 
-# install doctester
-RUN cargo install --git https://github.com/timescale/timescaledb-toolkit.git --branch main sql-doctester
-
 # add clippy
 RUN rustup component add clippy
 


### PR DESCRIPTION
- Raise timeout from the default of 6 hours to 12.
  aarch64 build seems to have been almost done when it got killed at 6 hours:
  it had gotten all the way to the doctester build which is almost the last
  step (and probably the last compiler run).  A later run took only 4 hours.
  Still, we're emulating a CPU; cut it some slack!
- Only setup QEMU for arm64 not a bunch of other platforms we don't use.
- Stop setting load: true .
- Stop building doctester.
  We've built it from source since commit 0b92688 .

for issue #422
