### PR TITLE
Fix APPROX_COUNT_DISTINCT_DEFAULT_SIZE value

### DIFF
--- a/extension/src/hyperloglog.rs
+++ b/extension/src/hyperloglog.rs
@@ -47,9 +47,9 @@ pub fn hyperloglog_trans(
     .internal()
 }
 
-const APPROX_COUNT_DISTINCT_DEFAULT_SIZE: i32 = 32678;
+const APPROX_COUNT_DISTINCT_DEFAULT_SIZE: i32 = 32768;
 
-/// Similar to hyperloglog_trans(), except size is set to a default of 32,678
+/// Similar to hyperloglog_trans(), except size is set to a default of 32,768
 #[pg_extern(immutable, parallel_safe,schema = "toolkit_experimental")]
 pub fn approx_count_distinct_trans(
     state: Internal,


### PR DESCRIPTION
The [Hyperloglog docs](https://docs.timescale.com/api/latest/hyperfunctions/approx_count_distincts/hyperloglog/) state the value for this should be a power of 2 between 16 and 2^18 and that if you're not sure, start with 32768 (2^15).

The value here (32678) seems to have been an honest mistake.