### PR TITLE
consider: Stop supporting upgrade from 1.4 and 1.5 .

### DIFF
--- a/extension/timescaledb_toolkit.control
+++ b/extension/timescaledb_toolkit.control
@@ -5,4 +5,4 @@ superuser = false
 module_pathname = '$libdir/timescaledb_toolkit' # only for testing, will be removed for real installs
 # comma-separated list of previous versions this version can be upgraded from
 # directly. This is used to generate upgrade scripts.
-# upgradeable_from = '1.4, 1.5, 1.5.1, 1.5.2, 1.6.0, 1.7.0, 1.8.0, 1.10.0-dev, 1.10.1, 1.11.0, 1.12.0, 1.12.1'
+# upgradeable_from = '1.5.1, 1.5.2, 1.6.0, 1.7.0, 1.8.0, 1.10.0-dev, 1.10.1, 1.11.0, 1.12.0, 1.12.1'


### PR DESCRIPTION
We are automating testing upgrades of binaries, but these, our two oldest versions, are hard to automate because:

- We released no binaries for 1.4
- The deb for 1.5 was labeled 1.5.0

We could special case these, but requiring two upgrade steps (1st to 1.5.1 and 2nd to latest) is not unreasonable for users who are eight months behind.

For issue #419