### PR TITLE
Allow testing of the ci docker image.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,17 @@ on:
     # we build at 8am UTC, 3am Eastern, midnight Pacific
     - cron:  '0 8 * * 1-4'
   workflow_dispatch:
+    inputs:
+      container-image:
+        description: 'Container image to pull from DockerHub'
+        required: false
 
 jobs:
   testpostgres:
     name: Test Postgres
     runs-on: ubuntu-20.04
     container:
-      image: timescaledev/rust-pgx:latest
+      image: ${{ inputs.container-image || 'timescaledev/rust-pgx:latest' }}
     strategy:
       matrix:
         pgversion: [12, 13, 14]
@@ -85,7 +89,7 @@ jobs:
     name: Test Crates
     runs-on: ubuntu-20.04
     container:
-      image: timescaledev/rust-pgx:latest
+      image: ${{ inputs.container-image || 'timescaledev/rust-pgx:latest' }}
       env:
         CARGO_INCREMENTAL: 0
         CARGO_NET_RETRY: 10
@@ -125,7 +129,7 @@ jobs:
     name: Test Updates
     runs-on: ubuntu-20.04
     container:
-      image: timescaledev/rust-pgx:latest
+      image: ${{ inputs.container-image || 'timescaledev/rust-pgx:latest' }}
       env:
         PGVERSION: 14
 

--- a/.github/workflows/ci_image_build.yml
+++ b/.github/workflows/ci_image_build.yml
@@ -6,6 +6,11 @@ on:
       - 'docker/ci/**'
       - '.github/workflows/ci_image_build.yml'
   workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Push image to DockerHub with these tags (change testing to latest to enable)'
+        required: false
+        default: timescaledev/rust-pgx:testing
 
 jobs:
   build:
@@ -47,10 +52,11 @@ jobs:
         id: image_build
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event_name == 'workflow_dispatch' }}
+          push: true
           context: .
           file: ./docker/ci/Dockerfile
-          tags: timescaledev/rust-pgx:latest
+          # Repeating the default here for 'pull_request'.
+          tags: ${{ inputs.tags || 'timescaledev/rust-pgx:testing' }}
 
       - name: Image digest
         run: echo ${{ steps.image_build.outputs.digest }}


### PR DESCRIPTION
1. Always publish the image, but default to a 'testing' tag.  Only after
   we've tested it will we use the 'latest' tag.

2. Parameterize the image tag in ci.yml - when we have a candidate
   image, we run this on 'main' specifying the 'testing' label.

If bors won't let us merge anything as long as the image is broken, we
can temporarily hard-code a known-good image label here.
