### PR TITLE
Add self-hosted runners for ARM64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,15 @@ on:
 jobs:
   testpostgres:
     name: Test Postgres
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.runner }}
     container:
       image: timescaledev/rust-pgx:latest
     strategy:
       matrix:
         pgversion: [12, 13, 14]
+        runner:
+          - ubuntu-20.04
+          - [self-hosted, Linux, ARM64]
     env:
       # Must keep in sync with `path: target` in cache entry below
       CARGO_TARGET_DIR_NAME: target


### PR DESCRIPTION
This commit add CI build using self-hosted runners for ARM64 by
extending the matrix with `runner` and using the original runner as
well as the ARM64 runner.