### PR TITLE
Document requirement to use same compiler for cargo-pgx and Toolkit

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -49,10 +49,20 @@ For Ubuntu you can follow the [postgres install instructions](https://www.postgr
 ```bash
 sudo apt-get install make gcc pkg-config clang postgresql-server-dev-14 libssl-dev
 ```
-and finally, [pgx](https://github.com/tcdi/pgx), which can be installed with
+
+Next you need [cargo-pgx](https://github.com/tcdi/pgx), which can be installed with
 ```bash
-cargo install --version '=0.4.5' cargo-pgx && cargo pgx init --pg14 pg_config
+cargo install --version '=0.4.5' --force cargo-pgx
 ```
+
+You must reinstall cargo-pgx whenver you update your Rust compiler, since cargo-pgx needs to be built with the same compiler as Toolkit.
+
+Finally, setup the pgx development environment with
+
+```bash
+cargo pgx init --pg14 pg_config
+```
+
 
 Installing from source is also available on macOS and requires the same set of prerequisites and set up commands listed above.
 


### PR DESCRIPTION
The same compiler must be used to compile cargo-pgx and Toolkit, or bad things (undefined behaviour) might happen. See https://github.com/tcdi/pgx/pull/687 for why this is the case.

This PR updates the installation documentation in the README to indicate this. I split the command in two since you only need to reinstall cargo-pgx, there's no need to re-run `cargo pgx init`.