### PR TITLE
Automatically set timezone to UTC in update-tester databases

### DIFF
--- a/tests/update/original_update_tests.md
+++ b/tests/update/original_update_tests.md
@@ -3,7 +3,6 @@
 
 
 ```sql,creation,min-toolkit-version=1.4.0
-SET TIME ZONE 'UTC';
 CREATE TABLE test_data(ts timestamptz, val DOUBLE PRECISION);
     INSERT INTO test_data
         SELECT '2020-01-01 00:00:00+00'::timestamptz + i * '1 hour'::interval,
@@ -24,7 +23,6 @@ CREATE MATERIALIZED VIEW regression_view AS
 
 
 ```sql,validation,min-toolkit-version=1.4.0
-SET timezone to 'UTC';
 SELECT
     num_resets(countagg),
     distinct_count(hll),

--- a/tests/update/time-vector.md
+++ b/tests/update/time-vector.md
@@ -1,7 +1,6 @@
 # Time Vector Tests
 
 ```sql,creation
-SET timezone to 'UTC';
 CREATE TABLE time_vector_data(time TIMESTAMPTZ, value DOUBLE PRECISION);
 INSERT INTO time_vector_data VALUES
     ('2020-1-1', 30.0),
@@ -12,7 +11,6 @@ INSERT INTO time_vector_data VALUES
 ```
 
 ```sql,validation
-SET timezone to 'UTC';
 SELECT unnest(timevector(time,value))::TEXT FROM time_vector_data;
 ```
 
@@ -27,7 +25,6 @@ SELECT unnest(timevector(time,value))::TEXT FROM time_vector_data;
  ```
 
 ```sql,creation
-SET timezone to 'UTC';
 CREATE TABLE tv_rollup_data(time TIMESTAMPTZ, value DOUBLE PRECISION, bucket INTEGER);
 INSERT INTO tv_rollup_data VALUES
     ('2020-1-1', 30.0, 1),

--- a/tools/update-tester/src/testrunner.rs
+++ b/tools/update-tester/src/testrunner.rs
@@ -39,8 +39,6 @@ pub fn run_update_tests<OnErr: FnMut(Test, TestError)>(
                 "installed unexpected version"
             );
 
-            test_client.set_timezone_utc();
-
             let errors =
                 test_client.create_test_objects_from_file(test_config, installed_version.clone());
 
@@ -111,7 +109,6 @@ pub fn create_test_objects_for_package_testing<OnErr: FnMut(Test, TestError)>(
 
     let current_toolkit_version = test_client.get_installed_extension_version();
 
-    test_client.set_timezone_utc();
     // create test objects
     let errors = test_client.create_test_objects_from_file(test_config, current_toolkit_version);
 
@@ -146,8 +143,6 @@ pub fn update_to_and_validate_new_toolkit_version<OnErr: FnMut(Test, TestError)>
     let test_config = root_config.with_db(test_db_name);
 
     let mut test_client = connect_to(&test_config);
-
-    test_client.set_timezone_utc();
 
     // get the currently installed version before updating
     let old_toolkit_version = test_client.get_installed_extension_version();
@@ -241,11 +236,6 @@ impl TestClient {
         });
     }
 
-    fn set_timezone_utc(&mut self) {
-        self.simple_query("SET TIME ZONE 'UTC';")
-            .unwrap_or_else(|e| panic!("could not set time zone to UTC due to {}", e));
-    }
-
     fn create_test_objects_from_file(
         &mut self,
         root_config: ConnectionConfig<'_>,
@@ -282,6 +272,10 @@ impl TestClient {
             .into_iter()
             .flat_map(|tests| {
                 let mut client = connect_to(&root_config).0;
+                client
+                    .simple_query("SET TIME ZONE 'UTC';")
+                    .unwrap_or_else(|e| panic!("could not set time zone to UTC due to {}", e));
+
                 tests
                     .tests
                     .into_iter()
@@ -340,6 +334,10 @@ impl TestClient {
             .into_iter()
             .flat_map(|tests| {
                 let mut client = connect_to(&root_config).0;
+                client
+                    .simple_query("SET TIME ZONE 'UTC';")
+                    .unwrap_or_else(|e| panic!("could not set time zone to UTC due to {}", e));
+
                 tests
                     .tests
                     .into_iter()


### PR DESCRIPTION
Removed code that set timezone in the test files, update-tester now automatically sets the timezone. 
