### PR TITLE
Remove incorrect comment in Dockerfile

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,7 +1,6 @@
 FROM rust:1.60 AS pgx_builder
 
 COPY docker/ci/setup.sh /
-# TODO rust image we're FROM is currently based on Debian 10!
 RUN OS_NAME=debian OS_CODE_NAME=bullseye /setup.sh
 
 ENV PATH "/home/postgres/pgx/0.4/bin:${PATH}"


### PR DESCRIPTION
bullseye is Debian 11; buster is Debian 10. We're on the latest Debian release. See https://github.com/timescale/timescaledb-toolkit/pull/552#discussion_r989113244.