### PR TITLE
Update toolkit to version 1.10.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,15 +61,15 @@ jobs:
         path: |
           /usr/local/cargo/registry
           /usr/local/cargo/git
-        key: ${{ runner.os }}-test-pg${{ matrix.pgversion }}-cargo-1.8
-        restore-keys: ${{ runner.os }}-test-pg${{ matrix.pgversion }}-cargo-1.5
+        key: ${{ runner.os }}-test-pg${{ matrix.pgversion }}-cargo-1.9
+        restore-keys: ${{ runner.os }}-test-pg${{ matrix.pgversion }}-cargo-1.8
 
     - name: Cache cargo target dir
       uses: actions/cache@v2
       with:
         path: target
-        key: ${{ runner.os }}-test-pg${{ matrix.pgversion }}-target-1.8
-        restore-keys: ${{ runner.os }}-test-pg${{ matrix.pgversion }}-target-1.5
+        key: ${{ runner.os }}-test-pg${{ matrix.pgversion }}-target-1.9
+        restore-keys: ${{ runner.os }}-test-pg${{ matrix.pgversion }}-target-1.8
 
     - name: Run pgx tests
       run: su postgres -c 'sh tools/build -pg${{ matrix.pgversion }} test-extension 2>&1'
@@ -111,15 +111,15 @@ jobs:
         path: |
           /usr/local/cargo/registry
           /usr/local/cargo/git
-        key: ${{ runner.os }}-test-crates-cargo-1.8
-        restore-keys: ${{ runner.os }}-test-crates-cargo-1.5
+        key: ${{ runner.os }}-test-crates-cargo-1.9
+        restore-keys: ${{ runner.os }}-test-crates-cargo-1.8
 
     - name: Cache cargo target dir
       uses: actions/cache@v2
       with:
         path: target
-        key: ${{ runner.os }}-test-crates-target-1.8
-        restore-keys: ${{ runner.os }}-test-crates-target-1.5
+        key: ${{ runner.os }}-test-crates-target-1.9
+        restore-keys: ${{ runner.os }}-test-crates-target-1.8
 
     - name: Run Crates Tests
       run: su postgres -c 'sh tools/build test-crates 2>&1'
@@ -154,22 +154,22 @@ jobs:
         path: |
           /usr/local/cargo/registry
           /usr/local/cargo/git
-        key: ${{ runner.os }}-test-updates-cargo-1.8
-        restore-keys: ${{ runner.os }}-test-crates-cargo-1.7
+        key: ${{ runner.os }}-test-updates-cargo-1.9
+        restore-keys: ${{ runner.os }}-test-crates-cargo-1.8
 
     - name: Cache cargo target dir
       uses: actions/cache@v2
       with:
         path: target
-        key: ${{ runner.os }}-test-updates-target-1.8
-        restore-keys: ${{ runner.os }}-test-crates-target-1.7
+        key: ${{ runner.os }}-test-updates-target-1.9
+        restore-keys: ${{ runner.os }}-test-crates-target-1.8
 
     - name: Cache old versions dir
       uses: actions/cache@v2
       with:
         path: old-versions
-        key: ${{ runner.os }}-test-old-versions-1.8
-        restore-keys: ${{ runner.os }}-test-old-versions-1.7
+        key: ${{ runner.os }}-test-old-versions-1.9
+        restore-keys: ${{ runner.os }}-test-old-versions-1.8
 
     - name: Run Update Tests
       run: su postgres -c 'sh tools/build -pg$PGVERSION -cargo-pgx /home/postgres/pgx/0.4/bin/cargo-pgx -cargo-pgx-old /home/postgres/pgx/0.2/bin/cargo-pgx test-updates 2>&1'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "timescaledb_toolkit"
-version = "1.9.0-dev"
+version = "1.10.0-dev"
 dependencies = [
  "aggregate_builder",
  "approx 0.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2327,7 +2327,7 @@ dependencies = [
 
 [[package]]
 name = "timescaledb_toolkit"
-version = "1.10.0-dev"
+version = "1.10.1-dev"
 dependencies = [
  "aggregate_builder",
  "approx 0.4.0",

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timescaledb_toolkit"
-version = "1.10.0-dev"
+version = "1.10.1-dev"
 edition = "2021"
 
 [lib]

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timescaledb_toolkit"
-version = "1.9.0-dev"
+version = "1.10.0-dev"
 edition = "2021"
 
 [lib]

--- a/extension/timescaledb_toolkit.control
+++ b/extension/timescaledb_toolkit.control
@@ -1,8 +1,8 @@
 comment = 'Library of analytical hyperfunctions, time-series pipelining, and other SQL utilities'
-default_version = '1.9.0-dev'
+default_version = '1.10.0-dev'
 relocatable = false
 superuser = false
 module_pathname = '$libdir/timescaledb_toolkit' # only for testing, will be removed for real installs
 # comma-separated list of previous versions this version can be upgraded from
 # directly. This is used to generate upgrade scripts.
-# upgradeable_from = '1.4, 1.5, 1.5.1, 1.5.2, 1.6.0, 1.7.0, 1.8.0'
+# upgradeable_from = '1.4, 1.5, 1.5.1, 1.5.2, 1.6.0, 1.7.0, 1.8.0, 1.9.0'

--- a/extension/timescaledb_toolkit.control
+++ b/extension/timescaledb_toolkit.control
@@ -1,8 +1,8 @@
 comment = 'Library of analytical hyperfunctions, time-series pipelining, and other SQL utilities'
-default_version = '1.10.0-dev'
+default_version = '1.10.1-dev'
 relocatable = false
 superuser = false
 module_pathname = '$libdir/timescaledb_toolkit' # only for testing, will be removed for real installs
 # comma-separated list of previous versions this version can be upgraded from
 # directly. This is used to generate upgrade scripts.
-# upgradeable_from = '1.4, 1.5, 1.5.1, 1.5.2, 1.6.0, 1.7.0, 1.8.0, 1.9.0'
+# upgradeable_from = '1.4, 1.5, 1.5.1, 1.5.2, 1.6.0, 1.7.0, 1.8.0, 1.10.0-dev'

--- a/tools/post-install/src/update_script.rs
+++ b/tools/post-install/src/update_script.rs
@@ -461,7 +461,7 @@ pub(crate) struct StaticFunction {
     types: &'static [&'static [&'static str]],
 }
 
-#[derive(Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Debug)]
 struct Version {
     major: u64,
     minor: u64,
@@ -493,7 +493,7 @@ fn version(s: &str) -> Version {
     version
 }
 
-fn new_objects<'a, T>(
+fn new_objects<'a, T: std::fmt::Debug>(
     stabilizations: &'a [(&'a str, T)],
     from_version: &'a str,
     to_version: &'a str,
@@ -501,9 +501,13 @@ fn new_objects<'a, T>(
     let to_version = to_version.trim_end_matches("-dev");
     println!("{}", from_version);
     let from_version = version(from_version);
+    let to_version = version(to_version);
     stabilizations
         .iter()
-        .skip_while(move |(version, _)| version != &to_version)
+        .skip_while(move |(version_str, _)| {
+            let version = version(version_str);
+            version > to_version
+        })
         .take_while(move |(at, _)| at != &"prehistory" && version(at) > from_version)
 }
 

--- a/tools/post-install/src/update_script.rs
+++ b/tools/post-install/src/update_script.rs
@@ -484,6 +484,7 @@ fn version(s: &str) -> Version {
         patch: nums
             .next()
             .unwrap_or("0")
+            .trim_end_matches("-dev")
             .parse()
             .unwrap_or_else(|e| panic!("error {} for major version in `{}`", e, s)),
     };

--- a/tools/post-install/src/update_script.rs
+++ b/tools/post-install/src/update_script.rs
@@ -31,6 +31,7 @@ pub(crate) fn generate_from_install(
     mut upgrade_file: impl Write,
 ) {
     let new_stabilizations = new_stabilizations(from_version, current_version);
+
     writeln!(
         &mut upgrade_file,
         "DROP SCHEMA IF EXISTS toolkit_experimental CASCADE;\n\
@@ -68,19 +69,7 @@ pub(crate) fn generate_from_install(
                 // TODO is there something more principled to do here?
                 writeln!(script_creator.upgrade_file, "CREATE SCHEMA {}", create).unwrap();
             }
-            Some(Create::Operator(create)) => {
-                // TODO we have no stable operators
-                // JOSH - operators are slightly different than other objects since
-                //        they're not necessarily in the toolkit_experimental when unstable.
-                //        Instead, to check if it's stable we need to check if
-                //        one of the inputs types, or the function is experimental.
-                //        in other words, we need to check if one of
-                //          FUNCTION=toolkit_experimental.*
-                //          LEFTARG=toolkit_experimental.*
-                //          RIGHTARG=toolkit_experimental.*
-                //        see `parse_operator_info()` for an attempt at this
-                writeln!(script_creator.upgrade_file, "CREATE OPERATOR {}", create).unwrap();
-            }
+            Some(Create::Operator(create)) => script_creator.handle_create_operator(create),
             Some(Create::Cast(create)) => {
                 // TODO we don't have a stable one of these yet
                 // JOSH - we should probably check if the FUNCTION is experimental also
@@ -113,6 +102,9 @@ enum Create {
     Schema(String),
     Cast(String),
 }
+
+const MUST_FIND_MATCH: bool = false;
+const ALLOW_NO_MATCH: bool = true;
 
 impl<Lines, Dst> UpdateScriptCreator<Lines, Dst>
 where
@@ -252,31 +244,7 @@ where
     }
 
     fn get_alterable_properties(&mut self) -> Vec<Option<String>> {
-        let mut alters = vec![None; ALTERABLE_PROPERTIES.len()];
-        for line in &mut self.lines {
-            let mut split = line.split_ascii_whitespace();
-            let first = match split.next() {
-                None => continue,
-                Some(first) => first,
-            };
-
-            // found `)` means we're done with
-            // ```
-            // CREATE TYPE <name> (
-            //     ...
-            // );
-            // ```
-            if first.starts_with(')') {
-                break;
-            }
-
-            for (i, property) in ALTERABLE_PROPERTIES.iter().enumerate() {
-                if first.eq_ignore_ascii_case(property) {
-                    assert_eq!(split.next(), Some("="));
-                    alters[i] = Some(split.next().expect("no value").to_string());
-                }
-            }
-        }
+        self.get_properties(&ALTERABLE_PROPERTIES[..], ALLOW_NO_MATCH);
         // Should return alters here, except PG12 doesn't allow alterations to type properties.
         // Once we no longer support PG12 change this back to returning alters
         vec![]
@@ -312,6 +280,104 @@ where
         }
 
         writeln!(self.upgrade_file, "{}", alter_statement).expect("cannot write ALTER TYPE");
+    }
+
+    fn handle_create_operator(&mut self, create: String) {
+        assert!(create.trim_end().ends_with('('));
+        // found
+        // ```
+        // CREATE OPERATOR <op> (
+        //     PROCEDURE=...,
+        //     LEFTARG=...,
+        //     RIGHTARG=...
+        // );
+        // ```
+        // if any of `PROCEDURE`, `LEFTARG`, or `RIGHTARG` refer to and
+        // experimental object the operator is experimental, otherwise it isn't
+        let op = extract_name(&create);
+
+        let fields = self.get_properties(&["PROCEDURE", "LEFTARG", "RIGHTARG"], MUST_FIND_MATCH);
+
+        let is_experimental = fields
+            .iter()
+            .filter_map(|f| f.as_ref())
+            .any(|f| f.contains("toolkit_experimental"));
+
+        let parse_operator_arg_type = |field: &Option<String>| {
+            field
+                .as_ref()
+                .unwrap()
+                // remove everything after the comma, if one exists
+                .split_terminator(',')
+                .next()
+                .unwrap()
+                // remove any trailing comments
+                .split_terminator("/*")
+                .next()
+                .unwrap()
+                .to_ascii_lowercase()
+                // handle `DOUBLE PRECISION`
+                .split_ascii_whitespace()
+                .map(|s| s.to_string())
+                .collect()
+        };
+        let operator = Function {
+            name: op.clone(),
+            types: vec![
+                parse_operator_arg_type(&fields[1]),
+                parse_operator_arg_type(&fields[2]),
+            ],
+        };
+        if is_experimental || self.new_stabilizations.new_operators.contains(&operator) {
+            writeln!(
+                self.upgrade_file,
+                "CREATE OPERATOR {} (\n    \
+                    PROCEDURE={}\n    \
+                    LEFTARG={}\n    \
+                    RIGHTARG={}\n    \
+                );",
+                op,
+                fields[0].as_ref().unwrap(),
+                fields[1].as_ref().unwrap(),
+                fields[2].as_ref().unwrap(),
+            )
+            .expect("cannot write CREATE OPERATOR")
+        }
+    }
+
+    fn get_properties(&mut self, fields: &[&str], allow_no_match: bool) -> Vec<Option<String>> {
+        let mut properties = vec![None; fields.len()];
+        for line in &mut self.lines {
+            // found `)` means we're done with
+            // ```
+            // CREATE <object> <name> (
+            //     ...
+            // );
+            // ```
+            if line.trim_start().starts_with(')') {
+                break;
+            }
+            let mut split = line.split('=');
+            let field = split.next().unwrap().trim();
+            let value = split.next().unwrap_or_else(|| panic!("no value for field {}", field)).trim();
+            assert_eq!(split.next(), None);
+
+            let mut found_match = false;
+            for (i, property) in fields.iter().enumerate() {
+                if field.eq_ignore_ascii_case(property) {
+                    properties[i] = Some(value.to_string());
+                    found_match = true;
+                }
+            }
+            if !found_match && !allow_no_match {
+                panic!(
+                    "{} is not considered an acceptable property for this object",
+                    field
+                )
+            }
+        }
+
+        properties
     }
 }
 
@@ -394,37 +460,6 @@ fn parse_ident(mut stmt: &str) -> (String, &str) {
     }
 }
 
-// TODO JOSH - this may not be done yet, but I'm leaving it in to help future devs
-// fn parse_operator_info(operator: &str) -> Function {
-//     let name = extract_name(operator);
-//     let args_start = operator.find('(').unwrap();
-//     let args = operator[args_start..].lines();
-//     let (mut left, mut right) = (None, None);
-//     for arg in args {
-//         let arg = arg.trim_start();
-//         let (sink, skip) = if arg.starts_with("LEFTARG") {
-//             (&mut left, "LEFTARG".len())
-//         } else if arg.starts_with("RIGHTARG") {
-//             (&mut right, "RIGHTARG".len())
-//         } else {
-//             continue;
-//         };
-//         // skip LEFT/RIGHTARG=
-//         let arg = &arg[skip + 1..];
-//         *sink = match arg.rfind(',') {
-//             Some(end) => arg[..end].to_ascii_lowercase().into(),
-//             None => arg
-//                 .split_ascii_whitespace()
-//                 .map(|s| s.to_ascii_lowercase())
-//                 .next(),
-//         }
-//     }
-//     Function {
-//         name,
-//         types: vec![vec![left.unwrap()], vec![right.unwrap()]],
-//     }
-// }
-
 fn extract_name(line: &str) -> String {
     let mut name: &str = line.split_ascii_whitespace().next().expect("no type name");
     if name.ends_with(';') {
@@ -500,7 +535,6 @@ fn new_objects<'a, T: std::fmt::Debug>(
     to_version: &'a str,
 ) -> impl Iterator<Item = &'a (&'a str, T)> + 'a {
     let to_version = to_version.trim_end_matches("-dev");
-    println!("{}", from_version);
     let from_version = version(from_version);
     let to_version = version(to_version);
     stabilizations
@@ -607,7 +641,7 @@ macro_rules! operators_stabilized_at {
                         $version,
                         &[
                             $(StaticFunction {
-                                name: stringify!($fn_name),
+                                name: $operator_name,
                                 types: &[$(
                                     &[$(
                                         stringify!($fn_type),


### PR DESCRIPTION
This change updates the version in preparation for the 1.10.1 release.

This also fixes the update script code to correctly handle postgresql operator objects and fixes some of the version comparison logic.