### PR TITLE
Splitting update-tester into subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,11 +348,36 @@ dependencies = [
  "ansi_term 0.11.0",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "term_size",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44bbe24bbd31a185bc2c4f7c2abe80bea13a20d57ee4e55be70ac512bdc76417"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_lex",
+ "indexmap",
+ "strsim 0.10.0",
+ "termcolor",
+ "terminal_size",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1333,6 +1358,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+
+[[package]]
 name = "owo-colors"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2227,7 +2258,7 @@ name = "sql-doctester"
 version = "0.1.0"
 dependencies = [
  "bytecount",
- "clap",
+ "clap 2.33.3",
  "colored",
  "postgres",
  "pulldown-cmark",
@@ -2280,6 +2311,12 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -2344,10 +2381,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "testrunner"
 version = "0.1.0"
 dependencies = [
- "clap",
+ "clap 2.33.3",
  "colored",
  "postgres",
  "rayon",
@@ -2361,6 +2417,15 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "term_size",
  "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+dependencies = [
+ "terminal_size",
 ]
 
 [[package]]
@@ -2690,9 +2755,9 @@ checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "update-tester"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
- "clap",
+ "clap 3.2.15",
  "colored",
  "control_file_reader",
  "postgres",

--- a/tools/build
+++ b/tools/build
@@ -163,7 +163,7 @@ while [ $# -gt 0 ]; do
             (
                 export CARGO_TARGET_DIR="$top_CARGO_TARGET_DIR"
                 $nop cargo pgx start $pg
-                $nop cargo run --manifest-path tools/update-tester/Cargo.toml -- \
+                $nop cargo run --manifest-path tools/update-tester/Cargo.toml -- full-update-test-source \
                  -h localhost \
                  -p $pg_port \
                  --cache old-versions \

--- a/tools/update-tester/Cargo.toml
+++ b/tools/update-tester/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "update-tester"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,7 +10,7 @@ control_file_reader = {path = "../../crates/scripting-utilities/control_file_rea
 postgres_connection_configuration = {path = "../../crates/scripting-utilities/postgres_connection_configuration"}
 
 colored = "2.0.0"
-clap = { version = "2.33", features = ["wrap_help"] }
+clap = { version = "3.2.15", features = ["wrap_help"] }
 postgres = "0.19.1"
 semver = "1.0.9"
 toml_edit = "0.14.3"


### PR DESCRIPTION
- Updated to Clap v3 and replaced the deprecated `clap_app!` macro
- Removed `-h` as a shorthand option for `HOST` since it conflicts with the `help` flag
- Added subcommands for the original functionality (`full-update-test-source`), creating test objects (`create-test-objects`), and validating results (`validate-test-objects`).

Differences between original functionality and the `create-test-objects`/`validate-test-objects` subcommands:
- The alter/create extension commands no longer use a specific version of the toolkit when called. It is expected that the user manually installs their toolkit versions before running `create-test-objects` and/or `validate-test-objects`.
- The temporary databases created by `full-update-test-source` are named after the version numbers of the toolkit versions that they are testing, but the new subcommands create and expect a database named `tsdb_toolkit_test`.
- The database created by `create-test-objects` is dropped at the end of `validate-test-objects` if the validation tests pass.