### PR TITLE
Use the org access credentials for docker

### DIFF
--- a/.github/workflows/ci_image_build.yml
+++ b/.github/workflows/ci_image_build.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ secrets.ORG_DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.ORG_DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Build
         uses: docker/build-push-action@v2


### PR DESCRIPTION
This commit switches us to using the organization docker credentials in hopes that they'll be more stable in the long term than our private ones.