### PR TITLE
Saturating Math for i32/integers

### DIFF
--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -17,6 +17,7 @@ pub mod stats_agg;
 pub mod utilities;
 pub mod time_vector;
 pub mod frequency;
+pub mod saturation;
 
 mod palloc;
 mod aggregate_utils;

--- a/extension/src/saturation.rs
+++ b/extension/src/saturation.rs
@@ -4,13 +4,13 @@ use pgx::*;
 
 /// Computes x+y, saturating at the numeric bounds instead of overflowing
 #[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
-fn addition_saturate_to_min(x: i32, y: i32) -> i32 {
+fn saturating_add(x: i32, y: i32) -> i32 {
     x.saturating_add(y)
 }
 
 /// Computes x+y, saturating at 0 for the minimum bound instead of i32::MIN
 #[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
-fn addition_saturate_to_zero(x: i32, y: i32) -> i32 {
+fn saturating_add_pos(x: i32, y: i32) -> i32 {
     // check to see if abs of y is greater than the abs of x?
     let result = x.saturating_add(y);
     if result > 0 {
@@ -22,13 +22,13 @@ fn addition_saturate_to_zero(x: i32, y: i32) -> i32 {
 
 /// Computes x-y, saturating at the numeric bounds instead of overflowing.
 #[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
-fn subtraction_saturate_to_min(x: i32, y: i32) -> i32 {
+fn saturating_sub(x: i32, y: i32) -> i32 {
     x.saturating_sub(y)
 }
 
 /// Computes x-y, saturating at 0 for the minimum bound instead of i32::MIN
 #[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
-fn subtraction_saturate_to_zero(x: i32, y: i32) -> i32 {
+fn saturating_sub_pos(x: i32, y: i32) -> i32 {
     if y > x {
         0
     } else {
@@ -38,18 +38,8 @@ fn subtraction_saturate_to_zero(x: i32, y: i32) -> i32 {
 
 /// Computes x*y, saturating at the numeric bounds instead of overflowing
 #[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
-fn multiplication_saturate_to_min(x: i32, y: i32) -> i32 {
+fn saturating_mul(x: i32, y: i32) -> i32 {
     x.saturating_mul(y)
-}
-
-/// Computes x*y, saturating at 0 for the minimum bound instead of i32::MIN
-#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
-fn multiplication_saturate_to_zero(x: i32, y: i32) -> i32 {
-    if x <= 0 || y <= 0 {
-        0
-    } else {
-        x.saturating_mul(y)
-    }
 }
 
 #[cfg(any(test, feature = "pg_test"))]
@@ -60,55 +50,49 @@ mod tests {
 
     #[pg_test]
     #[allow(arithmetic_overflow)]
-    fn test_addition_saturate_max() {
-        assert_eq!(i32::MAX, addition_saturate_to_min(i32::MAX, 100));
+    fn test_saturating_add_max() {
+        assert_eq!(i32::MAX, saturating_add(i32::MAX, 100));
     }
 
     #[pg_test]
     #[allow(arithmetic_overflow)]
-    fn test_addition_saturate_min() {
-        assert_eq!(i32::MIN, addition_saturate_to_min(i32::MIN, -100));
+    fn test_saturating_add_min() {
+        assert_eq!(i32::MIN, saturating_add(i32::MIN, -100));
     }
 
     #[pg_test]
     #[allow(arithmetic_overflow)]
-    fn test_addition_saturate_to_zero() {
-        assert_eq!(0, addition_saturate_to_zero(200, -350));
+    fn test_saturating_add_pos() {
+        assert_eq!(0, saturating_add_pos(200, -350));
     }
 
     #[pg_test]
     #[allow(arithmetic_overflow)]
-    fn test_subtraction_saturate_to_max() {
-        assert_eq!(i32::MAX, subtraction_saturate_to_min(i32::MAX, -10));
+    fn test_saturating_sub_max() {
+        assert_eq!(i32::MAX, saturating_sub(i32::MAX, -10));
     }
 
     #[pg_test]
     #[allow(arithmetic_overflow)]
-    fn test_subtraction_saturate_to_min() {
-        assert_eq!(i32::MIN, subtraction_saturate_to_min(i32::MIN, 10));
+    fn test_saturating_sub_min() {
+        assert_eq!(i32::MIN, saturating_sub(i32::MIN, 10));
     }
 
     #[pg_test]
     #[allow(arithmetic_overflow)]
-    fn test_subtraction_saturate_to_zero() {
-        assert_eq!(0, subtraction_saturate_to_zero(i32::MIN, 10));
+    fn test_saturating_sub_pos() {
+        assert_eq!(0, saturating_sub_pos(i32::MIN, 10));
     }
 
     #[pg_test]
     #[allow(arithmetic_overflow)]
-    fn test_multiplication_saturate_to_max() {
-        assert_eq!(i32::MAX, multiplication_saturate_to_min(i32::MAX, 2));
+    fn test_saturating_mul_max() {
+        assert_eq!(i32::MAX, saturating_mul(i32::MAX, 2));
     }
 
     #[pg_test]
     #[allow(arithmetic_overflow)]
-    fn test_multiplication_saturate_to_min() {
-        assert_eq!(i32::MIN, multiplication_saturate_to_min(i32::MAX, -2));
-    }
-
-    #[pg_test]
-    #[allow(arithmetic_overflow)]
-    fn test_multiplication_saturate_to_zero() {
-        assert_eq!(0, multiplication_saturate_to_zero(i32::MAX, -2));
+    fn test_saturating_mul_min() {
+        assert_eq!(i32::MIN, saturating_mul(i32::MAX, -2));
     }
 }

--- a/extension/src/saturation.rs
+++ b/extension/src/saturation.rs
@@ -1,0 +1,114 @@
+use pgx::*;
+
+/// Saturating Math for Integers
+
+/// Computes x+y, saturating at the numeric bounds instead of overflowing
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+fn addition_saturate_to_min(x: i32, y: i32) -> i32 {
+    x.saturating_add(y)
+}
+
+/// Computes x+y, saturating at 0 for the minimum bound instead of i32::MIN
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+fn addition_saturate_to_zero(x: i32, y: i32) -> i32 {
+    // check to see if abs of y is greater than the abs of x?
+    let result = x.saturating_add(y);
+    if result > 0 {
+        result
+    } else {
+        0
+    }
+}
+
+/// Computes x-y, saturating at the numeric bounds instead of overflowing.
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+fn subtraction_saturate_to_min(x: i32, y: i32) -> i32 {
+    x.saturating_sub(y)
+}
+
+/// Computes x-y, saturating at 0 for the minimum bound instead of i32::MIN
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+fn subtraction_saturate_to_zero(x: i32, y: i32) -> i32 {
+    if y > x {
+        0
+    } else {
+        x.saturating_sub(y)
+    }
+}
+
+/// Computes x*y, saturating at the numeric bounds instead of overflowing
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+fn multiplication_saturate_to_min(x: i32, y: i32) -> i32 {
+    x.saturating_mul(y)
+}
+
+/// Computes x*y, saturating at 0 for the minimum bound instead of i32::MIN
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+fn multiplication_saturate_to_zero(x: i32, y: i32) -> i32 {
+    if x <= 0 || y <= 0 {
+        0
+    } else {
+        x.saturating_mul(y)
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+    use pgx_macros::pg_test;
+
+    #[pg_test]
+    #[allow(arithmetic_overflow)]
+    fn test_addition_saturate_max() {
+        assert_eq!(i32::MAX, addition_saturate_to_min(i32::MAX, 100));
+    }
+
+    #[pg_test]
+    #[allow(arithmetic_overflow)]
+    fn test_addition_saturate_min() {
+        assert_eq!(i32::MIN, addition_saturate_to_min(i32::MIN, -100));
+    }
+
+    #[pg_test]
+    #[allow(arithmetic_overflow)]
+    fn test_addition_saturate_to_zero() {
+        assert_eq!(0, addition_saturate_to_zero(200, -350));
+    }
+
+    #[pg_test]
+    #[allow(arithmetic_overflow)]
+    fn test_subtraction_saturate_to_max() {
+        assert_eq!(i32::MAX, subtraction_saturate_to_min(i32::MAX, -10));
+    }
+
+    #[pg_test]
+    #[allow(arithmetic_overflow)]
+    fn test_subtraction_saturate_to_min() {
+        assert_eq!(i32::MIN, subtraction_saturate_to_min(i32::MIN, 10));
+    }
+
+    #[pg_test]
+    #[allow(arithmetic_overflow)]
+    fn test_subtraction_saturate_to_zero() {
+        assert_eq!(0, subtraction_saturate_to_zero(i32::MIN, 10));
+    }
+
+    #[pg_test]
+    #[allow(arithmetic_overflow)]
+    fn test_multiplication_saturate_to_max() {
+        assert_eq!(i32::MAX, multiplication_saturate_to_min(i32::MAX, 2));
+    }
+
+    #[pg_test]
+    #[allow(arithmetic_overflow)]
+    fn test_multiplication_saturate_to_min() {
+        assert_eq!(i32::MIN, multiplication_saturate_to_min(i32::MAX, -2));
+    }
+
+    #[pg_test]
+    #[allow(arithmetic_overflow)]
+    fn test_multiplication_saturate_to_zero() {
+        assert_eq!(0, multiplication_saturate_to_zero(i32::MAX, -2));
+    }
+}


### PR DESCRIPTION
Issue : https://github.com/timescale/timescaledb-toolkit/issues/423

This PR adds saturating math functions for addition/subtraction/multiplication for i32.

Each math operator has two functions: 

1. `*_saturate_to_min` saturates at the numeric bounds instead of overflowing, similar to Rusts builtin saturating methods.
2. `*_saturate_to_zero` saturates at 0 for the minimum bound instead of i32::MIN

The function names could probably use some work, I had a difficult time naming them in a way that wasn't too verbose while also being distinct from the builtin Rust `.saturating_*` methods.