### PR TITLE
Drop now-unused tools/build test-updates command.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,13 +164,6 @@ jobs:
         key: ${{ runner.os }}-test-updates-target-1.12.0
         restore-keys: ${{ runner.os }}-test-crates-target-1.11.0
 
-    - name: Cache old versions dir
-      uses: actions/cache@v2
-      with:
-        path: old-versions
-        key: ${{ runner.os }}-test-old-versions-1.12.0
-        restore-keys: ${{ runner.os }}-test-old-versions-1.11.0
-
     - name: Run binary update tests
       # TODO We've always tested only one postgres version here.  We test them all at release
       #  time anyway.  If we want to test them here, too, let's make it less slow first.

--- a/tools/build
+++ b/tools/build
@@ -16,7 +16,7 @@ die() {
 }
 
 usage() {
-    die 'build [ -n -pg1[234] ] ( test-crates | test-extension | install | test-doc | test-updates | clippy)'
+    die 'build [ -n -pg1[234] ] ( test-crates | test-extension | install | test-doc | clippy)'
 }
 
 require_pg_version() {
@@ -31,15 +31,6 @@ find_pg_config() {
     [ -x "$pg_config" ] || die "$pg_config not executable"
 }
 
-require_cargo_pgx() {
-    [ -n "$cargo_pgx" ] || die 'specify path to cargo-pgx (0.4 series or newer)'
-}
-
-require_cargo_pgx_old() {
-    [ -n "$cargo_pgx_old" ] || die 'specify path to cargo-pgx (0.2-0.3 series)'
-}
-
-
 [ $# -ge 1 ] || usage
 
 while [ $# -gt 0 ]; do
@@ -52,16 +43,6 @@ while [ $# -gt 0 ]; do
 
         -pgconfig)
             pg_config="$1"
-            shift
-            ;;
-
-        -cargo-pgx)
-            cargo_pgx="$1"
-            shift
-            ;;
-
-        -cargo-pgx-old)
-            cargo_pgx_old="$1"
             shift
             ;;
 
@@ -120,23 +101,6 @@ while [ $# -gt 0 ]; do
                  -p $pg_port \
                  -s "CREATE EXTENSION timescaledb; CREATE EXTENSION timescaledb_toolkit; SET SESSION TIMEZONE TO 'UTC'" \
                  docs
-            $nop cargo pgx stop $pg
-            ;;
-
-        test-updates)
-            require_pg_version
-            find_pg_config
-            require_cargo_pgx
-            require_cargo_pgx_old
-            $nop cargo pgx start $pg
-            $nop cargo run --manifest-path tools/update-tester/Cargo.toml -- full-update-test-source \
-                 -h localhost \
-                 -p $pg_port \
-                 --cache old-versions \
-                 . \
-                 "$pg_config" \
-                 "$cargo_pgx" \
-                 "$cargo_pgx_old"
             $nop cargo pgx stop $pg
             ;;
 

--- a/tools/update-tester/src/main.rs
+++ b/tools/update-tester/src/main.rs
@@ -41,6 +41,8 @@ fn main() {
         .subcommand_required(true)
         .arg_required_else_help(true)
 	.subcommand(
+            // TODO Remove?  This was backwards-compatibility for tools/build
+            //   test-updates which we no longer use (using tools/testbin now).
             Command::new("full-update-test-source")
             .long_flag("full-update-test-source")
             .about("Run update-test, building toolkit from source unless a local cache is supplied")


### PR DESCRIPTION
And stop caching its now nonexistent cache dir.

And leave TODO about dropping the now-unused full-update-test-source.