### PR TITLE
Add PG version as default feature to extension/Cargo.toml

### DIFF
--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [features]
-default = []
+default = ["pg14"]
 pg10 = ["pgx/pg10", "pgx-tests/pg10"]
 pg11 = ["pgx/pg11", "pgx-tests/pg11"]
 pg12 = ["pgx/pg12", "pgx-tests/pg12"]


### PR DESCRIPTION
While tools/build takes care this for the developer team, for new users who might be trying to build or even contribute a patch, not having something here could unnecessarily trip them up when running various `cargo` commands. 

This also helps out tools such as language servers which are totally ignorant of our tools/build setup but might e.g. use `cargo check`.
