### PR TITLE
change which cargo-pgx subcommand is added to PATH in CI image.

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -12,8 +12,7 @@ USER postgres
 RUN cargo install cargo-pgx --version '=0.2.4' --root /home/postgres/pgx/0.2 \
     && cargo install cargo-pgx --version '=0.4.5' --root /home/postgres/pgx/0.4
 
-# TODO After we upgrade to 0.4 change this to 0.4 and remove the hack in tools/build .
-ENV PATH "/home/postgres/pgx/0.2/bin/:${PATH}"
+ENV PATH "/home/postgres/pgx/0.4/bin:${PATH}"
 
 RUN set -ex \
     && cargo pgx init --pg12 download --pg13 download --pg14 download \


### PR DESCRIPTION
Now that #408 is merged, we should upgrade which pgx we use by default, i.e. which pgx is used to init the databases in ~/.pgx and which pgx we'll use to run our CI tests.