### PR TITLE
Stabilize timevector

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-stabilization.md
+++ b/.github/ISSUE_TEMPLATE/feature-stabilization.md
@@ -1,0 +1,36 @@
+---
+name: Feature Stabilization
+about: Checklist of tasks to move a feature out of experimental
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## [\<Feature Name>](<link to root issue for feature>)
+
+**What evidence do we have the feature is being used**
+
+**Why do we feel this feature is ready to be stable**
+
+**Is there any known further work needed on this feature after stabilization**
+
+**Are there any compatibility concerns that may arise during future work on this feature**
+
+### Feature History
+- Experimental release version:
+- Last version modifying on-disk format:
+- Target stabilization version:
+
+
+### Stabilization checklist:
+- [ ] Ensure tests exist for all public API
+- [ ] Ensure API documentation exists and is accurate
+- [ ] Remove `toolkit_experimental` tags and update test usages
+- [ ] Add arrow operators for accessors if applicable
+- [ ] Ensure arrow operators have test coverage
+- [ ] If present, ensure `combine` and `rollup` are tested
+- [ ] Add serialization tests for on disk format
+- [ ] Add upgrade tests
+- [ ] Add continuous aggregate test
+- [ ] Add feature level documentation

--- a/docs/asap.md
+++ b/docs/asap.md
@@ -48,7 +48,7 @@ It is hard to look at this data and make much sense of how the temperature has c
 We can use ASAP smoothing here to get a much clearer picture of the behavior over this interval.
 
 ```SQL ,ignore
-SELECT * FROM toolkit_experimental.unnest((SELECT toolkit_experimental.asap_smooth(month, value, 800) FROM temperatures));
+SELECT * FROM unnest((SELECT toolkit_experimental.asap_smooth(month, value, 800) FROM temperatures));
 ```
 ```
                 time                 |       value
@@ -124,7 +124,7 @@ SELECT
 </div>
 
 ```SQL
-SELECT * FROM toolkit_experimental.unnest(
+SELECT * FROM unnest(
     (SELECT toolkit_experimental.asap_smooth(date, reading, 8)
      FROM metrics));
 ```

--- a/docs/lttb.md
+++ b/docs/lttb.md
@@ -40,7 +40,7 @@ to 34 points
 
 ```SQL
 SELECT time, value::numeric(10,2)
-FROM toolkit_experimental.unnest((
+FROM unnest((
     SELECT toolkit_experimental.lttb(time, val, 34)
     FROM sample_data))
 ```
@@ -101,7 +101,7 @@ resulting data looks less and less like the original
 
 ```SQL
 SELECT time, value::numeric(10,2)
-FROM toolkit_experimental.unnest((
+FROM unnest((
     SELECT toolkit_experimental.lttb(time, val, 17)
     FROM sample_data))
 ```
@@ -132,7 +132,7 @@ FROM toolkit_experimental.unnest((
 
 ```SQL
 SELECT time, value::numeric(10,2)
-FROM toolkit_experimental.unnest((
+FROM unnest((
     SELECT toolkit_experimental.lttb(time, val, 8)
     FROM sample_data))
 ```
@@ -165,7 +165,7 @@ toolkit_experimental.lttb(
 ```
 
 This will construct and return a sorted timevector with at most `resolution`
-points. `toolkit_experimental.unnest(...)` can be used to
+points. `unnest(...)` can be used to
 extract the `(time, value)` pairs from this series
 
 ### Required Arguments <a id="lttb-required-arguments"></a>
@@ -180,7 +180,7 @@ extract the `(time, value)` pairs from this series
 
 ```SQL
 SELECT time, value
-FROM toolkit_experimental.unnest((
+FROM unnest((
     SELECT toolkit_experimental.lttb(time, val, 4)
     FROM sample_data))
 ```

--- a/docs/test_caggs.md
+++ b/docs/test_caggs.md
@@ -22,7 +22,8 @@ AS SELECT
     time_bucket('7 day'::interval, time) as week,
     hyperloglog(64, value1) as hll,
     counter_agg(time, value1) as counter,
-    stats_agg(value1, value2) as stats
+    stats_agg(value1, value2) as stats,
+    timevector(time, value2) as tvec
 FROM test
 GROUP BY time_bucket('7 day'::interval, time);
 ```
@@ -89,4 +90,27 @@ FROM weekly_aggs;
  average_y |   stddev_y    |   skewness_y    |   kurtosis_y
 -----------+---------------+-----------------+----------------
         67 | 23.6877840059 | -0.565748443434 | 2.39964349376
+```
+
+```SQL
+SELECT week, count(*)
+FROM (
+    SELECT week, unnest(tvec)
+    FROM weekly_aggs
+    WHERE week > '2020-06-01'::TIMESTAMPTZ
+) s
+GROUP BY week
+ORDER BY week;
+```
+```output
+          week          | count 
+------------------------+-------
+ 2020-06-08 00:00:00+00 |   168
+ 2020-06-15 00:00:00+00 |   168
+ 2020-06-22 00:00:00+00 |   168
+ 2020-06-29 00:00:00+00 |   168
+ 2020-07-06 00:00:00+00 |   168
+ 2020-07-13 00:00:00+00 |   168
+ 2020-07-20 00:00:00+00 |   168
+ 2020-07-27 00:00:00+00 |    59
 ```

--- a/docs/timeseries.md
+++ b/docs/timeseries.md
@@ -34,14 +34,14 @@ INSERT 0 4032
 Now lets capture this data into a time series which we'll store in a view.
 
 ```SQL ,non-transactional,ignore-output
-CREATE VIEW series AS SELECT toolkit_experimental.timevector(time, value) FROM test;
+CREATE VIEW series AS SELECT timevector(time, value) FROM test;
 ```
 
 We can now use this timevector to efficiently move the data around to other functions.
 
 ```SQL
 SELECT time, value::numeric(10,2) FROM
-toolkit_experimental.unnest((SELECT toolkit_experimental.lttb(timevector, 20) FROM series));
+unnest((SELECT toolkit_experimental.lttb(timevector, 20) FROM series));
 ```
 ```output
           time          |       value
@@ -108,7 +108,7 @@ This will construct and return timevector object containing the passed in time, 
 For this example, assume we have a table 'samples' with two columns, 'time' and 'weight'.  The following will return that table as a timevector.
 
 ```SQL ,ignore
-SELECT toolkit_experimental.timevector(time, weight) FROM samples;
+SELECT timevector(time, weight) FROM samples;
 ```
 
 ---
@@ -142,7 +142,7 @@ This example assumes a table 'samples' with columns 'time', 'data', and 'batch'.
 CREATE VIEW series AS
     SELECT
         batch,
-        toolkit_experimental.timevector(time, data) as batch_series
+        timevector(time, data) as batch_series
     FROM samples
     GROUP BY batch;
 ```
@@ -181,8 +181,8 @@ The unnest function is used to get the (time, value) pairs back out of a timevec
 ### Sample Usage <a id="timevector_unnest-examples"></a>
 
 ```SQL
-SELECT toolkit_experimental.unnest(
-    (SELECT toolkit_experimental.timevector(a.time, a.value)
+SELECT unnest(
+    (SELECT timevector(a.time, a.value)
     FROM
         (SELECT time, value
         FROM toolkit_experimental.generate_periodic_normal_series('2020-01-01 UTC'::timestamptz, 45654))

--- a/docs/timeseries_pipeline_elements.md
+++ b/docs/timeseries_pipeline_elements.md
@@ -49,7 +49,7 @@ Now suppose we want to know how much the temperature fluctuates on a daily basis
 ```SQL ,non-transactional,ignore-output
 CREATE VIEW daily_delta AS
     SELECT device,
-        toolkit_experimental.timevector(time, temperature)
+        timevector(time, temperature)
             -> (toolkit_experimental.sort()
             ->  toolkit_experimental.delta()) AS deltas
     FROM test_data
@@ -59,7 +59,7 @@ CREATE VIEW daily_delta AS
 This command creates a timevector from the time and temperature columns (grouped by device), sorts them in increasing time, and computes the deltas between values.  Now we can look at the deltas for a specific device.  Note that the output for this test is inaccurate as we've removed some of the pipeline elements for the moment.
 
 ```SQL,ignore-output
-SELECT time, value::numeric(4,2) AS delta FROM toolkit_experimental.unnest((SELECT deltas FROM daily_delta WHERE device = 3));
+SELECT time, value::numeric(4,2) AS delta FROM unnest((SELECT deltas FROM daily_delta WHERE device = 3));
 ```
 ```output
           time          | delta
@@ -140,8 +140,8 @@ This element will return a new timevector where each point is the difference bet
 ### Sample Usage <a id="timevector_pipeline_delta-examples"></a>
 ```SQL
 SELECT time, value
-FROM toolkit_experimental.unnest(
-    (SELECT toolkit_experimental.timevector('2020-01-01'::timestamptz + step * '1 day'::interval, step * step)
+FROM unnest(
+    (SELECT timevector('2020-01-01'::timestamptz + step * '1 day'::interval, step * step)
         -> toolkit_experimental.delta()
     FROM generate_series(1, 5) step)
 );
@@ -190,8 +190,8 @@ SELECT timevector(time, value) -> sort() -> lttb() FROM data;
 ### Sample Usage <a id="timevector_pipeline_lttb-examples"></a>
 ```SQL
 SELECT time, value
-FROM toolkit_experimental.unnest(
-    (SELECT toolkit_experimental.timevector('2020-01-01 UTC'::TIMESTAMPTZ + make_interval(days=>(foo*10)::int), 10 + 5 * cos(foo))
+FROM unnest(
+    (SELECT timevector('2020-01-01 UTC'::TIMESTAMPTZ + make_interval(days=>(foo*10)::int), 10 + 5 * cos(foo))
         -> toolkit_experimental.lttb(4)
     FROM generate_series(1,11,0.1) foo)
 );
@@ -230,8 +230,8 @@ This element takes in a timevector and returns a timevector consisting of the sa
 ### Sample Usage <a id="timevector_pipeline_sort-examples"></a>
 ```SQL
 SELECT time, value
-FROM toolkit_experimental.unnest(
-    (SELECT toolkit_experimental.timevector('2020-01-06'::timestamptz - step * '1 day'::interval, step * step)
+FROM unnest(
+    (SELECT timevector('2020-01-06'::timestamptz - step * '1 day'::interval, step * step)
         -> toolkit_experimental.sort()
     FROM generate_series(1, 5) step)
 );

--- a/extension/src/accessors.rs
+++ b/extension/src/accessors.rs
@@ -547,3 +547,22 @@ pub mod toolkit_experimental {
         }
     }
 }
+
+pg_type! {
+    #[derive(Debug)]
+    struct AccessorUnnest {
+    }
+}
+
+ron_inout_funcs!(AccessorUnnest);
+
+// Note that this should be able to replace the timescale_experimental.unnest function
+// and related object in src/timevector/pipeline/expansion.rs
+#[pg_extern(immutable, parallel_safe, name="unnest")]
+pub fn accessor_unnest(
+) -> AccessorUnnest<'static> {
+    build!{
+        AccessorUnnest {
+        }
+    }
+}

--- a/extension/src/asap.rs
+++ b/extension/src/asap.rs
@@ -106,13 +106,13 @@ fn find_downsample_interval(points: &[TSPoint], resolution: i64) -> i64 {
 fn asap_final(
     state: Internal,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<crate::time_vector::toolkit_experimental::Timevector<'static>> {
+) -> Option<Timevector<'static>> {
     asap_final_inner(unsafe { state.to_inner() }, fcinfo)
 }
 fn asap_final_inner(
     state: Option<Inner<ASAPTransState>>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<crate::time_vector::toolkit_experimental::Timevector<'static>> {
+) -> Option<Timevector<'static>> {
     unsafe {
         in_aggregate_context(fcinfo, || {
             let state = match state {
@@ -171,9 +171,9 @@ fn asap_final_inner(
     parallel_safe
 )]
 pub fn asap_on_timevector(
-    mut series: crate::time_vector::toolkit_experimental::Timevector<'static>,
+    mut series: Timevector<'static>,
     resolution: i32,
-) -> Option<crate::time_vector::toolkit_experimental::Timevector<'static>> {
+) -> Option<Timevector<'static>> {
     // TODO: implement this using zero copy (requires sort, find_downsample_interval, and downsample_and_gapfill on Timevector)
     let needs_sort = series.is_sorted();
 
@@ -317,7 +317,7 @@ mod tests {
             // and our decreased values should be around 64-72.  However, since the output is
             // rolling averages, expect these values to impact the results around these ranges as well.
 
-            client.select("create table asap_vals as SELECT * FROM toolkit_experimental.unnest((SELECT toolkit_experimental.asap_smooth(date, value, 100) FROM asap_test ))", None, None);
+            client.select("create table asap_vals as SELECT * FROM unnest((SELECT toolkit_experimental.asap_smooth(date, value, 100) FROM asap_test ))", None, None);
 
             let sanity = client
                 .select("SELECT COUNT(*) FROM asap_vals", None, None)
@@ -416,9 +416,9 @@ mod tests {
             client.select(
                 "create table asap_vals2 as
                 SELECT *
-                FROM toolkit_experimental.unnest(
+                FROM unnest(
                     (SELECT toolkit_experimental.asap_smooth(
-                        (SELECT toolkit_experimental.timevector(date, value) FROM asap_test),
+                        (SELECT timevector(date, value) FROM asap_test),
                         100)
                     )
                 )",

--- a/extension/src/asap.rs
+++ b/extension/src/asap.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use tspoint::TSPoint;
 
-use crate::time_vector::{Timevector, TimevectorData};
+use crate::time_vector::{Timevector_TSTZ_F64, Timevector_TSTZ_F64Data};
 
 // This is included for debug purposes and probably should not leave experimental
 #[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
@@ -106,13 +106,13 @@ fn find_downsample_interval(points: &[TSPoint], resolution: i64) -> i64 {
 fn asap_final(
     state: Internal,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<Timevector<'static>> {
+) -> Option<Timevector_TSTZ_F64<'static>> {
     asap_final_inner(unsafe { state.to_inner() }, fcinfo)
 }
 fn asap_final_inner(
     state: Option<Inner<ASAPTransState>>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<Timevector<'static>> {
+) -> Option<Timevector_TSTZ_F64<'static>> {
     unsafe {
         in_aggregate_context(fcinfo, || {
             let state = match state {
@@ -152,7 +152,7 @@ fn asap_final_inner(
             let nulls_len = (points.len() + 7) / 8;
 
             Some(crate::build! {
-                Timevector {
+                Timevector_TSTZ_F64 {
                     num_points: points.len() as u32,
                     flags: time_vector::FLAG_IS_SORTED,
                     internal_padding: [0; 3],
@@ -171,9 +171,9 @@ fn asap_final_inner(
     parallel_safe
 )]
 pub fn asap_on_timevector(
-    mut series: Timevector<'static>,
+    mut series: Timevector_TSTZ_F64<'static>,
     resolution: i32,
-) -> Option<Timevector<'static>> {
+) -> Option<Timevector_TSTZ_F64<'static>> {
     // TODO: implement this using zero copy (requires sort, find_downsample_interval, and downsample_and_gapfill on Timevector)
     let needs_sort = series.is_sorted();
 
@@ -209,7 +209,7 @@ pub fn asap_on_timevector(
     let nulls_len = (points.len() + 7) / 8;
 
     Some(crate::build! {
-        Timevector {
+        Timevector_TSTZ_F64 {
             num_points: points.len() as u32,
             flags: time_vector::FLAG_IS_SORTED,
             internal_padding: [0; 3],

--- a/extension/src/lttb.rs
+++ b/extension/src/lttb.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use tspoint::TSPoint;
 
-use crate::time_vector::{Timevector, TimevectorData};
+use crate::time_vector::{Timevector_TSTZ_F64, Timevector_TSTZ_F64Data};
 
 pub struct LttbTrans {
     series: Vec<TSPoint>,
@@ -67,13 +67,13 @@ pub fn lttb_trans_inner(
 pub fn lttb_final(
     state: Internal,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<Timevector<'static>> {
+) -> Option<Timevector_TSTZ_F64<'static>> {
     lttb_final_inner(unsafe { state.to_inner() }, fcinfo)
 }
 pub fn lttb_final_inner(
     state: Option<Inner<LttbTrans>>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<Timevector<'static>> {
+) -> Option<Timevector_TSTZ_F64<'static>> {
     unsafe {
         in_aggregate_context(fcinfo, || {
             let mut state = match state {
@@ -83,7 +83,7 @@ pub fn lttb_final_inner(
             state.series.sort_by_key(|point| point.ts);
             let series = Cow::from(&state.series);
             let downsampled = lttb(&*series, state.resolution);
-            flatten!(Timevector {
+            flatten!(Timevector_TSTZ_F64 {
                 num_points: downsampled.len() as u32,
                 flags: time_vector::FLAG_IS_SORTED,
                 internal_padding: [0; 3],
@@ -188,17 +188,17 @@ pub fn lttb(data: &[TSPoint], threshold: usize) -> Cow<'_, [TSPoint]> {
     parallel_safe
 )]
 pub fn lttb_on_timevector(
-    series: Timevector<'static>,
+    series: Timevector_TSTZ_F64<'static>,
     threshold: i32,
-) -> Option<Timevector<'static>> {
+) -> Option<Timevector_TSTZ_F64<'static>> {
     lttb_ts(series, threshold as usize).into()
 }
 
 // based on https://github.com/jeromefroe/lttb-rs version 0.2.0
 pub fn lttb_ts(
-    data: Timevector,
+    data: Timevector_TSTZ_F64,
     threshold: usize,
-) -> Timevector {
+) -> Timevector_TSTZ_F64 {
     if !data.is_sorted() {
         panic!("lttb requires sorted timevector");
     }
@@ -277,7 +277,7 @@ pub fn lttb_ts(
     let nulls_len = (sampled.len() + 7) / 8;
 
     crate::build! {
-        Timevector {
+        Timevector_TSTZ_F64 {
             num_points: sampled.len() as _,
             flags: time_vector::FLAG_IS_SORTED,
             internal_padding: [0; 3],

--- a/extension/src/lttb.rs
+++ b/extension/src/lttb.rs
@@ -67,13 +67,13 @@ pub fn lttb_trans_inner(
 pub fn lttb_final(
     state: Internal,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<crate::time_vector::toolkit_experimental::Timevector<'static>> {
+) -> Option<Timevector<'static>> {
     lttb_final_inner(unsafe { state.to_inner() }, fcinfo)
 }
 pub fn lttb_final_inner(
     state: Option<Inner<LttbTrans>>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<crate::time_vector::toolkit_experimental::Timevector<'static>> {
+) -> Option<Timevector<'static>> {
     unsafe {
         in_aggregate_context(fcinfo, || {
             let mut state = match state {
@@ -188,17 +188,17 @@ pub fn lttb(data: &[TSPoint], threshold: usize) -> Cow<'_, [TSPoint]> {
     parallel_safe
 )]
 pub fn lttb_on_timevector(
-    series: crate::time_vector::toolkit_experimental::Timevector<'static>,
+    series: Timevector<'static>,
     threshold: i32,
-) -> Option<crate::time_vector::toolkit_experimental::Timevector<'static>> {
+) -> Option<Timevector<'static>> {
     lttb_ts(series, threshold as usize).into()
 }
 
 // based on https://github.com/jeromefroe/lttb-rs version 0.2.0
 pub fn lttb_ts(
-    data: crate::time_vector::toolkit_experimental::Timevector,
+    data: Timevector,
     threshold: usize,
-) -> crate::time_vector::toolkit_experimental::Timevector {
+) -> Timevector {
     if !data.is_sorted() {
         panic!("lttb requires sorted timevector");
     }
@@ -314,7 +314,7 @@ mod tests {
             client.select(
                 "INSERT INTO results1
                 SELECT time, value
-                FROM toolkit_experimental.unnest(
+                FROM unnest(
                     (SELECT toolkit_experimental.lttb(time, value, 100) FROM test)
                 );",
                 None,
@@ -329,9 +329,9 @@ mod tests {
             client.select(
                 "INSERT INTO results2
                 SELECT time, value
-                FROM toolkit_experimental.unnest(
+                FROM unnest(
                     (SELECT toolkit_experimental.lttb(
-                        (SELECT toolkit_experimental.timevector(time, value) FROM test), 100)
+                        (SELECT timevector(time, value) FROM test), 100)
                     )
                 );",
                 None,

--- a/extension/src/stabilization_info.rs
+++ b/extension/src/stabilization_info.rs
@@ -14,18 +14,18 @@ crate::functions_stabilized_at! {
     "1.9.0" => {
         accessorunnest_in(cstring),
         accessorunnest_out(accessorunnest),
-        arrow_timevector_unnest(timevector,accessorunnest),
-        rollup(timevector),
+        arrow_timevector_unnest(timevector_tstz_f64,accessorunnest),
+        rollup(timevector_tstz_f64),
         timevector(timestamp with time zone,double precision),
         timevector_combine(internal,internal),
-        timevector_compound_trans(internal,timevector),
+        timevector_tstz_f64_compound_trans(internal,timevector_tstz_f64),
         timevector_deserialize(bytea,internal),
         timevector_final(internal),
-        timevector_in(cstring),
-        timevector_out(timevector),
+        timevector_tstz_f64_in(cstring),
+        timevector_tstz_f64_out(timevector_tstz_f64),
         timevector_serialize(internal),
-        timevector_trans(internal,timestamp with time zone,double precision),
-        unnest(timevector),
+        timevector_tstz_f64_trans(internal,timestamp with time zone,double precision),
+        unnest(timevector_tstz_f64),
         unnest(),
     }
     "1.8.0" => {
@@ -186,7 +186,7 @@ crate::functions_stabilized_at! {
 crate::types_stabilized_at! {
     STABLE_TYPES
     "1.9.0" => {
-        timevector,
+        timevector_tstz_f64,
         accessorunnest
     }
     "1.8.0" => {
@@ -211,7 +211,7 @@ crate::types_stabilized_at! {
 crate::operators_stabilized_at! {
     STABLE_OPERATORS
     "1.9.0" => {
-        "->"(timevector,accessorunnest),
+        "->"(timevector_tstz_f64,accessorunnest),
     }
     "1.8.0" => {
     }

--- a/extension/src/stabilization_info.rs
+++ b/extension/src/stabilization_info.rs
@@ -11,6 +11,27 @@
 
 crate::functions_stabilized_at! {
     STABLE_FUNCTIONS
+    "1.9.0" => {
+        accessorunnest_in(cstring),
+        accessorunnest_out(accessorunnest),
+        arrow_timevector_unnest(timevector,accessorunnest),
+        rollup(timevector),
+        timevector(timestamp with time zone,double precision),
+        timevector_combine(internal,internal),
+        timevector_compound_trans(internal,timevector),
+        timevector_deserialize(bytea,internal),
+        timevector_final(internal),
+        timevector_in(cstring),
+        timevector_out(timevector),
+        timevector_serialize(internal),
+        timevector_trans(internal,timestamp with time zone,double precision),
+        unnest(timevector),
+        unnest(),
+    }
+    "1.8.0" => {
+    }
+    "1.7.0" => {
+    }
     "1.6.0" => {
     }
     "1.5" => {
@@ -164,6 +185,14 @@ crate::functions_stabilized_at! {
 
 crate::types_stabilized_at! {
     STABLE_TYPES
+    "1.9.0" => {
+        timevector,
+        accessorunnest
+    }
+    "1.8.0" => {
+    }
+    "1.7.0" => {
+    }
     "1.6.0" => {
     }
     "1.5" => {
@@ -181,6 +210,13 @@ crate::types_stabilized_at! {
 
 crate::operators_stabilized_at! {
     STABLE_OPERATORS
+    "1.9.0" => {
+        "->"(timevector,accessorunnest),
+    }
+    "1.8.0" => {
+    }
+    "1.7.0" => {
+    }
     "1.6.0" => {
     }
     "1.5" => {

--- a/extension/src/time_vector/pipeline/aggregation.rs
+++ b/extension/src/time_vector/pipeline/aggregation.rs
@@ -104,7 +104,7 @@ pub mod toolkit_experimental {
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_run_pipeline_then_stats_agg(
-    mut timevector: Timevector,
+    mut timevector: Timevector_TSTZ_F64,
     pipeline: toolkit_experimental::PipelineThenStatsAgg,
 ) -> StatsSummary1D<'static> {
     if timevector.has_nulls() {
@@ -212,7 +212,7 @@ extension_sql!(
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_pipeline_then_sum(
-    timevector: Timevector,
+    timevector: Timevector_TSTZ_F64,
     pipeline: toolkit_experimental::PipelineThenSum,
 ) -> Option<f64> {
     let pipeline = pipeline.0;
@@ -302,7 +302,7 @@ extension_sql!(
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_pipeline_then_average(
-    timevector: Timevector,
+    timevector: Timevector_TSTZ_F64,
     pipeline: toolkit_experimental::PipelineThenAverage,
 ) -> Option<f64> {
     let pipeline = pipeline.0;
@@ -397,7 +397,7 @@ extension_sql!(
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_pipeline_then_num_vals(
-    timevector: Timevector,
+    timevector: Timevector_TSTZ_F64,
     pipeline: toolkit_experimental::PipelineThenNumVals,
 ) -> i64 {
     run_pipeline_elements(timevector, pipeline.elements.iter()).num_vals() as _
@@ -453,7 +453,7 @@ ALTER FUNCTION "arrow_pipeline_then_num_vals" SUPPORT toolkit_experimental.pipel
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_run_pipeline_then_counter_agg(
-    mut timevector: Timevector,
+    mut timevector: Timevector_TSTZ_F64,
     pipeline: toolkit_experimental::PipelineThenCounterAgg,
 ) -> Option<CounterSummary<'static>> {
     timevector = run_pipeline_elements(timevector, pipeline.elements.iter());
@@ -538,7 +538,7 @@ ALTER FUNCTION "arrow_run_pipeline_then_counter_agg" SUPPORT toolkit_experimenta
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_run_pipeline_then_hyperloglog(
-    mut timevector: Timevector,
+    mut timevector: Timevector_TSTZ_F64,
     pipeline: toolkit_experimental::PipelineThenHyperLogLog,
 ) -> HyperLogLog<'static> {
     timevector = run_pipeline_elements(timevector, pipeline.elements.iter());
@@ -621,7 +621,7 @@ ALTER FUNCTION "arrow_run_pipeline_then_hyperloglog" SUPPORT toolkit_experimenta
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_run_pipeline_then_percentile_agg(
-    mut timevector: Timevector,
+    mut timevector: Timevector_TSTZ_F64,
     pipeline: toolkit_experimental::PipelineThenPercentileAgg,
 ) -> UddSketch<'static> {
     timevector = run_pipeline_elements(timevector, pipeline.elements.iter());

--- a/extension/src/time_vector/pipeline/aggregation.rs
+++ b/extension/src/time_vector/pipeline/aggregation.rs
@@ -28,7 +28,6 @@ pub mod toolkit_experimental {
     use super::*;
     pub(crate) use crate::accessors::toolkit_experimental::*;
     pub(crate) use crate::time_vector::pipeline::UnstableTimevectorPipeline;
-    pub(crate) use crate::time_vector::Timevector;
 
     pg_type! {
         #[derive(Debug)]
@@ -105,7 +104,7 @@ pub mod toolkit_experimental {
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_run_pipeline_then_stats_agg(
-    mut timevector: toolkit_experimental::Timevector,
+    mut timevector: Timevector,
     pipeline: toolkit_experimental::PipelineThenStatsAgg,
 ) -> StatsSummary1D<'static> {
     if timevector.has_nulls() {
@@ -213,7 +212,7 @@ extension_sql!(
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_pipeline_then_sum(
-    timevector: toolkit_experimental::Timevector,
+    timevector: Timevector,
     pipeline: toolkit_experimental::PipelineThenSum,
 ) -> Option<f64> {
     let pipeline = pipeline.0;
@@ -303,7 +302,7 @@ extension_sql!(
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_pipeline_then_average(
-    timevector: toolkit_experimental::Timevector,
+    timevector: Timevector,
     pipeline: toolkit_experimental::PipelineThenAverage,
 ) -> Option<f64> {
     let pipeline = pipeline.0;
@@ -398,7 +397,7 @@ extension_sql!(
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_pipeline_then_num_vals(
-    timevector: toolkit_experimental::Timevector,
+    timevector: Timevector,
     pipeline: toolkit_experimental::PipelineThenNumVals,
 ) -> i64 {
     run_pipeline_elements(timevector, pipeline.elements.iter()).num_vals() as _
@@ -454,7 +453,7 @@ ALTER FUNCTION "arrow_pipeline_then_num_vals" SUPPORT toolkit_experimental.pipel
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_run_pipeline_then_counter_agg(
-    mut timevector: toolkit_experimental::Timevector,
+    mut timevector: Timevector,
     pipeline: toolkit_experimental::PipelineThenCounterAgg,
 ) -> Option<CounterSummary<'static>> {
     timevector = run_pipeline_elements(timevector, pipeline.elements.iter());
@@ -539,7 +538,7 @@ ALTER FUNCTION "arrow_run_pipeline_then_counter_agg" SUPPORT toolkit_experimenta
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_run_pipeline_then_hyperloglog(
-    mut timevector: toolkit_experimental::Timevector,
+    mut timevector: Timevector,
     pipeline: toolkit_experimental::PipelineThenHyperLogLog,
 ) -> HyperLogLog<'static> {
     timevector = run_pipeline_elements(timevector, pipeline.elements.iter());
@@ -622,7 +621,7 @@ ALTER FUNCTION "arrow_run_pipeline_then_hyperloglog" SUPPORT toolkit_experimenta
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_run_pipeline_then_percentile_agg(
-    mut timevector: toolkit_experimental::Timevector,
+    mut timevector: Timevector,
     pipeline: toolkit_experimental::PipelineThenPercentileAgg,
 ) -> UddSketch<'static> {
     timevector = run_pipeline_elements(timevector, pipeline.elements.iter());

--- a/extension/src/time_vector/pipeline/arithmetic.rs
+++ b/extension/src/time_vector/pipeline/arithmetic.rs
@@ -33,7 +33,7 @@ pub enum Function {
     Trunc,
 }
 
-pub fn apply(mut series: Timevector<'_>, function: Function, rhs: f64) -> Timevector<'_> {
+pub fn apply(mut series: Timevector_TSTZ_F64<'_>, function: Function, rhs: f64) -> Timevector_TSTZ_F64<'_> {
     let function: fn(f64, f64) -> f64 = match function {
         Add => |a, b| a + b,
         Sub => |a, b| a - b,

--- a/extension/src/time_vector/pipeline/delta.rs
+++ b/extension/src/time_vector/pipeline/delta.rs
@@ -26,8 +26,8 @@ extension_sql!(
 );
 
 pub fn timevector_delta<'s>(
-    series: &toolkit_experimental::Timevector<'s>,
-) -> toolkit_experimental::Timevector<'s> {
+    series: &Timevector<'s>,
+) -> Timevector<'s> {
     if !series.is_sorted() {
         panic!("can only compute deltas for sorted timevector");
     }

--- a/extension/src/time_vector/pipeline/delta.rs
+++ b/extension/src/time_vector/pipeline/delta.rs
@@ -26,8 +26,8 @@ extension_sql!(
 );
 
 pub fn timevector_delta<'s>(
-    series: &Timevector<'s>,
-) -> Timevector<'s> {
+    series: &Timevector_TSTZ_F64<'s>,
+) -> Timevector_TSTZ_F64<'s> {
     if !series.is_sorted() {
         panic!("can only compute deltas for sorted timevector");
     }
@@ -49,7 +49,7 @@ pub fn timevector_delta<'s>(
 
     let nulls_len = (delta_points.len() + 7) / 8;
 
-    build!(Timevector {
+    build!(Timevector_TSTZ_F64 {
         num_points: delta_points.len() as u32,
         flags: series.flags,
         internal_padding: [0; 3],

--- a/extension/src/time_vector/pipeline/expansion.rs
+++ b/extension/src/time_vector/pipeline/expansion.rs
@@ -82,7 +82,7 @@ pub fn arrow_finalize_with_unnest<'p>(
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_run_pipeline_then_unnest(
-    timevector: toolkit_experimental::Timevector,
+    timevector: Timevector,
     pipeline: toolkit_experimental::PipelineThenUnnest,
 ) -> impl Iterator<Item = (name!(time, crate::raw::TimestampTz), name!(value, f64))> {
     let series = run_pipeline_elements(timevector, pipeline.elements.iter())
@@ -137,7 +137,7 @@ pub fn arrow_force_materialize<'e>(
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_run_pipeline_then_materialize(
-    timevector: toolkit_experimental::Timevector,
+    timevector: Timevector,
     pipeline: toolkit_experimental::PipelineForceMaterialize,
 ) -> toolkit_experimental::Timevector<'static> {
     run_pipeline_elements(timevector, pipeline.elements.iter()).in_current_context()

--- a/extension/src/time_vector/pipeline/expansion.rs
+++ b/extension/src/time_vector/pipeline/expansion.rs
@@ -82,7 +82,7 @@ pub fn arrow_finalize_with_unnest<'p>(
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_run_pipeline_then_unnest(
-    timevector: Timevector,
+    timevector: Timevector_TSTZ_F64,
     pipeline: toolkit_experimental::PipelineThenUnnest,
 ) -> impl Iterator<Item = (name!(time, crate::raw::TimestampTz), name!(value, f64))> {
     let series = run_pipeline_elements(timevector, pipeline.elements.iter())
@@ -137,9 +137,9 @@ pub fn arrow_force_materialize<'e>(
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_run_pipeline_then_materialize(
-    timevector: Timevector,
+    timevector: Timevector_TSTZ_F64,
     pipeline: toolkit_experimental::PipelineForceMaterialize,
-) -> toolkit_experimental::Timevector<'static> {
+) -> toolkit_experimental::Timevector_TSTZ_F64<'static> {
     run_pipeline_elements(timevector, pipeline.elements.iter()).in_current_context()
 }
 

--- a/extension/src/time_vector/pipeline/fill_to.rs
+++ b/extension/src/time_vector/pipeline/fill_to.rs
@@ -83,9 +83,9 @@ pub fn fillto_pipeline_element<'e>(
 }
 
 pub fn fill_to<'s>(
-    series: toolkit_experimental::Timevector<'s>,
+    series: Timevector<'s>,
     element: &toolkit_experimental::Element,
-) -> toolkit_experimental::Timevector<'s> {
+) -> Timevector<'s> {
     let (interval, method) = match element {
         Element::FillTo {
             interval,

--- a/extension/src/time_vector/pipeline/fill_to.rs
+++ b/extension/src/time_vector/pipeline/fill_to.rs
@@ -83,9 +83,9 @@ pub fn fillto_pipeline_element<'e>(
 }
 
 pub fn fill_to<'s>(
-    series: Timevector<'s>,
+    series: Timevector_TSTZ_F64<'s>,
     element: &toolkit_experimental::Element,
-) -> Timevector<'s> {
+) -> Timevector_TSTZ_F64<'s> {
     let (interval, method) = match element {
         Element::FillTo {
             interval,
@@ -128,7 +128,7 @@ pub fn fill_to<'s>(
 
     let nulls_len = (result.len() + 7) / 8;
     build! {
-        Timevector {
+        Timevector_TSTZ_F64 {
             num_points: result.len() as _,
             flags: series.flags,
             internal_padding: [0; 3],

--- a/extension/src/time_vector/pipeline/filter.rs
+++ b/extension/src/time_vector/pipeline/filter.rs
@@ -24,9 +24,9 @@ pub fn filter_lambda_pipeline_element<'l, 'e>(
 }
 
 pub fn apply_lambda_to<'a>(
-    mut series: Timevector<'a>,
+    mut series: Timevector_TSTZ_F64<'a>,
     lambda: &lambda::LambdaData<'_>,
-) -> Timevector<'a> {
+) -> Timevector_TSTZ_F64<'a> {
     let expression = lambda.parse();
     if expression.ty() != &lambda::Type::Bool {
         panic!("invalid lambda type: the lambda must return a BOOLEAN")
@@ -49,7 +49,7 @@ pub fn apply_lambda_to<'a>(
 }
 
 pub fn filter_lambda_over_series(
-    series: &mut Timevector<'_>,
+    series: &mut Timevector_TSTZ_F64<'_>,
     mut func: impl FnMut(i64, f64) -> bool,
 ) {
     series.points.as_owned().retain(|p| func(p.ts, p.val));

--- a/extension/src/time_vector/pipeline/map.rs
+++ b/extension/src/time_vector/pipeline/map.rs
@@ -553,21 +553,6 @@ mod tests {
                 (ts:\"2020-01-03 00:00:00+00\",val:60)\
             ],null_val:[0])"
             );
-
-            let val = client
-                .select(
-                    "SELECT (timevector(time, value) ->> 'jan_3_x3')::TEXT FROM series",
-                    None,
-                    None,
-                )
-                .first()
-                .get_one::<String>();
-            assert_eq!(
-                val.unwrap(),
-                "(version:1,num_points:1,flags:1,internal_padding:(0,0,0),points:[\
-                (ts:\"2020-01-03 00:00:00+00\",val:60)\
-            ],null_val:[0])"
-            );
         });
     }
 
@@ -654,7 +639,7 @@ mod tests {
                 num_elements:1,\
                 elements:[\
                     MapSeries(\
-                        function:\"public.serier(toolkit_experimental.timevector)\"\
+                        function:\"public.serier(public.timevector)\"\
                     )\
                 ]\
             )";

--- a/extension/src/time_vector/pipeline/sort.rs
+++ b/extension/src/time_vector/pipeline/sort.rs
@@ -14,8 +14,8 @@ pub fn sort_pipeline_element<'p, 'e>() -> toolkit_experimental::UnstableTimevect
 }
 
 pub fn sort_timevector(
-    mut series: toolkit_experimental::Timevector<'_>,
-) -> toolkit_experimental::Timevector<'_> {
+    mut series: Timevector<'_>,
+) -> Timevector<'_> {
     if series.is_sorted() {
         return series;
     }

--- a/extension/src/time_vector/pipeline/sort.rs
+++ b/extension/src/time_vector/pipeline/sort.rs
@@ -14,8 +14,8 @@ pub fn sort_pipeline_element<'p, 'e>() -> toolkit_experimental::UnstableTimevect
 }
 
 pub fn sort_timevector(
-    mut series: Timevector<'_>,
-) -> Timevector<'_> {
+    mut series: Timevector_TSTZ_F64<'_>,
+) -> Timevector_TSTZ_F64<'_> {
     if series.is_sorted() {
         return series;
     }
@@ -46,7 +46,7 @@ pub fn sort_timevector(
         (points, null_val)
     };
 
-    TimevectorData {
+    Timevector_TSTZ_F64Data {
         header: 0,
         version: 1,
         padding: [0; 3],

--- a/tools/update-tester/src/testrunner.rs
+++ b/tools/update-tester/src/testrunner.rs
@@ -330,7 +330,7 @@ impl TestClient {
                 .unwrap_or_else(|e| panic!("error checking type existence: {}", e));
         }
 
-        for operator in stabilization::STABLE_OPERATORS {
+        for operator in stabilization::STABLE_OPERATORS() {
             let check_existence = format!("SELECT '{}'::regoperator;", operator);
             self.simple_query(&check_existence)
                 .unwrap_or_else(|e| panic!("error checking operator existence: {}", e));

--- a/tools/update-tester/src/testrunner.rs
+++ b/tools/update-tester/src/testrunner.rs
@@ -214,8 +214,7 @@ impl TestClient {
                     time_weight('locf', ts, val) AS twa, \
                     uddsketch(100, 0.001, val) as udd, \
                     tdigest(100, val) as tdig, \
-                    stats_agg(val) as stats, \
-                    timevector(ts, val) as tvec \
+                    stats_agg(val) as stats \
                 FROM test_data;\
         ";
         self.simple_query(create_test_view)
@@ -229,14 +228,8 @@ impl TestClient {
                 average(twa), \
                 approx_percentile(0.1, udd), \
                 approx_percentile(0.1, tdig), \
-                kurtosis(stats),
-                valsum \
-            FROM regression_view JOIN (
-                SELECT sum(value) AS valsum 
-                FROM unnest(
-                    (SELECT tvec FROM regression_view)
-                )
-            ) s ON true;\
+                kurtosis(stats) \
+            FROM regression_view;\
         ";
         let view_output = self
             .simple_query(query_test_view)

--- a/tools/update-tester/src/testrunner/stabilization.rs
+++ b/tools/update-tester/src/testrunner/stabilization.rs
@@ -50,11 +50,23 @@ macro_rules! operators_stabilized_at {
             }
         )*
     ) => {
-         // TODO JOSH - this may not be right
-        pub static $export_symbol: &[&str] = &[
-            $(
-                $(concat!($operator_name, "(", stringify!( $($fn_type),+ ) ")"),)*
-            )*
-        ];
+        #[allow(non_snake_case)]
+        pub fn $export_symbol() -> std::collections::HashSet<String> {
+            static OPERATORS: &[(&str, &[&str])] = &[
+                $(
+                    $(
+                        (
+                            $operator_name,
+                            &[
+                                $( stringify!($($fn_type)+) ),*
+                            ]
+                        ),
+                    )*
+                )*
+            ];
+            OPERATORS.iter().map(|(name, types)| {
+                format!("{}({})", name, types.join(","))
+            }).collect()
+        }
     };
 }


### PR DESCRIPTION
This change moves the timevector function and object out of the toolkit_experimental schema.  It also adds a template issue for feature stabilization.