### PR TITLE
Update pgx to 0.5.4.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1102,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "981ce8e6b75a371c8c9a7f35ee895e94446fa91fa87af21bb379fb1bdcfb0afa"
+checksum = "516bfa73122828ba6b05c7943ebfe53cb1e02f413278459b8b8e78ed75b0b02f"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1132,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-macros"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d8ecdf7715f6f8caad0ca157617456d196353c100ddc64e4f0130386946d41"
+checksum = "861572c28af362133271ccef290733114763acf89e5c0566f2af031dbe79b3eb"
 dependencies = [
  "pgx-utils",
  "proc-macro2",
@@ -1145,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-config"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d5d686ea09dce55a820df6b91392b1d25aa0f49e7659b63a57f18083fbdc8c"
+checksum = "5d61bec7bf2c7a8c56249d9627eb718e3e662bb763927a28567bc1e6b59296ff"
 dependencies = [
  "dirs",
  "eyre",
@@ -1161,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7197050b02d4c4f6a20fcf6c0b4532724febbac99b1805f137cbb1beaa7ae0f3"
+checksum = "8df1c36c12f62459a3ca08ddaf7503eacfc6c07ed7482a52cdb93ebfb23863d5"
 dependencies = [
  "bindgen",
  "eyre",
@@ -1182,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f14845507aedcf77112641ffef99a346faab4b828f6fb30766f9bfaf3641b0f0"
+checksum = "269d9da323cbfd111f2d755ec0cc848f6b8cdf279bb244ad1f594495fa4ceb07"
 dependencies = [
  "eyre",
  "libc",
@@ -1205,9 +1205,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-utils"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e884579ff059e62dbc634a47a12a31d7e84ff96738186cbef71beb3d987ff470"
+checksum = "fb2ee712d498250263f0d19040aa85897d1456229f0504f38fbc62b3f1af58cd"
 dependencies = [
  "atty",
  "convert_case",
@@ -1850,9 +1850,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "aggregate_builder"
 version = "0.1.0"
 dependencies = [
@@ -105,21 +90,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "backtrace"
-version = "0.3.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
-
-[[package]]
 name = "bare-metal"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,21 +137,6 @@ dependencies = [
  "rustc-hash",
  "shlex",
 ]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit_field"
@@ -253,12 +208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.0.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
-
-[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,33 +256,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
-]
-
-[[package]]
-name = "color-eyre"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
-dependencies = [
- "backtrace",
- "color-spantrace",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors",
- "tracing-error",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
-dependencies = [
- "once_cell",
- "owo-colors",
- "tracing-core",
- "tracing-error",
 ]
 
 [[package]]
@@ -406,15 +328,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -582,16 +495,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
-name = "fancy-regex"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
-dependencies = [
- "bit-set",
- "regex",
-]
-
-[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,16 +516,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -729,12 +622,6 @@ dependencies = [
  "libc",
  "wasi",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
 
 [[package]]
 name = "glob"
@@ -860,9 +747,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "libloading"
@@ -879,21 +766,6 @@ name = "libm"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
-
-[[package]]
-name = "line-wrap"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
-dependencies = [
- "safemem",
-]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -961,15 +833,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
-dependencies = [
- "adler",
-]
 
 [[package]]
 name = "mio"
@@ -1109,15 +972,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "pgx"
-version = "0.5.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bfbe2a1b1b2c77fc04a8b72149590f193dc34e12b586e3efa737b899ea5b91d"
+checksum = "981ce8e6b75a371c8c9a7f35ee895e94446fa91fa87af21bb379fb1bdcfb0afa"
 dependencies = [
  "atomic-traits",
  "bitflags",
@@ -1273,14 +1127,14 @@ dependencies = [
  "time",
  "tracing",
  "tracing-error",
- "uuid 1.1.2",
+ "uuid 1.2.1",
 ]
 
 [[package]]
 name = "pgx-macros"
-version = "0.5.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a3d26c61adb81663ffb5391126783dcb3f6512d55189915793a066d7219634"
+checksum = "c1d8ecdf7715f6f8caad0ca157617456d196353c100ddc64e4f0130386946d41"
 dependencies = [
  "pgx-utils",
  "proc-macro2",
@@ -1291,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-pg-config"
-version = "0.5.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "850a9f2e7a8b24c2c5a2d5b73b97b274a2d7cb8663f4b37d304ad12e8730286e"
+checksum = "c7d5d686ea09dce55a820df6b91392b1d25aa0f49e7659b63a57f18083fbdc8c"
 dependencies = [
  "dirs",
  "eyre",
@@ -1302,18 +1156,16 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "toml",
- "tracing",
  "url",
 ]
 
 [[package]]
 name = "pgx-pg-sys"
-version = "0.5.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbc0dc317c60943633f1b84d757bc8ecce578506682bae065d66815b732bfa24"
+checksum = "7197050b02d4c4f6a20fcf6c0b4532724febbac99b1805f137cbb1beaa7ae0f3"
 dependencies = [
  "bindgen",
- "color-eyre",
  "eyre",
  "memoffset",
  "once_cell",
@@ -1323,7 +1175,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rayon",
- "rustversion",
  "shlex",
  "sptr",
  "syn",
@@ -1331,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "pgx-tests"
-version = "0.5.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d57c8354ed351e0bf62384cebd4e4ee1fd58513b8d419ca4d8dd0e140ca84ce"
+checksum = "f14845507aedcf77112641ffef99a346faab4b828f6fb30766f9bfaf3641b0f0"
 dependencies = [
  "eyre",
  "libc",
@@ -1354,15 +1205,14 @@ dependencies = [
 
 [[package]]
 name = "pgx-utils"
-version = "0.5.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1dfb18f7a5efd503087c909ca04baa316d730e2632eb32b625d831d34ad902a"
+checksum = "e884579ff059e62dbc634a47a12a31d7e84ff96738186cbef71beb3d987ff470"
 dependencies = [
  "atty",
  "convert_case",
  "cstr_core",
  "eyre",
- "owo-colors",
  "petgraph",
  "proc-macro2",
  "quote",
@@ -1372,7 +1222,6 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "syn",
- "syntect",
  "tracing",
  "tracing-error",
  "tracing-subscriber",
@@ -1408,20 +1257,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "plist"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd39bc6cdc9355ad1dc5eeedefee696bb35c34caf21768741e81826c0bbd7225"
-dependencies = [
- "base64",
- "indexmap",
- "line-wrap",
- "serde",
- "time",
- "xml-rs",
-]
 
 [[package]]
 name = "post-install"
@@ -1486,9 +1321,9 @@ checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
@@ -1691,12 +1526,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,22 +1559,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
-
-[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
-
-[[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -1845,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
 dependencies = [
  "itoa",
  "ryu",
@@ -2040,29 +1857,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syntect"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c454c27d9d7d9a84c7803aaa3c50cd088d2906fe3c6e42da3209aa623576a8"
-dependencies = [
- "bincode",
- "bitflags",
- "fancy-regex",
- "flate2",
- "fnv",
- "lazy_static",
- "once_cell",
- "plist",
- "regex-syntax",
- "serde",
- "serde_derive",
- "serde_json",
- "thiserror",
- "walkdir",
- "yaml-rust",
 ]
 
 [[package]]
@@ -2488,9 +2282,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.1.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
 dependencies = [
  "getrandom",
 ]
@@ -2629,12 +2423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xml-rs"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
-
-[[package]]
 name = "xshell"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2648,12 +2436,3 @@ name = "xshell-macros"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4916a4a3cad759e499a3620523bf9545cc162d7a06163727dde97ce9aaa4cf39"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]

--- a/Readme.md
+++ b/Readme.md
@@ -51,7 +51,7 @@ sudo apt-get install make gcc pkg-config clang postgresql-server-dev-14 libssl-d
 
 Next you need [cargo-pgx](https://github.com/tcdi/pgx), which can be installed with
 ```bash
-cargo install --version '=0.5.0' --force cargo-pgx
+cargo install --version '=0.5.3' --force cargo-pgx
 ```
 
 You must reinstall cargo-pgx whenver you update your Rust compiler, since cargo-pgx needs to be built with the same compiler as Toolkit.

--- a/Readme.md
+++ b/Readme.md
@@ -51,7 +51,7 @@ sudo apt-get install make gcc pkg-config clang postgresql-server-dev-14 libssl-d
 
 Next you need [cargo-pgx](https://github.com/tcdi/pgx), which can be installed with
 ```bash
-cargo install --version '=0.5.3' --force cargo-pgx
+cargo install --version '=0.5.4' --force cargo-pgx
 ```
 
 You must reinstall cargo-pgx whenver you update your Rust compiler, since cargo-pgx needs to be built with the same compiler as Toolkit.

--- a/docker/ci/setup.sh
+++ b/docker/ci/setup.sh
@@ -60,7 +60,7 @@ EOF
 
         # Install cargo pgx
         # Keep synchronized with `cargo install --version N.N.N cargo-pgx` in Readme.md and Cargo.toml
-        cargo install cargo-pgx --version =0.5.0
+        cargo install cargo-pgx --version =0.5.3
 
         # Initialize new PostgreSQL instances and update the configuration
         # files so that they can use TimescaleDB that we installed above.

--- a/docker/ci/setup.sh
+++ b/docker/ci/setup.sh
@@ -60,7 +60,7 @@ EOF
 
         # Install cargo pgx
         # Keep synchronized with `cargo install --version N.N.N cargo-pgx` in Readme.md and Cargo.toml
-        cargo install cargo-pgx --version =0.5.3
+        cargo install cargo-pgx --version =0.5.4
 
         # Initialize new PostgreSQL instances and update the configuration
         # files so that they can use TimescaleDB that we installed above.

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -18,8 +18,8 @@ pg_test = ["approx"]
 [dependencies]
 # Keep synchronized with `cargo install --version N.N.N cargo-pgx` in Readme.md and docker/ci/Dockerfile
 # Also `pgx-tests` down below in `dev-dependencies`.
-pgx = "=0.5.3"
-pgx-macros = "=0.5.3"
+pgx = "=0.5.4"
+pgx-macros = "=0.5.4"
 encodings = {path="../crates/encodings"}
 flat_serialize = {path="../crates/flat_serialize/flat_serialize"}
 flat_serialize_macro = {path="../crates/flat_serialize/flat_serialize_macro"}
@@ -52,5 +52,5 @@ spfunc = "0.1.0"
 statrs = "0.15.0"
 
 [dev-dependencies]
-pgx-tests = "=0.5.3"
+pgx-tests = "=0.5.4"
 approx = "0.4.0"

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -18,8 +18,8 @@ pg_test = ["approx"]
 [dependencies]
 # Keep synchronized with `cargo install --version N.N.N cargo-pgx` in Readme.md and docker/ci/Dockerfile
 # Also `pgx-tests` down below in `dev-dependencies`.
-pgx = "=0.5.0"
-pgx-macros = "=0.5.0"
+pgx = "=0.5.3"
+pgx-macros = "=0.5.3"
 encodings = {path="../crates/encodings"}
 flat_serialize = {path="../crates/flat_serialize/flat_serialize"}
 flat_serialize_macro = {path="../crates/flat_serialize/flat_serialize_macro"}
@@ -52,5 +52,5 @@ spfunc = "0.1.0"
 statrs = "0.15.0"
 
 [dev-dependencies]
-pgx-tests = "=0.5.0"
+pgx-tests = "=0.5.3"
 approx = "0.4.0"


### PR DESCRIPTION
This has various fixes for RHEL derivatives (centos 7 and Rocky 8).