### PR TITLE
Make Actions cache keys update automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,15 +63,15 @@ jobs:
         path: |
           /usr/local/cargo/registry
           /usr/local/cargo/git
-        key: ${{ runner.os }}-test-pg${{ matrix.pgversion }}-cargo-1.12.0
-        restore-keys: ${{ runner.os }}-test-pg${{ matrix.pgversion }}-cargo-1.11.0
+        key: ${{ runner.os }}-test-pg${{ matrix.pgversion }}-cargo-${{ hashFiles('Cargo.lock', '.github/workflows/ci.yml') }}
+        restore-keys: ${{ runner.os }}-test-pg${{ matrix.pgversion }}-cargo-
 
     - name: Cache cargo target dir
       uses: actions/cache@v2
       with:
         path: target
-        key: ${{ runner.os }}-test-pg${{ matrix.pgversion }}-target-1.12.0
-        restore-keys: ${{ runner.os }}-test-pg${{ matrix.pgversion }}-target-1.11.0
+        key: ${{ runner.os }}-test-pg${{ matrix.pgversion }}-target-${{ hashFiles('Cargo.lock', '.github/workflows/ci.yml') }}
+        restore-keys: ${{ runner.os }}-test-pg${{ matrix.pgversion }}-target-
 
     - name: Run pgx tests
       run: su postgres -c 'sh tools/build -pg${{ matrix.pgversion }} test-extension 2>&1'
@@ -112,15 +112,15 @@ jobs:
         path: |
           /usr/local/cargo/registry
           /usr/local/cargo/git
-        key: ${{ runner.os }}-test-crates-cargo-1.12.0
-        restore-keys: ${{ runner.os }}-test-crates-cargo-1.11.0
+        key: ${{ runner.os }}-test-crates-cargo-${{ hashFiles('Cargo.lock', '.github/workflows/ci.yml') }}
+        restore-keys: ${{ runner.os }}-test-crates-cargo-
 
     - name: Cache cargo target dir
       uses: actions/cache@v2
       with:
         path: target
-        key: ${{ runner.os }}-test-crates-target-1.12.0
-        restore-keys: ${{ runner.os }}-test-crates-target-1.11.0
+        key: ${{ runner.os }}-test-crates-target-${{ hashFiles('Cargo.lock', '.github/workflows/ci.yml') }}
+        restore-keys: ${{ runner.os }}-test-crates-target-
 
     - name: Run Crates Tests
       run: su postgres -c 'sh tools/build test-crates 2>&1'
@@ -154,22 +154,22 @@ jobs:
         path: |
           /usr/local/cargo/registry
           /usr/local/cargo/git
-        key: ${{ runner.os }}-test-updates-cargo-1.12.0
-        restore-keys: ${{ runner.os }}-test-crates-cargo-1.11.0
+        key: ${{ runner.os }}-test-updates-cargo-${{ hashFiles('Cargo.lock', '.github/workflows/ci.yml') }}
+        restore-keys: ${{ runner.os }}-test-crates-cargo-
 
     - name: Cache cargo target dir
       uses: actions/cache@v2
       with:
         path: target
-        key: ${{ runner.os }}-test-updates-target-1.12.0
-        restore-keys: ${{ runner.os }}-test-crates-target-1.11.0
+        key: ${{ runner.os }}-test-updates-target-${{ hashFiles('Cargo.lock', '.github/workflows/ci.yml') }}
+        restore-keys: ${{ runner.os }}-test-crates-target-
 
     - name: Cache old versions dir
       uses: actions/cache@v2
       with:
         path: old-versions
-        key: ${{ runner.os }}-test-old-versions-1.12.0
-        restore-keys: ${{ runner.os }}-test-old-versions-1.11.0
+        key: ${{ runner.os }}-test-old-versions-${{ hashFiles('Cargo.lock', '.github/workflows/ci.yml') }}
+        restore-keys: ${{ runner.os }}-test-old-versions-
 
     - name: Run binary update tests
       # TODO We've always tested only one postgres version here.  We test them all at release

--- a/.github/workflows/clippy_rustfmt.yml
+++ b/.github/workflows/clippy_rustfmt.yml
@@ -40,15 +40,15 @@ jobs:
         path: |
           /usr/local/cargo/registry
           /usr/local/cargo/git
-        key: ${{ runner.os }}-clippy-cargo-1.12.0
-        restore-keys: ${{ runner.os }}-clippy-cargo-1.11.0
+        key: ${{ runner.os }}-clippy-cargo-${{ hashFiles('Cargo.lock', '.github/workflows/clippy_rustfmt.yml') }}
+        restore-keys: ${{ runner.os }}-clippy-cargo-
 
     - name: Cache cargo target dir
       uses: actions/cache@v2
       with:
         path: target
-        key: ${{ runner.os }}-clippy-target-1.12.0
-        restore-keys: ${{ runner.os }}-clippy-target-1.11.0
+        key: ${{ runner.os }}-clippy-target-${{ hashFiles('Cargo.lock', '.github/workflows/clippy_rustfmt.yml') }}
+        restore-keys: ${{ runner.os }}-clippy-target-
 
     - name: Run Clippy
       # Github captures stdout and stderr separately and then intermingles them


### PR DESCRIPTION
Based on [how pgx does caching](https://github.com/tcdi/pgx/blob/b92c60974c203e07e05cf1320581084be20a8e8a/.github/workflows/tests.yml#L103), compute GitHub Actions cache keys based on the hash of lockfile and workflow file. Now we don't need to bump the versions manually every release.

Note that `restore-keys` will look for the most recent matching cache with the same prefix if there are no exact matches, so a cache will be available even on commits that update the lockfile/workflow file.