### PR TITLE
Add .dockerignore and update .gitignore .

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+**/*.iml
+**/*.o
+**/.DS_Store
+.editorconfig
+.idea
+.vscode
+.vsls.json
+.git
+old-versions
+target
+target-analyzer

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,9 @@
 .DS_Store
-.idea/
-.vscode/
-.vsls.json
+/.idea
+/.vscode
+/.vsls.json
+/old-versions
 /target
 *.iml
-sql/*.generated.sql
-extension/sql/timescaledb_toolkit-*.sql
 /target-analyzer
-.editorconfig
+/.editorconfig


### PR DESCRIPTION
Without .dockerignore, 'docker build' copies muchos gigabytes into docker-land for no good reason.

.gitignore wasn't ignoring 'old-versions' (from tools/update-tester) and was ignoring .sql files we no longer litter the working directory with (maybe old versions of pgx did?).