### PR TITLE
Relax tolerance in UDDSketch merge assertions

### DIFF
--- a/crates/udd-sketch/src/lib.rs
+++ b/crates/udd-sketch/src/lib.rs
@@ -290,7 +290,7 @@ impl UDDSketch {
         assert!(
             (self.gamma.powf(1.0 / f64::powi(2.0, self.compactions as i32)) - 
              other.gamma.powf(1.0 / f64::powi(2.0, other.compactions as i32))
-            ).abs() < f64::EPSILON
+            ).abs() < 1e-9 // f64::EPSILON too small, see issue #396
         );
         assert!(self.max_buckets == other.max_buckets);
 


### PR DESCRIPTION
Fixes #396 by increasing the tolerance in our comparison of the calculated initial error parameters for two `UDDSketches` being merged