### PR TITLE
Run clippy GitHub Actions job without qualification

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,21 +1,11 @@
 name: Clippy
 on:
   pull_request:
-    paths-ignore:
-    - '**/Dockerfile'
-    - '**.md'
-    - '**.txt'
-    - '**.yml'
   push:
     branches:
     - main
     - staging
     - trying
-    paths-ignore:
-    - '**/Dockerfile'
-    - '**.md'
-    - '**.txt'
-    - '**.yml'
   schedule:
     # we build at 8am UTC, 3am Eastern, midnight Pacific
     - cron:  '0 8 * * 1-4'


### PR DESCRIPTION
bors requires that all jobs report a success or failure. In the case where a PR did not trigger this clippy job based on the path qualifications (that are being removed here), then the job wouldn't run and thus wouldn't have a status to report to bors. This would lead to bors timeouts.

It isn't a great solution to run clippy even where it isn't needed, but not being able to merge PRs is an even worse position to be in.