### PR TITLE
Use toml_edit to read extension version from Cargo.toml .

### DIFF
--- a/crates/scripting-utilities/control_file_reader/src/lib.rs
+++ b/crates/scripting-utilities/control_file_reader/src/lib.rs
@@ -5,8 +5,8 @@ use std::fmt;
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// extract the current version from the control file
-pub fn get_current_version(manifest_file: &str) -> Result<String> {
-    get_field_val(manifest_file, "version").map(|v| v.to_string())
+pub fn get_current_version(control_file: &str) -> Result<String> {
+    get_field_val(control_file, "version").map(|v| v.to_string())
 }
 
 /// extract the list of versions we're upgradeable-from from the control file

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "timescaledb_toolkit"
-# single quotes on version number for easier parsing
-version = '1.12.0-dev'
+version = "1.12.0-dev"
 edition = "2021"
 
 [lib]

--- a/tools/update-tester/src/main.rs
+++ b/tools/update-tester/src/main.rs
@@ -12,7 +12,7 @@ use colored::Colorize;
 
 use xshell::{read_file, Cmd};
 
-use control_file_reader::{get_current_version, get_upgradeable_from};
+use control_file_reader::get_upgradeable_from;
 use postgres_connection_configuration::ConnectionConfig;
 
 // macro for literate path joins
@@ -368,8 +368,16 @@ fn get_version_info(root_dir: &str) -> xshell::Result<(String, Vec<String>)> {
     let manifest_contents = read_file(manifest_file)?;
     let control_contents = read_file(control_file)?;
 
-    let current_version = get_current_version(&manifest_contents)
-        .unwrap_or_else(|e| panic!("{} in manifest {}", e, manifest_contents));
+    let current_version = manifest_contents
+        .parse::<toml_edit::Document>()
+        .expect("failed to parse extension/Cargo.toml")
+        .get("package")
+        .expect("failed to find [package] in extension/Cargo.toml")
+        .get("version")
+        .expect("failed to find package.version in extension/Cargo.toml")
+        .as_str()
+        .expect("package.version not a string in extension/Cargo.toml")
+        .to_owned();
 
     let upgradable_from = get_upgradeable_from(&control_contents)
         .unwrap_or_else(|e| panic!("{} in control file {}", e, control_contents));


### PR DESCRIPTION
Reusing control-file parser led us to require single-quotes which aren't the general style and aren't what cargo-edit uses.