### PR TITLE
Upgrading tools to use clap v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,15 +37,6 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -341,22 +332,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.33.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
-dependencies = [
- "ansi_term 0.11.0",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "term_size",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44bbe24bbd31a185bc2c4f7c2abe80bea13a20d57ee4e55be70ac512bdc76417"
@@ -365,10 +340,10 @@ dependencies = [
  "bitflags",
  "clap_lex",
  "indexmap",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
  "terminal_size",
- "textwrap 0.15.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -2258,7 +2233,7 @@ name = "sql-doctester"
 version = "0.1.0"
 dependencies = [
  "bytecount",
- "clap 2.33.3",
+ "clap",
  "colored",
  "postgres",
  "pulldown-cmark",
@@ -2305,12 +2280,6 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
@@ -2371,16 +2340,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
-dependencies = [
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2403,20 +2362,10 @@ dependencies = [
 name = "testrunner"
 version = "0.1.0"
 dependencies = [
- "clap 2.33.3",
+ "clap",
  "colored",
  "postgres",
  "rayon",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "term_size",
- "unicode-width",
 ]
 
 [[package]]
@@ -2667,7 +2616,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "lazy_static",
  "matchers",
  "regex",
@@ -2757,7 +2706,7 @@ checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 name = "update-tester"
 version = "0.3.0"
 dependencies = [
- "clap 3.2.15",
+ "clap",
  "colored",
  "control_file_reader",
  "postgres",
@@ -2808,12 +2757,6 @@ name = "vcell"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/tools/sql-doctester/Cargo.toml
+++ b/tools/sql-doctester/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 bytecount = "0.6.2"
-clap = { version = "2.33", features = ["wrap_help"] }
+clap = { version = "3.2.15", features = ["wrap_help"] }
 colored = "2.0.0"
 postgres = "0.19.1"
 pulldown-cmark = "0.8.0"

--- a/tools/sql-doctester/src/main.rs
+++ b/tools/sql-doctester/src/main.rs
@@ -7,29 +7,45 @@ use std::{
     process::exit,
 };
 
-use clap::clap_app;
-
 use colored::Colorize;
 
+use clap::{Arg, Command};
 use runner::ConnectionConfig;
-
 mod parser;
 mod runner;
 
 fn main() {
-    let matches = clap_app!(("sql-doctester") =>
-        (@arg HOST: -h --host [hostname] conflicts_with[URL] "postgres host")
-        (@arg PORT: -p --port [portnumber] conflicts_with[URL] "postgres port")
-        (@arg USER: -u --user [username] conflicts_with[URL] "postgres user")
-        (@arg PASSWORD: -a --password [password] conflicts_with[URL] "postgres password")
-        (@arg DB: -d --database [database] conflicts_with[URL] "postgres database the root \
-            connection should use. By default this DB will only be used \
-            to spawn the individual test databases; no tests will run against \
-            it.")
-        (@arg START_SCRIPT: -s --("startup-script") [startup_script] conflicts_with[START_FILE] "SQL command that should be run when each test database is created.")
-        (@arg START_FILE: -f --("startup-file") [startup_file] "File containing SQL commands that should be run when each test database is created.")
-        (@arg INPUT: <tests>  "Path in which to search for tests")
-    ).get_matches();
+    let matches = Command::new("sql-doctester")
+        .about("Runs sql commands from docs/ dir to test out toolkit")
+        .arg_required_else_help(true)
+        .arg(Arg::new("HOST").short('h').long("host").takes_value(true))
+        .arg(Arg::new("PORT").short('p').long("port").takes_value(true))
+        .arg(Arg::new("USER").short('u').long("user").takes_value(true))
+        .arg(
+            Arg::new("PASSWORD")
+                .short('a')
+                .long("password")
+                .takes_value(true),
+        )
+        .arg(Arg::new("DB").short('d').long("database").takes_value(true))
+        .arg(
+            Arg::new("START_SCRIPT")
+                .short('s')
+                .long("startup-script")
+                .takes_value(true)
+                .conflicts_with("START_FILE"),
+        )
+        .arg(
+            Arg::new("START_FILE")
+                .short('f')
+                .long("startup-file")
+                .takes_value(true)
+                .conflicts_with("START_SCRIPT"),
+        )
+        .arg(Arg::new("INPUT").takes_value(true))
+        .mut_arg("help", |_h| Arg::new("help").long("help"))
+        .get_matches();
+
     let dirname = matches.value_of("INPUT").expect("need input");
 
     let connection_config = ConnectionConfig {

--- a/tools/testrunner/Cargo.toml
+++ b/tools/testrunner/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-clap = { version = "2.33", features = ["wrap_help"] }
+clap = { version = "3.2.15", features = ["wrap_help"] }
 colored = "2.0.0"
 postgres = "0.19.0"
 rayon = "1.5"

--- a/tools/testrunner/src/main.rs
+++ b/tools/testrunner/src/main.rs
@@ -1,7 +1,11 @@
+use std::{
+    borrow::Cow,
+    io::{self, Write},
+    process::exit,
+    time::Instant,
+};
 
-use std::{borrow::Cow, io::{self, Write}, process::exit, time::Instant};
-
-use clap::clap_app;
+use clap::{Arg, Command};
 
 use colored::Colorize;
 
@@ -9,17 +13,21 @@ use postgres::{Client, NoTls, SimpleQueryMessage::Row};
 use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 
 fn main() {
-    let matches = clap_app!(("testrunner") =>
-        (@arg HOST: -h --host [hostname] conflicts_with[URL] "postgres host")
-        (@arg PORT: -p --port [portnumber] conflicts_with[URL] "postgres port")
-        (@arg USER: -u --user [username] conflicts_with[URL] "postgres user")
-        (@arg PASSWORD: -a --password [password] conflicts_with[URL] "postgres password")
-        (@arg DB: -d --database [database] conflicts_with[URL] "postgres database the root \
-            connection should use. By default this DB will only be used \
-            to spawn the individual test databases; no tests will run against \
-            it.")
-    ).get_matches();
-
+    let matches = Command::new("testrunner")
+        .about("Testrunner")
+        .arg_required_else_help(true)
+        .arg(Arg::new("HOST").short('h').long("host").takes_value(true))
+        .arg(Arg::new("PORT").short('p').long("port").takes_value(true))
+        .arg(Arg::new("USER").short('u').long("user").takes_value(true))
+        .arg(
+            Arg::new("PASSWORD")
+                .short('a')
+                .long("password")
+                .takes_value(true),
+        )
+        .arg(Arg::new("DB").short('d').long("database").takes_value(true))
+        .mut_arg("help", |_h| Arg::new("help").long("help"))
+        .get_matches();
     let connection_config = ConnectionConfig {
         host: matches.value_of("HOST"),
         port: matches.value_of("PORT"),


### PR DESCRIPTION
Updating `sql-doctester` and `testrunner` to use the same format `update-tester` now uses