### PR TITLE
Adding git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# Merge and parent commit for cargo fmt changes
+b7433344f90b142094e73e84c332385498db9335
+8b50127c9e4bad1696a68a800ce1ef019cf6fc3c


### PR DESCRIPTION
Part 2 of updating toolkit to use `cargo fmt` by uploading `.git-blame-ignore-revs` with the `cargo fmt` commits in the file.

Part 1 can be found here: https://github.com/timescale/timescaledb-toolkit/pull/524

You can use git config to set git to always use the ignoreRevsFile in a project with the following command:
```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```
You could also just pass it in as a flag to git blame but then you have to remember to always include the flag.
```
git blame --ignore-revs-file .git-blame-ignore-revs
```