### PR TITLE
Fix Docker image build

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -32,21 +32,21 @@ RUN set -ex \
     && cd timescaledb \
     && git checkout 2.5.x \
     && cd ~/timescaledb \
-        && ./bootstrap -DPG_CONFIG=~/.pgx/12.11/pgx-install/bin/pg_config -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DUSE_OPENSSL=false -DSEND_TELEMETRY_DEFAULT=false -DREGRESS_CHECKS=false \
+        && ./bootstrap -DPG_CONFIG=~/.pgx/12.*/pgx-install/bin/pg_config -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DUSE_OPENSSL=false -DSEND_TELEMETRY_DEFAULT=false -DREGRESS_CHECKS=false \
         && cd build \
         && make -j4 \
         && make -j4 install \
         && echo "shared_preload_libraries = 'timescaledb'" >> ~/.pgx/data-12/postgresql.conf \
     && cd .. \
     && rm -rf ./build \
-        && ./bootstrap -DPG_CONFIG=~/.pgx/13.7/pgx-install/bin/pg_config -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DUSE_OPENSSL=false -DSEND_TELEMETRY_DEFAULT=false -DREGRESS_CHECKS=false \
+        && ./bootstrap -DPG_CONFIG=~/.pgx/13.*/pgx-install/bin/pg_config -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DUSE_OPENSSL=false -DSEND_TELEMETRY_DEFAULT=false -DREGRESS_CHECKS=false \
         && cd build \
         && make -j4 \
         && make -j4 install \
         && echo "shared_preload_libraries = 'timescaledb'" >> ~/.pgx/data-13/postgresql.conf \
     && cd .. \
     && rm -rf ./build \
-        && ./bootstrap -DPG_CONFIG=~/.pgx/14.3/pgx-install/bin/pg_config -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DUSE_OPENSSL=false -DSEND_TELEMETRY_DEFAULT=false -DREGRESS_CHECKS=false \
+        && ./bootstrap -DPG_CONFIG=~/.pgx/14.*/pgx-install/bin/pg_config -DCMAKE_BUILD_TYPE="RelWithDebInfo" -DUSE_OPENSSL=false -DSEND_TELEMETRY_DEFAULT=false -DREGRESS_CHECKS=false \
         && cd build \
         && make -j4 \
         && make -j4 install \


### PR DESCRIPTION
Currently the CI Docker image hardcodes the latest PostgreSQL version, and as a result hasn't been buildable for a while. This fixes that so it doesn't need to be updated every release.

Note that the base branch for this PR is [`jl/org_access_credentials`](https://github.com/timescale/timescaledb-toolkit/tree/jl/org_access_credentials), so this PR will be merged into #550.