### PR TITLE
Remove unused arrayvec dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,12 +63,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "asap"
 version = "0.1.0"
 
@@ -884,7 +878,6 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 name = "hyperloglogplusplus"
 version = "0.1.0"
 dependencies = [
- "arrayvec",
  "encodings",
  "fnv",
  "quickcheck",

--- a/crates/hyperloglogplusplus/Cargo.toml
+++ b/crates/hyperloglogplusplus/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-arrayvec = { version = "0.5.2", features = ["array-sizes-33-128"] }
 serde = { version = "1.0", features = ["derive"] }
 encodings = { path="../encodings" }
 


### PR DESCRIPTION
We don't use arrayvec anywhere, get rid of it.

I noticed this while looking at our outdated dependencies. We should probably wait until after 1.11 to update dependencies, but this removal can be done now.