### PR TITLE
Adding Time Vector tests to update tester

### DIFF
--- a/tests/update/original_update_tests.md
+++ b/tests/update/original_update_tests.md
@@ -24,6 +24,7 @@ CREATE MATERIALIZED VIEW regression_view AS
 
 
 ```sql,validation,min-toolkit-version=1.4.0
+SET timezone to 'UTC';
 SELECT
     num_resets(countagg),
     distinct_count(hll),

--- a/tests/update/time-vector.md
+++ b/tests/update/time-vector.md
@@ -1,0 +1,64 @@
+# Time Vector Tests
+
+```sql,creation
+SET timezone to 'UTC';
+CREATE TABLE time_vector_data(time TIMESTAMPTZ, value DOUBLE PRECISION);
+INSERT INTO time_vector_data VALUES
+    ('2020-1-1', 30.0),
+    ('2020-1-2', 45.0),
+    ('2020-1-3', NULL),
+    ('2020-1-4', 55.5),
+    ('2020-1-5', 10.0);
+```
+
+```sql,validation
+SET timezone to 'UTC';
+SELECT unnest(timevector(time,value))::TEXT FROM time_vector_data;
+```
+
+```output
+             unnest
+---------------------------------
+ ("2020-01-01 00:00:00+00",30)
+ ("2020-01-02 00:00:00+00",45)
+ ("2020-01-03 00:00:00+00",NaN)
+ ("2020-01-04 00:00:00+00",55.5)
+ ("2020-01-05 00:00:00+00",10)
+ ```
+
+```sql,creation
+SET timezone to 'UTC';
+CREATE TABLE tv_rollup_data(time TIMESTAMPTZ, value DOUBLE PRECISION, bucket INTEGER);
+INSERT INTO tv_rollup_data VALUES
+    ('2020-1-1', 30.0, 1),
+    ('2020-1-2', 45.0, 1),
+    ('2020-1-3', NULL, 2),
+    ('2020-1-4', 55.5, 2),
+    ('2020-1-5', 10.0, 3),
+    ('2020-1-6', 13.0, 3),
+    ('2020-1-7', 71.0, 4),
+    ('2020-1-8', 0.0, 4);
+```
+
+```sql,validation
+SELECT unnest(rollup(tvec))::TEXT
+   FROM (
+       SELECT timevector(time, value) AS tvec
+       FROM tv_rollup_data 
+       GROUP BY bucket 
+       ORDER BY bucket
+   ) s;
+```
+
+```output
+            unnest
+-------------------------------
+ ("2020-01-01 00:00:00+00",30)
+ ("2020-01-02 00:00:00+00",45)
+ ("2020-01-03 00:00:00+00",NaN)
+ ("2020-01-04 00:00:00+00",55.5)
+ ("2020-01-05 00:00:00+00",10)
+ ("2020-01-06 00:00:00+00",13)
+ ("2020-01-07 00:00:00+00",71)
+ ("2020-01-08 00:00:00+00",0)
+ ```

--- a/tools/update-tester/src/testrunner.rs
+++ b/tools/update-tester/src/testrunner.rs
@@ -148,6 +148,7 @@ pub fn update_to_and_validate_new_toolkit_version<OnErr: FnMut(Test, TestError)>
     let mut test_client = connect_to(&test_config);
 
     test_client.set_timezone_utc();
+
     // get the currently installed version before updating
     let old_toolkit_version = test_client.get_installed_extension_version();
 
@@ -470,9 +471,7 @@ pub fn validate_output(output: Vec<SimpleQueryMessage>, test: &Test) -> Result<(
                 }
                 rows.push(row);
             }
-            CommandComplete(_) => {
-                break;
-            }
+            CommandComplete(_) => {}
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
Added Update Tester tests for time vector
Removed `break` from the match statement in the `validate_output` fn so that we can have multiple sql statements in a validation test.