### PR TITLE
Add missing cargo pgx start/stop runs.

### DIFF
--- a/tools/build
+++ b/tools/build
@@ -114,11 +114,13 @@ while [ $# -gt 0 ]; do
 
         test-doc)
             require_pg_version
+            $nop cargo pgx start $pg
             $nop cargo run -p sql-doctester -- \
                  -h localhost \
                  -p $pg_port \
                  -s "CREATE EXTENSION timescaledb; CREATE EXTENSION timescaledb_toolkit; SET SESSION TIMEZONE TO 'UTC'" \
                  docs
+            $nop cargo pgx stop $pg
             ;;
 
         test-updates)
@@ -135,6 +137,7 @@ while [ $# -gt 0 ]; do
                  "$pg_config" \
                  "$cargo_pgx" \
                  "$cargo_pgx_old"
+            $nop cargo pgx stop $pg
             ;;
 
         *)


### PR DESCRIPTION
We previously got away with it because we ran test-post-install before test-doc and test-post-install forgot to cargo pgx stop!