### PR TITLE
Prevent unnecessary rebuilds using Cargo in root

### DIFF
--- a/extension/.cargo/config
+++ b/extension/.cargo/config
@@ -1,3 +1,0 @@
-[build]
-# Postgres symbols won't be available until runtime
-rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]


### PR DESCRIPTION
Currently `.cargo/config` and `extension/.cargo/config` are the same file (except for whitespace differences).

The [Cargo docs](https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure) specify that Cargo config files are looked for in each parent directory, so including the exact same config file in the `extension/` directory and its parent directory is unnecessary.

The [pgx README](https://github.com/tcdi/pgx/blob/1a89778046547c52c714fe6885069eab5638f965/cargo-pgx/README.md#creating-a-new-extension) says:

> **Workspace users:** `cargo pgx new $NAME` will create a `$NAME/.cargo/config`, you should move this into your workspace root as `.cargo./config`.
>
> If you don't, you may experience unnecessary rebuilds using tools like Rust-Analyzer, as it will use the wrong `rustflags` option.


Config file duplication results in `cargo test` in the root directory building Toolkit from scratch twice, since Cargo invalidates previously built dependencies whenever it uses a new config file (even if they are semantically identical).