### PR TITLE
Use flat_serialize::FlatSerializable directly where needed.

### DIFF
--- a/extension/src/accessors.rs
+++ b/extension/src/accessors.rs
@@ -2,9 +2,7 @@
 use counter_agg::range::I64Range;
 use pgx::*;
 
-use flat_serialize::*;
-
-use std::convert::TryInto;
+use std::convert::TryInto as _;
 
 use crate::{
     build, flatten,

--- a/extension/src/counter_agg.rs
+++ b/extension/src/counter_agg.rs
@@ -2,8 +2,6 @@ use serde::{Serialize, Deserialize};
 
 use pgx::*;
 
-use flat_serialize::*;
-
 use crate::{
     aggregate_utils::in_aggregate_context,
     ron_inout_funcs,

--- a/extension/src/countminsketch.rs
+++ b/extension/src/countminsketch.rs
@@ -2,7 +2,6 @@ use pgx::*;
 
 use aggregate_builder::aggregate;
 use countminsketch::{CountMinHashFn, CountMinSketch as CountMinSketchInternal};
-use flat_serialize::*;
 
 use crate::{
     flatten,

--- a/extension/src/datum_utils.rs
+++ b/extension/src/datum_utils.rs
@@ -623,7 +623,6 @@ mod tests {
     use super::*;
     use crate::{build, palloc::Inner, pg_type, ron_inout_funcs};
     use aggregate_builder::*;
-    use flat_serialize::*;
     use pgx_macros::pg_test;
 
     #[pg_schema]

--- a/extension/src/frequency.rs
+++ b/extension/src/frequency.rs
@@ -12,8 +12,6 @@ use serde::{
     Deserialize, Serialize,
 };
 
-use flat_serialize::*;
-
 use crate::{
     aggregate_utils::{get_collation, in_aggregate_context},
     build,

--- a/extension/src/gauge_agg.rs
+++ b/extension/src/gauge_agg.rs
@@ -2,7 +2,6 @@ use pgx::*;
 use serde::{Deserialize, Serialize};
 
 use counter_agg::{range::I64Range, GaugeSummaryBuilder, MetricSummary};
-use flat_serialize::FlatSerializable;
 use flat_serialize_macro::FlatSerializable;
 use stats_agg::stats2d::StatsSummary2D;
 use tspoint::TSPoint;

--- a/extension/src/hyperloglog.rs
+++ b/extension/src/hyperloglog.rs
@@ -9,8 +9,6 @@ use serde::{Deserialize, Serialize};
 use pg_sys::{Datum, Oid};
 use pgx::*;
 
-use flat_serialize::*;
-
 use crate::{
     aggregate_utils::{get_collation, in_aggregate_context},
     datum_utils::DatumHashBuilder,

--- a/extension/src/stats_agg.rs
+++ b/extension/src/stats_agg.rs
@@ -1,8 +1,6 @@
 
 use pgx::*;
 
-use flat_serialize::*;
-
 use crate::{
     aggregate_utils::in_aggregate_context,
     ron_inout_funcs,

--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -5,8 +5,6 @@ use serde::{Serialize, Deserialize};
 
 use pgx::*;
 
-use flat_serialize::*;
-
 use crate::{
     aggregate_utils::in_aggregate_context,
     ron_inout_funcs,

--- a/extension/src/time_weighted_average.rs
+++ b/extension/src/time_weighted_average.rs
@@ -6,7 +6,6 @@ use crate::{
     aggregate_utils::in_aggregate_context, flatten, ron_inout_funcs, palloc::{Internal, InternalAsValue, Inner, ToInternal}, pg_type,
     accessors::toolkit_experimental,
 };
-use flat_serialize::*;
 use pgx::*;
 
 use tspoint::TSPoint;

--- a/extension/src/type_builder.rs
+++ b/extension/src/type_builder.rs
@@ -137,6 +137,7 @@ macro_rules! pg_type_impl {
             impl<$lifetemplate> [<$name Data>] $(<$inlife>)? {
                 #[allow(clippy::missing_safety_doc)]
                 pub unsafe fn flatten<'any>(&self) -> $name<'any> {
+                    use flat_serialize::FlatSerializable as _;
                     use $crate::type_builder::CachedDatum::Flattened;
                     // if we already have a CachedDatum::Flattened can just
                     // return it without re-flattening?
@@ -158,6 +159,7 @@ macro_rules! pg_type_impl {
 
                 pub fn to_pg_bytes(&self) -> &'static [u8] {
                     use std::{mem::MaybeUninit, slice};
+                    use flat_serialize::FlatSerializable as _;
                     unsafe {
                         let len = self.num_bytes();
                         // valena tyes have a maximum size
@@ -180,6 +182,7 @@ macro_rules! pg_type_impl {
                 where
                     Self: Sized,
                 {
+                    use flat_serialize::FlatSerializable as _;
                     if is_null {
                         return None;
                     }

--- a/extension/src/uddsketch.rs
+++ b/extension/src/uddsketch.rs
@@ -1,8 +1,6 @@
 
 use pgx::*;
 
-use flat_serialize::*;
-
 use encodings::{delta, prefix_varint};
 
 use uddsketch::{SketchHashKey, UDDSketch as UddSketchInternal};


### PR DESCRIPTION
Don't require callers of pg_type! and build! to use it for them.