### PR TITLE
Add 'ci' mode to testbin .

### DIFF
--- a/tools/build
+++ b/tools/build
@@ -26,14 +26,7 @@ require_pg_version() {
 find_pg_config() {
     if [ -z "$pg_config" ]; then
         require_pg_version
-        full_version=$(
-            cd "$HOME/.pgx"
-            set -- $pg_version.*/pgx-install
-            [ "$1" = "$pg_version.*/pgx-install" ] && die "$pg_version not installed in $HOME/.pgx"
-            set -- $(dirname $*)
-            [ $# -eq 1 ] || die "too many installations for $pg_version, found: $*"
-            echo $1)
-        pg_config="$HOME/.pgx/$full_version/pgx-install/bin/pg_config"
+        pg_config=`sed -ne 's/"//g' -e s/^pg$pg_version=//p ~/.pgx/config.toml`
     fi
     [ -x "$pg_config" ] || die "$pg_config not executable"
 }

--- a/tools/build
+++ b/tools/build
@@ -16,7 +16,7 @@ die() {
 }
 
 usage() {
-    die 'build [ -n -pg1[234] ] ( test-crates | test-extension | test-post-install | test-doc | test-updates | clippy)'
+    die 'build [ -n -pg1[234] ] ( test-crates | test-extension | install | test-doc | test-updates | clippy)'
 }
 
 require_pg_version() {
@@ -96,19 +96,19 @@ while [ $# -gt 0 ]; do
             ;;
 
         install)
-            cd extension
             require_pg_version
             find_pg_config
-            $nop cargo pgx install -c "$pg_config"
+            (cd extension && $nop cargo pgx install -c "$pg_config")
+            $nop cargo run --manifest-path tools/post-install/Cargo.toml "$pg_config"
             ;;
 
-        # Requires extension has been installed.  `install` or `test-extension` takes care of that.
+        # Reruns the tests test-extension does if they're left installed.
+        # TODO Remove this and testrunner.
         test-post-install)
             require_pg_version
             find_pg_config
             $nop cargo pgx stop $pg
             $nop cargo pgx start $pg
-            $nop cargo run --manifest-path tools/post-install/Cargo.toml "$pg_config"
             $nop cargo run --manifest-path tools/testrunner/Cargo.toml -- -h localhost -p $pg_port
             ;;
 

--- a/tools/testbin
+++ b/tools/testbin
@@ -124,21 +124,21 @@ deb_init() {
 # Requires:
 # - FROM_VERSION
 deb_start_test() {
-        # We released 1.10.0-dev by accident.  We have to support upgrades
-        # from it (and we tested that at the time), but we pulled the deb, so
-        # we can't test it here.
-        [ $FROM_VERSION = 1.10.0-dev ] && return 1
-        cmp_version=`cmp_version $FROM_VERSION`
-        [ "$ARCH" -eq arm64 ] && [ $cmp_version -lt $MIN_DEB_ARM ] && return 1
+    # We released 1.10.0-dev by accident.  We have to support upgrades
+    # from it (and we tested that at the time), but we pulled the deb, so
+    # we can't test it here.
+    [ $FROM_VERSION = 1.10.0-dev ] && return 1
+    cmp_version=`cmp_version $FROM_VERSION`
+    [ "$ARCH" -eq arm64 ] && [ $cmp_version -lt $MIN_DEB_ARM ] && return 1
 
-        [ $cmp_version -ge $MIN_DEB_EPOCH ] && EPOCH=1:
-        for PG_VERSION in $PG_VERSIONS; do
-            select_pg $PG_VERSION
-            deb=timescaledb-toolkit-postgresql-${PG_VERSION}=${EPOCH}${FROM_VERSION}~${OS_NAME}${OS_VERSION}
-            $nop sudo apt-get -qq install $deb
+    [ $cmp_version -ge $MIN_DEB_EPOCH ] && EPOCH=1:
+    for PG_VERSION in $PG_VERSIONS; do
+        select_pg $PG_VERSION
+        deb=timescaledb-toolkit-postgresql-${PG_VERSION}=${EPOCH}${FROM_VERSION}~${OS_NAME}${OS_VERSION}
+        $nop sudo apt-get -qq install $deb
 
-            PATH=/usr/lib/postgresql/$PG_VERSION/bin:$PATH start_test
-        done
+        PATH=/usr/lib/postgresql/$PG_VERSION/bin:$PATH start_test
+    done
 }
 
 test_deb() {

--- a/tools/testbin
+++ b/tools/testbin
@@ -52,7 +52,7 @@ die() {
 
 usage() {
     print 'testbin check-control' >&2
-    die 'testbin [-n] -bindir DIR -dbroot DIR -pgport N -version VERSION ( deb | rpm )'
+    die 'testbin [-n] -bindir DIR -dbroot DIR -pgport N -version VERSION ( ci | deb | rpm )'
 }
 
 # Run this before each merge so the control file doesn't get out of sync with this script.

--- a/tools/testbin
+++ b/tools/testbin
@@ -111,7 +111,7 @@ finish_test() {
     stop_postgres
 }
 
-test_deb() {
+deb_init() {
     [ -n "$OS_NAME" ] || die 'OS_NAME environment variable must be set to the distribution name e.g. debian or ubuntu'
     [ -n "$OS_VERSION" ] || die 'OS_VERSION environment variable must be set to the distribution version number'
 
@@ -119,21 +119,32 @@ test_deb() {
     EPOCH=
     MIN_DEB_ARM=`cmp_version $MIN_DEB_ARM`
     MIN_DEB_EPOCH=`cmp_version $MIN_DEB_EPOCH`
-    for from_version; do
+}
+
+# Requires:
+# - FROM_VERSION
+deb_start_test() {
         # We released 1.10.0-dev by accident.  We have to support upgrades
         # from it (and we tested that at the time), but we pulled the deb, so
         # we can't test it here.
-        [ $from_version = 1.10.0-dev ] && continue
-        cmp_version=`cmp_version $from_version`
-        [ "$ARCH" -eq arm64 ] && [ $cmp_version -lt $MIN_DEB_ARM ] && continue
+        [ $FROM_VERSION = 1.10.0-dev ] && return 1
+        cmp_version=`cmp_version $FROM_VERSION`
+        [ "$ARCH" -eq arm64 ] && [ $cmp_version -lt $MIN_DEB_ARM ] && return 1
+
         [ $cmp_version -ge $MIN_DEB_EPOCH ] && EPOCH=1:
         for PG_VERSION in $PG_VERSIONS; do
             select_pg $PG_VERSION
-            deb=timescaledb-toolkit-postgresql-${PG_VERSION}=${EPOCH}${from_version}~${OS_NAME}${OS_VERSION}
+            deb=timescaledb-toolkit-postgresql-${PG_VERSION}=${EPOCH}${FROM_VERSION}~${OS_NAME}${OS_VERSION}
             $nop sudo apt-get -qq install $deb
 
             PATH=/usr/lib/postgresql/$PG_VERSION/bin:$PATH start_test
         done
+}
+
+test_deb() {
+    deb_init
+    for FROM_VERSION; do
+        deb_start_test || continue
         for PG_VERSION in $PG_VERSIONS; do
             select_pg $PG_VERSION
             deb=timescaledb-toolkit-postgresql-${PG_VERSION}_${TOOLKIT_VERSION}~${OS_NAME}${OS_VERSION}_${ARCH}.deb
@@ -142,6 +153,20 @@ test_deb() {
             finish_test
 
             $nop sudo dpkg -P timescaledb-toolkit-postgresql-$PG_VERSION
+        done
+    done
+}
+
+test_ci() {
+    deb_init
+    for FROM_VERSION; do
+        deb_start_test || continue
+        for PG_VERSION in $PG_VERSIONS; do
+            select_pg $PG_VERSION
+            $nop sudo dpkg -P timescaledb-toolkit-postgresql-$PG_VERSION
+            $nop tools/build -pg$PG_VERSION install
+
+            finish_test
         done
     done
 }
@@ -201,10 +226,12 @@ cleanup() {
 
 run() {
     [ -n "$LOGNAME" ] || die 'LOGNAME environment variable must be set to the login name'
-    [ -d "$BINDIR" ] || die '-bindir required'
     [ -n "$DB_ROOT" ] || die '-dbroot required'
     [ -e "$DB_ROOT" ] && die "cowardly refusing to clobber $DB_ROOT"
     [ -n "$PG_PORT_BASE" ] || die '-pgport required'
+
+    # TODO Requiring -bindir and -version when not all methods need them is awkward but eh.
+    [ -d "$BINDIR" ] || die '-bindir required'
     [ -n "$TOOLKIT_VERSION" ] || die '-version required'
 
     trap cleanup 0
@@ -247,7 +274,7 @@ while [ $# -gt 0 ]; do
             check_control
             ;;
 
-        deb|rpm)
+        ci|deb|rpm)
             run $arg
             ;;
 


### PR DESCRIPTION
This is mostly the same as 'deb' but for use in our continuous
integration checks, where we are installing from source rather than
testing a new binary package.
