### PR TITLE
Update Docker image to support building binary packages.

### DIFF
--- a/.github/workflows/ci_image_build.yml
+++ b/.github/workflows/ci_image_build.yml
@@ -7,56 +7,31 @@ on:
       - '.github/workflows/ci_image_build.yml'
   workflow_dispatch:
     inputs:
-      tags:
-        description: 'Push image to DockerHub with these tags (change testing to latest to enable)'
+      tag-base:
+        description: 'Push image to DockerHub with this base tag (remove "-test" enable)'
         required: false
-        default: timescaledev/rust-pgx:testing
+        # Repeating the default here for ease of editing in the github actions form.  Keep in sync with below.
+        default: timescaledev/toolkit-builder-test
+      toolkit-commit:
+        description: 'Toolkit commit (branch, tag, etc.) to build image from'
+        required: false
+        default: main
+      builder-commit:
+        description: 'Commit (branch, tag, etc.) on release-build-scripts repository to use'
+        required: false
 
 jobs:
   build:
+    env:
+      GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB_PACKAGE }}
     runs-on: ubuntu-20.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-ci-buildx-debian-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-ci-buildx-debian
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.ORG_DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.ORG_DOCKER_HUB_ACCESS_TOKEN }}
-
-      - name: Build
-        uses: docker/build-push-action@v2
-        with:
-          push: false
-          load: true
-          context: .
-          file: ./docker/ci/Dockerfile
-          tags: timescaledev/rust-pgx:latest
-
-      - name: Push
-        id: image_build
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          context: .
-          file: ./docker/ci/Dockerfile
-          # Repeating the default here for 'pull_request'.
-          tags: ${{ inputs.tags || 'timescaledev/rust-pgx:testing' }}
-
-      - name: Image digest
-        run: echo ${{ steps.image_build.outputs.digest }}
+      - name: Run release-build-scripts job
+        # Repeating the default here for 'pull_request'.  Keep in sync with above.
+        # TODO Change default from 'eg/prebuilt-image' to 'main' after merge.
+        run: |
+          gh workflow run toolkit-image.yml \
+                -R timescale/release-build-scripts \
+                -r ${{ inputs.builder-commit || 'eg/prebuilt-image' }} \
+                -f tag-base=${{ inputs.tag-base || 'timescaledev/toolkit-builder-test' }} \
+                -f toolkit-commit=${{ inputs.toolkit-commit || github.event.pull_request.head.sha }}

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,8 +5,8 @@ the Docker files for that is present in this directory.
 
 ## Pre-requisites
 
-You need to have Docker installed with support for multi-platform
-build to use `buildx`. It is available in `docker.io` package on Ubuntu:
+You need to have Docker installed with support for DockerKit multi-platform
+and activate it by setting environment variable `DOCKER_BUILDKIT=1`.
 
 ```bash
 apt-get install docker.io
@@ -18,11 +18,16 @@ To build a new Docker image `rust-pgx` for multiple platforms and push
 it to the development repository:
 
 ```bash
-docker buildx build --platform linux/arm64/v8,linux/amd64 --tag timescaledev/rust-pgx:latest --push .
+ARCH=amd64
+OS_NAME=debian
+OS_VERSION=11
+OS_CODE_NAME=bullseye
+DOCKER_BUILDKIT=1 docker build --platform $ARCH --build-arg ARCH=$ARCH --build-arg OS_NAME=$OS_NAME --build-arg OS_VERSION=$OS_VERSION --build-arg OS_CODE_NAME=$OS_CODE_NAME -f docker/ci/Dockerfile -t timescaledev/toolkit-builder-test:$OS_NAME-$OS_VERSION-$ARCH .
+docker build --tag timescaledev/rust-pgx-test:latest --push .
 ```
 
-There is a test repository `timescaledev/rust-pgx-test` available as
-well that you can use if you want to test changes to the docker image.
+We publish the images as `timescaledev/toolkit-builder` instead of
+`timescaledev/toolkit-builder-test` after testing.
 
 ## Troubleshooting
 
@@ -43,8 +48,8 @@ $ docker buildx build --platform linux/arm64/v8,linux/amd64 --tag timescaledev/r
 error: failed to solve: failed to fetch oauth token: Post "https://auth.docker.io/token": x509: certificate has expired or is not yet valid: current time 2022-07-28T07:19:52+01:00 is after 2018-04-29T13:06:19Z
 ```
 
-You probably have build toolkit enabled and it can cause issues. You
-can disable it and try again:
+You may have better luck with buildx instead of BuildKit.
+Install from https://github.com/docker/buildx and then:
 
 ```bash
 export DOCKER_BUILDKIT=0

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -1,8 +1,32 @@
-FROM rust:1.60 AS pgx_builder
+ARG ARCH
+ARG OS_NAME
+ARG OS_VERSION
+
+# Without DockerKit, this doesn't work, even though documetation suggests it should.
+# With DockerKit, TARGETARCH is supposed to come in for free, but that doesn't work either.
+FROM --platform=${ARCH} ${OS_NAME}:${OS_VERSION} AS toolkit-base
+
+ARG ARCH
+ARG OS_CODE_NAME
+# Docker requires we redeclare these after FROM ¯\_(ツ)_/¯
+ARG OS_NAME
+ARG OS_VERSION
+
+ENV HOME /home/postgres
+
+# Docker fails to set LOGNAME :(
+ENV LOGNAME root
+ENV CARGO_HOME /usr/local/cargo
+ENV RUSTUP_HOME /usr/local/rustup
+ENV PATH "${CARGO_HOME}/bin:/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin"
 
 COPY docker/ci/setup.sh /
-RUN OS_NAME=debian OS_CODE_NAME=bullseye /setup.sh
+COPY tools/dependencies.sh /
+# TODO simple option processing a la build and testbin would make this less error-prone
+RUN /setup.sh ${ARCH} ${OS_NAME} ${OS_VERSION} "${OS_CODE_NAME}" postgres ${HOME}
 
-FROM pgx_builder AS rust-pgx
+# TODO What does this 'AS' do?  It doesn't seem to name it.  We need -t for that.
+FROM toolkit-base AS toolkit-builder
 
-USER root
+WORKDIR ${HOME}
+# Leave USER root for Github Actions.

--- a/docker/ci/setup.sh
+++ b/docker/ci/setup.sh
@@ -1,82 +1,249 @@
 #!/bin/sh
 
+# TODO rename to tools/setup - this is useful even for developer setup (add Mac/brew support)
+
 set -ex
 
-if [ -z "$OS_NAME" ] || [ -z "$OS_CODE_NAME" ]; then
-    echo >&2 'OS_NAME and OS_CODE_NAME environment variables must be set'
+if [ -z "$CARGO_HOME" ] || [ -z "$RUSTUP_HOME" ]; then
+    echo >&2 'CARGO_HOME and RUSTUP_HOME environment variables must be set'
+    exit 3
+fi
+
+if [ "$1" = -unprivileged ]; then
+    privileged=false
+    shift
+else
+    privileged=true
+fi
+
+if [ $# -ne 6 ]; then
+    echo >&2 'usage: setup.sh ARCH OS_NAME OS_VERSION OS_CODE_NAME BUILDER_USERNAME BUILDER_HOME'
     exit 2
 fi
 
-case "$1" in
-    '')
-        # The postgresql packages create this user, but with /var/lib/postgresql as the home directory.
-        # We have some old scripts that expect that to be /home/postgresql so let's stick with that.
-        useradd -m postgres
+ARCH=$1
+OS_NAME=$2
+OS_VERSION=$3
+OS_CODE_NAME=$4
+BUILDER_USERNAME=$5
+BUILDER_HOME=$6
 
-        apt-get -qq update
-        apt-get -qq install \
-                bash \
-                clang \
-                cmake \
-                gnupg \
-                libclang1 \
-                libclang-dev \
-                postgresql-common \
+. /dependencies.sh
+
+# Phase 0 - set platform-specific parameters
+case $OS_NAME in
+    centos | rockylinux)
+        PG_BASE=/usr/pgsql-
+        ;;
+    debian | ubuntu)
+        PG_BASE=/usr/lib/postgresql/
+        ;;
+    *)
+        echo >&2 "unsupported $OS_NAME"
+        exit 4
+        ;;
+esac
+
+if $privileged; then
+    # Phase 1 - cross-platform prerequisites
+    useradd -u 1001 -md "$BUILDER_HOME" $BUILDER_USERNAME
+
+    # Phase 2 - platform-specific package installation
+    case $OS_NAME in
+        # Red Hat Enterprise derivatives
+        centos | rockylinux)
+            case $OS_VERSION in
+                7)
+                    # TODO There's actually more to it than just the pgx bug:  it's unclear how to
+                    # even build because it can't find libclang.so without
+                    #   scl enable llvm-toolset-7 'tools/build -pg14 test-extension'
+                    # We may have to just add a centos7 check to the packaging script, too.
+
+                    # Postgresql packages require both
+                    # - llvm-toolset-7-clang from centos-release-scl-rh
+                    # - llvm5.0-devel from epel-release
+                    # ¯\_(ツ)_/¯
+                    yum -q -y install centos-release-scl-rh epel-release
+                    yum -q -y install devtoolset-7-gcc llvm-toolset-7-clang-devel llvm-toolset-7-clang-libs
+                    # devtoolset-7 includes a BROKEN sudo!  It even leads with a TODO about its brokenness!
+                    rm -f /opt/rh/devtoolset-7/root/usr/bin/sudo
+                    # for fpm
+                    yum -q -y install rh-ruby26-ruby-devel
+
+                    # TODO Would be nice to be able to resolve all system
+                    #  differences here rather than also in package-rpm.sh -
+                    #  maybe install wrappers in /usr/local/bin or setup ~/.profile .
+                    #  For now, most the knowledge is split.
+                    # Here, we only need `cc` for installing cargo-pgx below.
+                    set +e      # scl_source has unchecked yet harmless errors?!  ¯\_(ツ)_/¯
+                    . scl_source enable devtoolset-7
+                    # And rh-ruby26 for gem install fpm below.
+                    . scl_source enable rh-ruby26
+                    set -e
+                    ;;
+
+                8)
+                    dnf -qy module disable postgresql
+                    # fpm suddenly requires newer public_suffix that requires newer ruby
+                    # https://github.com/jordansissel/fpm/issues/1923 ¯\_(ツ)_/¯
+                    dnf -qy module enable ruby:2.6
+                    dnf -qy install ruby-devel rubygems
+                    ;;
+
+                *)
+                    echo >&2 'only 7 or 8 supported'
+                    exit 5
+                    ;;
+            esac
+
+            # pgx needs:
+            # - gcc (specifically; clang won't do!)
+            # - openssl-devel
+            # - make
+            # - pkg-config
+            yum -q -y install \
+                curl \
+                gcc \
+                git \
+                make \
+                openssl-devel \
+                pkg-config \
+                rpm-build \
                 sudo
 
-        # We'll run tools/testbin as this user, and it needs to (un)install packages.
-        echo 'postgres ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
+            # Setup the postgresql.org package repository.
+            yum -q -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-${OS_VERSION}-${ARCH}/pgdg-redhat-repo-latest.noarch.rpm
 
-        # Setup the postgresql.org package repository.
-        # Don't use the -y flag as it is not supported on old versions of the script.
-        yes | sh /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+            # Setup the timescaledb package repository.
+            cat > /etc/yum.repos.d/timescale_timescaledb.repo <<EOF
+[timescale_timescaledb]
+name=timescale_timescaledb
+baseurl=https://packagecloud.io/timescale/timescaledb/el/$OS_VERSION/$ARCH
+repo_gpgcheck=1
+gpgcheck=0
+enabled=1
+gpgkey=https://packagecloud.io/timescale/timescaledb/gpgkey
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300
+EOF
 
-        # Setup the timescaledb package repository.
-        wget --quiet -O - https://packagecloud.io/timescale/timescaledb/gpgkey | apt-key add -
-        mkdir -p /etc/apt/sources.list.d
-        # TODO Don't duplicate os name and version here.  Deduplicate with packaging scripts.
-        cat > /etc/apt/sources.list.d/timescaledb.list <<EOF
+            for pg in $PG_VERSIONS; do
+                yum -q -y install \
+                    postgresql$pg-devel \
+                    postgresql$pg-server \
+                    timescaledb-2-postgresql-$pg
+                # We install as user postgres, so that needs write access to these.
+                chown $BUILDER_USERNAME $PG_BASE$pg/lib $PG_BASE$pg/share/extension
+            done
+
+            gem install fpm -v $FPM_VERSION -N
+            ;;
+
+        # Debian family
+        debian | ubuntu)
+            # Image comes in with no package lists so we have to start with this.
+            apt-get -qq update
+
+            # Stop most debconf prompts.  Some have no default and we'd need
+            # to provide actual values via DEBCONF_OVERRIDE but we don't have
+            # any of those right now.
+            export DEBIAN_FRONTEND=noninteractive
+
+            # pgx needs:
+            # - gcc (specifically; clang won't do!)
+            # - libssl-dev
+            # - make
+            # - pkg-config
+            apt-get -qq install \
+                    build-essential \
+                    curl \
+                    debhelper \
+                    fakeroot \
+                    gcc \
+                    git \
+                    gnupg \
+                    libssl-dev \
+                    make \
+                    pkg-config \
+                    postgresql-common \
+                    sudo
+
+            # Setup the postgresql.org package repository.
+            # Don't use the -y flag as it is not supported on old versions of the script.
+            yes | /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh
+
+            # Setup the timescaledb package repository.
+            # TODO Blindly trusting a key that may change every time we run
+            #   defeats the purpose of package-signing but without a key rotation
+            #   story, the only security we have here is by trusting the system
+            #   certificate store, which we trust docker to provide a good copy
+            #   of.  May as well just put [trusted=yes] into sources.list instead
+            #   of bothering with apt-key...
+            curl -Ls https://packagecloud.io/timescale/timescaledb/gpgkey | apt-key add -
+            mkdir -p /etc/apt/sources.list.d
+            # TODO Don't duplicate os name and version here.  Deduplicate with packaging scripts.
+            cat > /etc/apt/sources.list.d/timescaledb.list <<EOF
 deb https://packagecloud.io/timescale/timescaledb/$OS_NAME/ $OS_CODE_NAME main
 EOF
 
-        apt-get -qq update
+            apt-get -qq update
 
-        for pg in 12 13 14; do
+        for pg in $PG_VERSIONS; do
             apt-get -qq install \
                     postgresql-$pg \
                     postgresql-server-dev-$pg
             # timescaledb packages Recommend toolkit, which we don't want here.
             apt-get -qq install --no-install-recommends timescaledb-2-postgresql-$pg
             # We install as user postgres, so that needs write access to these.
-            chown postgres /usr/lib/postgresql/$pg/lib /usr/share/postgresql/$pg/extension
+            chown $BUILDER_USERNAME $PG_BASE$pg/lib /usr/share/postgresql/$pg/extension
         done
 
-        cd ~postgres
-        exec su postgres -c "$0 unprivileged"
+        # Ubuntu is the only system we want an image for that sticks an extra
+        # copy of the default PATH into PAM's /etc/environment and we su or sudo
+        # to $BUILDER_USERNAME thereby picking up that PATH and clobbering the
+        # one we set in Dockerfile.  There's nothing else in here, so at first I
+        # thought to remove it.  That works on 20.04 and 22.04, but still leaves
+        # a busted PATH on 18.04!  On 18.04, we get clobbered by ENV_PATH in
+        # /etc/login.defs .  We fix all three by setting our PATH here:
+        echo > /etc/environment "PATH=$PATH"
         ;;
+    esac
 
-    unprivileged)
-        rustup component add clippy rustfmt
+    # Phase 3 - cross-platform privileged tasks after package installation
 
-        # Install cargo pgx
-        # Keep synchronized with `cargo install --version N.N.N cargo-pgx` in Readme.md and Cargo.toml
-        cargo install cargo-pgx --version =0.5.4
+    # We've benefitted from being able to test expansions to our cargo
+    # installation without having to rebuild the CI image before, so
+    # donate the cargo installation to the builder user.
+    install -d -o $BUILDER_USERNAME "$CARGO_HOME" "$RUSTUP_HOME"
 
-        # Initialize new PostgreSQL instances and update the configuration
-        # files so that they can use TimescaleDB that we installed above.
-        # TODO Not sure all this is necessary...
-        cargo pgx init --pg12 /usr/lib/postgresql/12/bin/pg_config --pg13 /usr/lib/postgresql/13/bin/pg_config --pg14 /usr/lib/postgresql/14/bin/pg_config
-        cargo pgx start pg12 && cargo pgx stop pg12
-        cargo pgx start pg13 && cargo pgx stop pg13
-        cargo pgx start pg14 && cargo pgx stop pg14
+    # We'll run tools/testbin as this user, and it needs to (un)install packages.
+    echo "$BUILDER_USERNAME ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-        echo "shared_preload_libraries = 'timescaledb'" >> ~/.pgx/data-12/postgresql.conf
-        echo "shared_preload_libraries = 'timescaledb'" >> ~/.pgx/data-13/postgresql.conf
-        echo "shared_preload_libraries = 'timescaledb'" >> ~/.pgx/data-14/postgresql.conf
+    cd "$BUILDER_HOME"
+    exec sudo -H --preserve-env=PATH,CARGO_HOME,RUSTUP_HOME -u $BUILDER_USERNAME "$0" -unprivileged "$@"
+fi
 
-        ;;
+# Phase 4 - unprivileged cross-platform tasks
 
-    *)
-        echo >&2 'run as root without arguments'
-        ;;
-esac
+curl -s https://sh.rustup.rs |
+    sh -s -- -q -y --no-modify-path --default-toolchain $RUST_TOOLCHAIN --profile $RUST_PROFILE -c $RUST_COMPONENTS
+
+# Install pgx
+cargo install cargo-pgx --version =$PGX_VERSION
+
+# Configure pgx
+## `cargo pgx init` is not additive; must specify all versions in one command.
+for pg in $PG_VERSIONS; do
+    init_flags="$init_flags --pg$pg $PG_BASE$pg/bin/pg_config"
+done
+cargo pgx init $init_flags
+## Initialize pgx-managed databases so we can add the timescaledb load.
+for pg in $PG_VERSIONS; do
+    echo "shared_preload_libraries = 'timescaledb'" >> ~/.pgx/data-$pg/postgresql.conf
+done
+
+# Clone and fetch dependencies so we builds have less work to do.
+git clone https://github.com/timescale/timescaledb-toolkit
+cd timescaledb-toolkit
+cargo fetch

--- a/tools/build
+++ b/tools/build
@@ -73,7 +73,7 @@ while [ $# -gt 0 ]; do
             shift
             ;;
 
-        -pg1[234])
+        -pg1[0-9])         # If this script survives to postgresql 19, WE WIN!
             pg_version=${arg#-pg}
             pg=pg$pg_version
             [ -z "$pg_port" ] && pg_port=288$pg_version
@@ -87,8 +87,7 @@ while [ $# -gt 0 ]; do
         clippy)
             find_profile
             $nop cargo fetch
-            # We need to pick a postgres version to clippy the timescaledb_toolkit crate, but it doesn't matter which one.
-            $nop cargo clippy --profile $profile --workspace --features 'pg14 pg_test' -- -D warnings
+            $nop cargo clippy --profile $profile --workspace --features pg_test -- -D warnings
             ;;
 
         test-crates)

--- a/tools/dependencies.sh
+++ b/tools/dependencies.sh
@@ -1,0 +1,21 @@
+# Dependency configuration
+# Ideally, all dependencies would be specified in just one place.
+# Exceptions:
+# - crate dependencies are specified in Cargo.toml files
+# - postgres versions are duplicated in the Github Actions matrix
+# - Readme.md lists some, too.  TODO is it acceptable to just point to this file?
+# All our automation scripts read this, so at least we're not duplicating this
+# information across all those.
+
+PG_VERSIONS='12 13 14'
+
+# Keep synchronized with extension/Cargo.toml and `cargo install --version N.N.N cargo-pgx` in Readme.md .
+PGX_VERSION=0.5.4
+
+RUST_TOOLCHAIN=1.60.0
+RUST_PROFILE=minimal
+RUST_COMPONENTS=clippy,rustfmt
+
+# We use fpm 1.14.2 to build RPMs.
+# TODO Use rpmbuild directly.
+FPM_VERSION=1.14.2

--- a/tools/testbin
+++ b/tools/testbin
@@ -36,11 +36,12 @@ MIN_DEB_EPOCH=1.7.0
 #   starts postgres on, so we duplicate that knowledge.  Watch out for
 #   that changing!
 PGX_PORT_BASE=28800
-# TODO Drop default and require -pgversions after existing usage updated.
-PG_VERSIONS='12 13 14'
 CONTROL=extension/timescaledb_toolkit.control
 # Pattern we require in $CONTROL for finding versions to test upgrade from.
 UPGRADEABLE_RE="^# upgradeable_from = '[0-9][-dev0-9., ]*'$"
+
+# For PG_VERSIONS default.
+. tools/dependencies.sh
 
 print() {
     printf '%s\n' "$*"


### PR DESCRIPTION
Our current package-building script builds fresh Docker images for all platforms, builds the packages, and then discards the Docker images. So slow and wasteful!

It's also all duplicated with the container-building script here.

Now all this logic lives in just one place.

We do have to keep the packaging in the private repository in order to access our hosted arm64 runner.

Next steps:
- Use the new image
- Move the package-build script here
- Automated release action