### PR TITLE
Update Docker image for pgx 0.5.0

### DIFF
--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -3,8 +3,6 @@ FROM rust:1.60 AS pgx_builder
 COPY docker/ci/setup.sh /
 RUN OS_NAME=debian OS_CODE_NAME=bullseye /setup.sh
 
-ENV PATH "/home/postgres/pgx/0.4/bin:${PATH}"
-
 FROM pgx_builder AS rust-pgx
 
 USER root

--- a/docker/ci/setup.sh
+++ b/docker/ci/setup.sh
@@ -60,10 +60,7 @@ EOF
 
         # Install cargo pgx
         # Keep synchronized with `cargo install --version N.N.N cargo-pgx` in Readme.md and Cargo.toml
-        cargo install cargo-pgx --version =0.2.4 --root ~/pgx/0.2
-        cargo install cargo-pgx --version =0.4.5 --root ~/pgx/0.4
-
-        PATH=$HOME/pgx/0.4/bin:$PATH
+        cargo install cargo-pgx --version =0.5.0
 
         # Initialize new PostgreSQL instances and update the configuration
         # files so that they can use TimescaleDB that we installed above.


### PR DESCRIPTION
pgx 0.5.0 just released! This PR updates the CI to have pgx 0.5.0 and adds pgx 0.5.0 to the `$PATH` instead of pgx 0.4.5.

This PR should be merged right before merging #547 so that the CI can pass on that PR before merging it.