### PR TITLE
Use layers in Dockerfile and add instructions

### DIFF
--- a/.github/workflows/ci_image_build.yml
+++ b/.github/workflows/ci_image_build.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,52 @@
+# Docker images
+
+To speed up builds, we are using a set of pre-build docker images and
+the Docker files for that is present in this directory.
+
+## Pre-requisites
+
+You need to have Docker installed with support for multi-platform
+build to use `buildx`. It is available in `docker.io` package on Ubuntu:
+
+```bash
+apt-get install docker.io
+```
+
+## Building multi-platform images
+
+To build a new Docker image `rust-pgx` for multiple platforms and push
+it to the development repository:
+
+```bash
+docker buildx build --platform linux/arm64/v8,linux/amd64 --tag timescaledev/rust-pgx:latest --push .
+```
+
+There is a test repository `timescaledev/rust-pgx-test` available as
+well that you can use if you want to test changes to the docker image.
+
+## Troubleshooting
+
+If you get the following error when pushing:
+
+```
+$ docker buildx build --platform linux/arm64/v8,linux/amd64 --tag timescaledev/rust-pgx-test:latest --push .
+[+] Building 487.0s (54/54) FINISHED                                                                                                                                                                          
+ => [internal] load .dockerignore                                                                                                                                                                        0.0s
+ => => transferring context: 2B                                                                                                                                                                          0.0s 
+    .
+    .
+    .
+=> [auth] timescaledev/rust-pgx-test:pull,push token for registry-1.docker.io                                                                                                                           0.0s 
+------
+ > exporting to image:
+------
+error: failed to solve: failed to fetch oauth token: Post "https://auth.docker.io/token": x509: certificate has expired or is not yet valid: current time 2022-07-28T07:19:52+01:00 is after 2018-04-29T13:06:19Z
+```
+
+You probably have build toolkit enabled and it can cause issues. You
+can disable it and try again:
+
+```bash
+export DOCKER_BUILDKIT=0
+docker buildx build --platform linux/arm64/v8,linux/amd64 --tag timescaledev/rust-pgx-test:latest --push .
+```

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,64 +1,63 @@
 FROM rust:1.60 AS pgx_builder
 
 RUN apt-get update \
-    && apt-get install -y clang libclang1 sudo bash cmake \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y clang libclang1 sudo bash cmake
 
-RUN useradd -ms /bin/bash postgres
-USER postgres
+# We install PostgreSQL from PGDG rather than building it locally.
+RUN apt-get -y install postgresql-common gnupg
+RUN sh /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -y install libclang-dev postgresql-12 postgresql-server-dev-12 postgresql-13 postgresql-server-dev-13 postgresql-14 postgresql-server-dev-14
+RUN rm -rf /var/lib/apt/lists/*
 
-# install cargo pgx
-# Keep synchronized with `cargo install --version N.N.N cargo-pgx` in Readme.md and Cargo.toml
-RUN cargo install cargo-pgx --version '=0.2.4' --root /home/postgres/pgx/0.2 \
-    && cargo install cargo-pgx --version '=0.4.5' --root /home/postgres/pgx/0.4
-
-ENV PATH "/home/postgres/pgx/0.4/bin:${PATH}"
-
-RUN set -ex \
-    && cargo pgx init --pg12 download --pg13 download --pg14 download \
-    && cargo pgx start pg12 \
-    && cargo pgx stop  pg12 \
-    && cargo pgx start pg13 \
-    && cargo pgx stop  pg13 \
-    && cargo pgx start pg14 \
-    && cargo pgx stop  pg14
-
-
-# install timescaledb
-# TODO make seperate image from ^
-RUN set -ex \
-    && cd ~ \
-    && git clone https://github.com/timescale/timescaledb.git \
-    && cd timescaledb \
-    && git checkout 2.5.x \
-    && cd ~/timescaledb \
-        && ./bootstrap -DPG_CONFIG=~/.pgx/12.11/pgx-install/bin/pg_config -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DUSE_OPENSSL=false -DSEND_TELEMETRY_DEFAULT=false -DREGRESS_CHECKS=false \
-        && cd build \
-        && make -j4 \
-        && make -j4 install \
-        && echo "shared_preload_libraries = 'timescaledb'" >> ~/.pgx/data-12/postgresql.conf \
-    && cd .. \
-    && rm -rf ./build \
-        && ./bootstrap -DPG_CONFIG=~/.pgx/13.7/pgx-install/bin/pg_config -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DUSE_OPENSSL=false -DSEND_TELEMETRY_DEFAULT=false -DREGRESS_CHECKS=false \
-        && cd build \
-        && make -j4 \
-        && make -j4 install \
-        && echo "shared_preload_libraries = 'timescaledb'" >> ~/.pgx/data-13/postgresql.conf \
-    && cd .. \
-    && rm -rf ./build \
-        && ./bootstrap -DPG_CONFIG=~/.pgx/14.3/pgx-install/bin/pg_config -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DUSE_OPENSSL=false -DSEND_TELEMETRY_DEFAULT=false -DREGRESS_CHECKS=false \
-        && cd build \
-        && make -j4 \
-        && make -j4 install \
-        && echo "shared_preload_libraries = 'timescaledb'" >> ~/.pgx/data-14/postgresql.conf \
-    && cd ~ \
-    && rm -rf ~/timescaledb
+# add clippy
+RUN rustup component add clippy
 
 # install doctester
 RUN cargo install --git https://github.com/timescale/timescaledb-toolkit.git --branch main sql-doctester
 
-# add clippy
-RUN rustup component add clippy
+# Build the TimescaleDB extension for all the servers that we
+# installed above.
+
+RUN git clone --single-branch --branch 2.5.x https://github.com/timescale/timescaledb.git
+
+WORKDIR timescaledb
+
+RUN cmake -S . -B build-12 -DPG_CONFIG=/usr/lib/postgresql/12/bin/pg_config -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DUSE_OPENSSL=false -DSEND_TELEMETRY_DEFAULT=false -DREGRESS_CHECKS=false
+RUN cmake -S . -B build-13 -DPG_CONFIG=/usr/lib/postgresql/13/bin/pg_config -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DUSE_OPENSSL=false -DSEND_TELEMETRY_DEFAULT=false -DREGRESS_CHECKS=false
+RUN cmake -S . -B build-14 -DPG_CONFIG=/usr/lib/postgresql/14/bin/pg_config -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DUSE_OPENSSL=false -DSEND_TELEMETRY_DEFAULT=false -DREGRESS_CHECKS=false
+
+RUN cmake --build build-12 --parallel
+RUN cmake --build build-13 --parallel
+RUN cmake --build build-14 --parallel
+
+RUN cmake --install build-12
+RUN cmake --install build-13
+RUN cmake --install build-14
+
+RUN rm -rf build-12 build-13 build-14
+
+WORKDIR pgx
+
+# Install cargo pgx
+# Keep synchronized with `cargo install --version N.N.N cargo-pgx` in Readme.md and Cargo.toml
+RUN cargo install cargo-pgx --version '=0.2.4' --root /pgx/0.2
+RUN cargo install cargo-pgx --version '=0.4.5' --root /pgx/0.4
+
+ENV PATH "/pgx/0.4/bin:${PATH}"
+
+USER postgres
+
+# Initialize new PostgreSQL instances and update the configuration
+# files so that they can use TimescaleDB that we installed above.
+RUN cargo pgx init --pg12 /usr/lib/postgresql/12/bin/pg_config --pg13 /usr/lib/postgresql/13/bin/pg_config --pg14 /usr/lib/postgresql/14/bin/pg_config
+RUN cargo pgx start pg12 && cargo pgx stop pg12
+RUN cargo pgx start pg13 && cargo pgx stop pg13
+RUN cargo pgx start pg14 && cargo pgx stop pg14
+
+RUN echo "shared_preload_libraries = 'timescaledb'" >> ~/.pgx/data-12/postgresql.conf
+RUN echo "shared_preload_libraries = 'timescaledb'" >> ~/.pgx/data-13/postgresql.conf
+RUN echo "shared_preload_libraries = 'timescaledb'" >> ~/.pgx/data-14/postgresql.conf
 
 FROM pgx_builder AS rust-pgx
 


### PR DESCRIPTION
In order to speed up builds when developing the Dockerfile for CI
builds is layered. This will make it easier to work with when
developing since it does not require running all commands in one go and
can instead rely on the cached layers to avoid redoing work.

Also adds instructions on how to build a multi-platform build for the
CI as well as some troubleshooting tips.