### PR TITLE
Try using org-wide Docker Hub secrets

### DIFF
--- a/.github/workflows/ci_image_build.yml
+++ b/.github/workflows/ci_image_build.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build
         uses: docker/build-push-action@v2


### PR DESCRIPTION
Not sure if this will work, but maybe `DOCKERHUB_*` are org-wide secrets and so using those will let us push a new CI image to Docker Hub? There's no way to find out without creating a PR.