### PR TITLE
Adding min_n and max_n aggregates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,6 +1987,7 @@ dependencies = [
  "flat_serialize_macro",
  "hyperloglogplusplus",
  "once_cell",
+ "ordered-float",
  "paste",
  "pest",
  "pest_derive",

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,8 @@ This changelog should be updated as part of a PR if the work is worth noting (mo
 
 #### New experimental features
 
+- New min_n/max_n functions and related min_n_by/max_n_by.  The former is used to get the top N values from a column while the later will also track some additional data, such as another column or even the entire row.  These should give the same results as a normal select with an order by and limit, except they can be composed and combined like other toolkit aggregates.
+
 #### Stabilized features
 
 #### Bug fixes

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -39,6 +39,7 @@ approx = {version = "0.4.0", optional = true}
 bincode = "1.3.1"
 serde = { version = "1.0", features = ["derive"] }
 once_cell = "1.8.0"
+ordered-float = {version = "1.0", features = ["serde"] }
 paste = "1.0"
 rand = { version = "0.8.3", features = ["getrandom", "small_rng"] }
 rand_distr = "0.4.0"

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -17,6 +17,7 @@ pub mod frequency;
 pub mod gauge_agg;
 pub mod hyperloglog;
 pub mod lttb;
+pub mod nmost;
 pub mod ohlc;
 pub mod range;
 pub mod saturation;

--- a/extension/src/nmost.rs
+++ b/extension/src/nmost.rs
@@ -1,0 +1,264 @@
+use pgx::*;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    aggregate_utils::in_aggregate_context,
+    datum_utils::{deep_copy_datum, free_datum, DatumStore},
+    palloc::{Inner, Internal, InternalAsValue},
+};
+
+use std::collections::BinaryHeap;
+
+mod max_float;
+mod max_int;
+mod max_time;
+mod min_float;
+mod min_int;
+mod min_time;
+
+mod max_by_float;
+mod max_by_int;
+mod max_by_time;
+mod min_by_float;
+mod min_by_int;
+mod min_by_time;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NMostTransState<T: Ord> {
+    capacity: usize,
+    heap: BinaryHeap<T>,
+}
+
+impl<T: Ord> NMostTransState<T> {
+    fn new(capacity: usize, first_val: T) -> NMostTransState<T> {
+        let mut new_heap = NMostTransState {
+            capacity,
+            heap: BinaryHeap::with_capacity(capacity),
+        };
+
+        new_heap.new_entry(first_val);
+
+        new_heap
+    }
+
+    fn new_entry(&mut self, new_val: T) {
+        // If at capacity see if we need to replace something
+        if self.heap.len() == self.capacity {
+            if !self.belongs_in_heap(&new_val) {
+                return;
+            }
+
+            self.heap.pop();
+        }
+
+        self.heap.push(new_val)
+    }
+
+    fn belongs_in_heap(&self, val: &T) -> bool {
+        // Note that this will actually be '>' if T is a Reverse<...> type
+        val < self.heap.peek().unwrap()
+    }
+}
+
+impl<T: Ord + Copy> From<(&[T], usize)> for NMostTransState<T> {
+    fn from(input: (&[T], usize)) -> Self {
+        let (vals, capacity) = input;
+        let mut state = Self::new(capacity, vals[0]);
+        for val in vals[1..].iter() {
+            state.new_entry(*val);
+        }
+        state
+    }
+}
+
+fn nmost_trans_function<T: Ord>(
+    state: Option<Inner<NMostTransState<T>>>,
+    val: T,
+    capacity: usize,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Inner<NMostTransState<T>>> {
+    unsafe {
+        in_aggregate_context(fcinfo, || {
+            if state.is_none() {
+                return Internal::new(NMostTransState::<T>::new(capacity, val)).to_inner();
+            }
+
+            let mut state = state.unwrap();
+            state.new_entry(val);
+            Some(state)
+        })
+    }
+}
+
+fn nmost_rollup_trans_function<T: Ord + Copy>(
+    state: Option<Inner<NMostTransState<T>>>,
+    sorted_vals: &[T],
+    capacity: usize,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Inner<NMostTransState<T>>> {
+    unsafe {
+        in_aggregate_context(fcinfo, || {
+            if let Some(mut state) = state {
+                for val in sorted_vals {
+                    // The values are sorted, so as soon as we find one that shouldn't be added, we're done
+                    if !state.belongs_in_heap(val) {
+                        return Some(state);
+                    }
+                    state.new_entry(*val);
+                }
+
+                Some(state)
+            } else {
+                Internal::new::<NMostTransState<T>>((sorted_vals, capacity).into()).to_inner()
+            }
+        })
+    }
+}
+
+fn nmost_trans_combine<T: Clone + Ord + Copy>(
+    first: Option<Inner<NMostTransState<T>>>,
+    second: Option<Inner<NMostTransState<T>>>,
+) -> Option<Inner<NMostTransState<T>>> {
+    match (first, second) {
+        (None, None) => None,
+        (None, Some(only)) | (Some(only), None) => unsafe {
+            Internal::new(only.clone()).to_inner()
+        },
+        (Some(a), Some(b)) => {
+            let mut a = a.clone();
+            // This could be made more efficient by iterating in the appropriate order with an early exit, but would requiring ordering the other heap
+            for entry in b.heap.iter() {
+                a.new_entry(*entry);
+            }
+            unsafe { Internal::new(a).to_inner() }
+        }
+    }
+}
+
+// TODO: serialize and deserialize will need to be implemented with Datum handling code
+#[derive(Clone, Debug)]
+pub struct NMostByTransState<T: Ord> {
+    values: NMostTransState<(T, usize)>,
+    data: Vec<Datum>,
+    oid: pg_sys::Oid,
+}
+
+impl<T: Clone + Ord> NMostByTransState<T> {
+    fn new(capacity: usize, first_val: T, first_element: pgx::AnyElement) -> NMostByTransState<T> {
+        // first entry will always have index 0
+        let first_val = (first_val, 0);
+        NMostByTransState {
+            values: NMostTransState::new(capacity, first_val),
+            data: vec![unsafe { deep_copy_datum(first_element.datum(), first_element.oid()) }],
+            oid: first_element.oid(),
+        }
+    }
+
+    fn new_entry(&mut self, new_val: T, new_element: pgx::AnyElement) {
+        assert!(new_element.oid() == self.oid);
+        if self.data.len() < self.values.capacity {
+            // Not yet full, easy case
+            self.values.new_entry((new_val, self.data.len()));
+            self.data
+                .push(unsafe { deep_copy_datum(new_element.datum(), new_element.oid()) });
+        } else if self
+            .values
+            .belongs_in_heap(&(new_val.clone(), self.data.len()))
+        {
+            // Full and value belongs in the heap (using len() for this check just keeps us from
+            // succeeding if we tie the max heap element)
+
+            let (_, index_to_replace) = *self
+                .values
+                .heap
+                .peek()
+                .expect("Can't be empty in this case");
+            let old_datum = std::mem::replace(&mut self.data[index_to_replace], unsafe {
+                deep_copy_datum(new_element.datum(), new_element.oid())
+            });
+            unsafe { free_datum(old_datum, new_element.oid()) };
+            self.values.new_entry((new_val, index_to_replace));
+        }
+    }
+
+    // Sort the trans state and break it into a tuple of (capacity, values array, datum_store)
+    fn into_sorted_parts(self) -> (usize, Vec<T>, DatumStore<'static>) {
+        let values = self.values;
+        let heap = values.heap;
+        let (val_ary, idx_ary): (Vec<T>, Vec<usize>) = heap.into_sorted_vec().into_iter().unzip();
+
+        let mut mapped_data = vec![];
+        for i in idx_ary {
+            mapped_data.push(self.data[i]);
+        }
+
+        (
+            values.capacity,
+            val_ary,
+            DatumStore::from((self.oid, mapped_data)),
+        )
+    }
+}
+
+impl<T: Ord + Copy> From<(&[T], &DatumStore<'_>, usize)> for NMostByTransState<T> {
+    fn from(in_tuple: (&[T], &DatumStore, usize)) -> Self {
+        let (vals, data, capacity) = in_tuple;
+        let mut elements = data.clone().into_anyelement_iter();
+        let mut state = Self::new(capacity, vals[0], elements.next().unwrap());
+        for val in vals[1..].iter() {
+            state.new_entry(*val, elements.next().unwrap());
+        }
+        state
+    }
+}
+
+fn nmost_by_trans_function<T: Ord + Clone>(
+    state: Option<Inner<NMostByTransState<T>>>,
+    val: T,
+    data: pgx::AnyElement,
+    capacity: usize,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Inner<NMostByTransState<T>>> {
+    unsafe {
+        in_aggregate_context(fcinfo, || {
+            if state.is_none() {
+                return Internal::new(NMostByTransState::<T>::new(capacity, val, data)).to_inner();
+            }
+
+            let mut state = state.unwrap();
+            state.new_entry(val, data);
+            Some(state)
+        })
+    }
+}
+
+fn nmost_by_rollup_trans_function<T: Ord + Copy>(
+    state: Option<Inner<NMostByTransState<T>>>,
+    sorted_vals: &[T],
+    datum_store: &DatumStore,
+    capacity: usize,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Inner<NMostByTransState<T>>> {
+    unsafe {
+        in_aggregate_context(fcinfo, || {
+            if let Some(mut state) = state {
+                for (val, element) in sorted_vals
+                    .iter()
+                    .zip(datum_store.clone().into_anyelement_iter())
+                {
+                    // The values are sorted, so as soon as we find one that shouldn't be added, we're done
+                    if !state.values.belongs_in_heap(&(*val, state.values.capacity)) {
+                        return Some(state);
+                    }
+                    state.new_entry(*val, element);
+                }
+
+                Some(state)
+            } else {
+                Internal::new::<NMostByTransState<T>>((sorted_vals, datum_store, capacity).into())
+                    .to_inner()
+            }
+        })
+    }
+}

--- a/extension/src/nmost/max_by_float.rs
+++ b/extension/src/nmost/max_by_float.rs
@@ -1,0 +1,220 @@
+use pgx::{iter::TableIterator, *};
+
+use crate::nmost::max_float::toolkit_experimental::*;
+use crate::nmost::*;
+
+use crate::{
+    build, flatten,
+    palloc::{Internal, InternalAsValue, ToInternal},
+    pg_type, ron_inout_funcs,
+};
+
+use ordered_float::NotNan;
+use std::cmp::Reverse;
+
+type MaxByFloatTransType = NMostByTransState<Reverse<NotNan<f64>>>;
+
+#[pg_schema]
+pub mod toolkit_experimental {
+    use super::*;
+
+    pg_type! {
+        #[derive(Debug)]
+        struct MaxByFloats<'input> {
+            values: MaxFloatsData<'input>,  // Nesting pg_types adds 8 bytes of header
+            data: DatumStore<'input>,
+        }
+    }
+    ron_inout_funcs!(MaxByFloats);
+
+    impl<'input> From<MaxByFloatTransType> for MaxByFloats<'input> {
+        fn from(item: MaxByFloatTransType) -> Self {
+            let (capacity, val_ary, data) = item.into_sorted_parts();
+            unsafe {
+                flatten!(MaxByFloats {
+                    values: build!(MaxFloats {
+                        capacity: capacity as u32,
+                        elements: val_ary.len() as u32,
+                        values: val_ary
+                            .into_iter()
+                            .map(|x| f64::from(x.0))
+                            .collect::<Vec<f64>>()
+                            .into()
+                    })
+                    .0,
+                    data,
+                })
+            }
+        }
+    }
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_by_float_trans(
+    state: Internal,
+    value: f64,
+    data: AnyElement,
+    capacity: i64,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    nmost_by_trans_function(
+        unsafe { state.to_inner::<MaxByFloatTransType>() },
+        Reverse(NotNan::new(value).unwrap()),
+        data,
+        capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_by_float_rollup_trans(
+    state: Internal,
+    value: toolkit_experimental::MaxByFloats<'static>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    let values: Vec<Reverse<NotNan<f64>>> = value
+        .values
+        .values
+        .clone()
+        .into_iter()
+        .map(|x| Reverse(NotNan::new(x).unwrap()))
+        .collect();
+    nmost_by_rollup_trans_function(
+        unsafe { state.to_inner::<MaxByFloatTransType>() },
+        &values,
+        &value.data,
+        value.values.capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_by_float_final(state: Internal) -> toolkit_experimental::MaxByFloats<'static> {
+    unsafe { state.to_inner::<MaxByFloatTransType>().unwrap().clone() }.into()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_values",
+    immutable,
+    parallel_safe
+)]
+pub fn max_n_by_float_to_values(
+    agg: toolkit_experimental::MaxByFloats<'static>,
+    _dummy: Option<AnyElement>,
+) -> TableIterator<'static, (name!(value, f64), name!(data, AnyElement))> {
+    TableIterator::new(
+        agg.values
+            .values
+            .clone()
+            .into_iter()
+            .zip(agg.data.clone().into_anyelement_iter()),
+    )
+}
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.max_n_by(\n\
+        value double precision, data AnyElement, capacity bigint\n\
+    ) (\n\
+        sfunc = toolkit_experimental.max_n_by_float_trans,\n\
+        stype = internal,\n\
+        finalfunc = toolkit_experimental.max_n_by_float_final\n\
+    );\n\
+",
+    name = "max_n_by_float",
+    requires = [max_n_by_float_trans, max_n_by_float_final],
+);
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.rollup(\n\
+        toolkit_experimental.MaxByFloats\n\
+    ) (\n\
+        sfunc = toolkit_experimental.max_n_by_float_rollup_trans,\n\
+        stype = internal,\n\
+        finalfunc = toolkit_experimental.max_n_by_float_final\n\
+    );\n\
+",
+    name = "max_n_by_float_rollup",
+    requires = [max_n_by_float_rollup_trans, min_n_by_float_final],
+);
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+    use pgx_macros::pg_test;
+
+    #[pg_test]
+    fn max_by_float_correctness() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            client.select(
+                "CREATE TABLE data(val DOUBLE PRECISION, category INT)",
+                None,
+                None,
+            );
+
+            for i in 0..100 {
+                let i = (i * 83) % 100; // mess with the ordering just a little
+
+                client.select(
+                    &format!("INSERT INTO data VALUES ({}.0/128, {})", i, i % 4),
+                    None,
+                    None,
+                );
+            }
+
+            // Test into_values
+            let mut result =
+                client.select("SELECT toolkit_experimental.into_values(toolkit_experimental.max_n_by(val, data, 3), NULL::data)::TEXT from data",
+                    None, None,
+                );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(0.7734375,\"(0.7734375,3)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(0.765625,\"(0.765625,2)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(0.7578125,\"(0.7578125,1)\")")
+            );
+            assert!(result.next().is_none());
+
+            // Test rollup
+            let mut result =
+                client.select(
+                    "WITH aggs as (SELECT category, toolkit_experimental.max_n_by(val, data, 5) as agg from data GROUP BY category)
+                        SELECT toolkit_experimental.into_values(toolkit_experimental.rollup(agg), NULL::data)::TEXT FROM aggs",
+                        None, None,
+                    );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(0.7734375,\"(0.7734375,3)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(0.765625,\"(0.765625,2)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(0.7578125,\"(0.7578125,1)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(0.75,\"(0.75,0)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(0.7421875,\"(0.7421875,3)\")")
+            );
+            assert!(result.next().is_none());
+        })
+    }
+}

--- a/extension/src/nmost/max_by_int.rs
+++ b/extension/src/nmost/max_by_int.rs
@@ -1,0 +1,191 @@
+use pgx::{iter::TableIterator, *};
+
+use crate::nmost::max_int::toolkit_experimental::*;
+use crate::nmost::*;
+
+use crate::{
+    build, flatten,
+    palloc::{Internal, InternalAsValue, ToInternal},
+    pg_type, ron_inout_funcs,
+};
+
+use std::cmp::Reverse;
+
+type MaxByIntTransType = NMostByTransState<Reverse<i64>>;
+
+#[pg_schema]
+pub mod toolkit_experimental {
+    use super::*;
+
+    pg_type! {
+        #[derive(Debug)]
+        struct MaxByInts<'input> {
+            values: MaxIntsData<'input>,  // Nesting pg_types adds 8 bytes of header
+            data: DatumStore<'input>,
+        }
+    }
+    ron_inout_funcs!(MaxByInts);
+
+    impl<'input> From<MaxByIntTransType> for MaxByInts<'input> {
+        fn from(item: MaxByIntTransType) -> Self {
+            let (capacity, val_ary, data) = item.into_sorted_parts();
+            unsafe {
+                flatten!(MaxByInts {
+                    values: build!(MaxInts {
+                        capacity: capacity as u32,
+                        elements: val_ary.len() as u32,
+                        values: val_ary
+                            .into_iter()
+                            .map(|x| x.0)
+                            .collect::<Vec<i64>>()
+                            .into()
+                    })
+                    .0,
+                    data,
+                })
+            }
+        }
+    }
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_by_int_trans(
+    state: Internal,
+    value: i64,
+    data: AnyElement,
+    capacity: i64,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    nmost_by_trans_function(
+        unsafe { state.to_inner::<MaxByIntTransType>() },
+        Reverse(value),
+        data,
+        capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_by_int_rollup_trans(
+    state: Internal,
+    value: toolkit_experimental::MaxByInts<'static>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    let values: Vec<Reverse<i64>> = value
+        .values
+        .values
+        .clone()
+        .into_iter()
+        .map(Reverse)
+        .collect();
+    nmost_by_rollup_trans_function(
+        unsafe { state.to_inner::<MaxByIntTransType>() },
+        &values,
+        &value.data,
+        value.values.capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_by_int_final(state: Internal) -> toolkit_experimental::MaxByInts<'static> {
+    unsafe { state.to_inner::<MaxByIntTransType>().unwrap().clone() }.into()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_values",
+    immutable,
+    parallel_safe
+)]
+pub fn max_n_by_int_to_values(
+    agg: toolkit_experimental::MaxByInts<'static>,
+    _dummy: Option<AnyElement>,
+) -> TableIterator<'static, (name!(value, i64), name!(data, AnyElement))> {
+    TableIterator::new(
+        agg.values
+            .values
+            .clone()
+            .into_iter()
+            .zip(agg.data.clone().into_anyelement_iter()),
+    )
+}
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.max_n_by(\n\
+        value bigint, data AnyElement, capacity bigint\n\
+    ) (\n\
+        sfunc = toolkit_experimental.max_n_by_int_trans,\n\
+        stype = internal,\n\
+        finalfunc = toolkit_experimental.max_n_by_int_final\n\
+    );\n\
+",
+    name = "max_n_by_int",
+    requires = [max_n_by_int_trans, max_n_by_int_final],
+);
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.rollup(\n\
+        toolkit_experimental.MaxByInts\n\
+    ) (\n\
+        sfunc = toolkit_experimental.max_n_by_int_rollup_trans,\n\
+        stype = internal,\n\
+        finalfunc = toolkit_experimental.max_n_by_int_final\n\
+    );\n\
+",
+    name = "max_n_by_int_rollup",
+    requires = [max_n_by_int_rollup_trans, min_n_by_int_final],
+);
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+    use pgx_macros::pg_test;
+
+    #[pg_test]
+    fn max_by_int_correctness() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            client.select("CREATE TABLE data(val INT8, category INT)", None, None);
+
+            for i in 0..100 {
+                let i = (i * 83) % 100; // mess with the ordering just a little
+
+                client.select(
+                    &format!("INSERT INTO data VALUES ({}, {})", i, i % 4),
+                    None,
+                    None,
+                );
+            }
+
+            // Test into_values
+            let mut result =
+                client.select("SELECT toolkit_experimental.into_values(toolkit_experimental.max_n_by(val, data, 3), NULL::data)::TEXT from data",
+                    None, None,
+                );
+            assert_eq!(result.next().unwrap()[1].value(), Some("(99,\"(99,3)\")"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("(98,\"(98,2)\")"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("(97,\"(97,1)\")"));
+            assert!(result.next().is_none());
+
+            // Test rollup
+            let mut result =
+                client.select(
+                    "WITH aggs as (SELECT category, toolkit_experimental.max_n_by(val, data, 5) as agg from data GROUP BY category)
+                        SELECT toolkit_experimental.into_values(toolkit_experimental.rollup(agg), NULL::data)::TEXT FROM aggs",
+                        None, None,
+                    );
+            assert_eq!(result.next().unwrap()[1].value(), Some("(99,\"(99,3)\")"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("(98,\"(98,2)\")"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("(97,\"(97,1)\")"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("(96,\"(96,0)\")"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("(95,\"(95,3)\")"));
+            assert!(result.next().is_none());
+        })
+    }
+}

--- a/extension/src/nmost/max_by_time.rs
+++ b/extension/src/nmost/max_by_time.rs
@@ -1,0 +1,226 @@
+use pgx::{iter::TableIterator, *};
+
+use crate::nmost::max_time::toolkit_experimental::*;
+use crate::nmost::*;
+
+use crate::{
+    build, flatten,
+    palloc::{Internal, InternalAsValue, ToInternal},
+    pg_type, ron_inout_funcs,
+};
+
+use std::cmp::Reverse;
+
+type MaxByTimeTransType = NMostByTransState<Reverse<pg_sys::TimestampTz>>;
+
+#[pg_schema]
+pub mod toolkit_experimental {
+    use super::*;
+
+    pg_type! {
+        #[derive(Debug)]
+        struct MaxByTimes<'input> {
+            values: MaxTimesData<'input>,  // Nesting pg_types adds 8 bytes of header
+            data: DatumStore<'input>,
+        }
+    }
+    ron_inout_funcs!(MaxByTimes);
+
+    impl<'input> From<MaxByTimeTransType> for MaxByTimes<'input> {
+        fn from(item: MaxByTimeTransType) -> Self {
+            let (capacity, val_ary, data) = item.into_sorted_parts();
+            unsafe {
+                flatten!(MaxByTimes {
+                    values: build!(MaxTimes {
+                        capacity: capacity as u32,
+                        elements: val_ary.len() as u32,
+                        values: val_ary
+                            .into_iter()
+                            .map(|x| x.0)
+                            .collect::<Vec<pg_sys::TimestampTz>>()
+                            .into()
+                    })
+                    .0,
+                    data,
+                })
+            }
+        }
+    }
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_by_time_trans(
+    state: Internal,
+    value: crate::raw::TimestampTz,
+    data: AnyElement,
+    capacity: i64,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    nmost_by_trans_function(
+        unsafe { state.to_inner::<MaxByTimeTransType>() },
+        Reverse(value.into()),
+        data,
+        capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_by_time_rollup_trans(
+    state: Internal,
+    value: toolkit_experimental::MaxByTimes<'static>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    let values: Vec<Reverse<pg_sys::TimestampTz>> = value
+        .values
+        .values
+        .clone()
+        .into_iter()
+        .map(Reverse)
+        .collect();
+    nmost_by_rollup_trans_function(
+        unsafe { state.to_inner::<MaxByTimeTransType>() },
+        &values,
+        &value.data,
+        value.values.capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_by_time_final(state: Internal) -> toolkit_experimental::MaxByTimes<'static> {
+    unsafe { state.to_inner::<MaxByTimeTransType>().unwrap().clone() }.into()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_values",
+    immutable,
+    parallel_safe
+)]
+pub fn max_n_by_time_to_values(
+    agg: toolkit_experimental::MaxByTimes<'static>,
+    _dummy: Option<AnyElement>,
+) -> TableIterator<
+    'static,
+    (
+        name!(value, crate::raw::TimestampTz),
+        name!(data, AnyElement),
+    ),
+> {
+    TableIterator::new(
+        agg.values
+            .values
+            .clone()
+            .into_iter()
+            .map(crate::raw::TimestampTz::from)
+            .zip(agg.data.clone().into_anyelement_iter()),
+    )
+}
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.max_n_by(\n\
+        value timestamptz, data AnyElement, capacity bigint\n\
+    ) (\n\
+        sfunc = toolkit_experimental.max_n_by_time_trans,\n\
+        stype = internal,\n\
+        finalfunc = toolkit_experimental.max_n_by_time_final\n\
+    );\n\
+",
+    name = "max_n_by_time",
+    requires = [max_n_by_time_trans, max_n_by_time_final],
+);
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.rollup(\n\
+        toolkit_experimental.MaxByTimes\n\
+    ) (\n\
+        sfunc = toolkit_experimental.max_n_by_time_rollup_trans,\n\
+        stype = internal,\n\
+        finalfunc = toolkit_experimental.max_n_by_time_final\n\
+    );\n\
+",
+    name = "max_n_by_time_rollup",
+    requires = [max_n_by_time_rollup_trans, min_n_by_time_final],
+);
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+    use pgx_macros::pg_test;
+
+    #[pg_test]
+    fn max_by_time_correctness() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            client.select(
+                "CREATE TABLE data(val TIMESTAMPTZ, category INT)",
+                None,
+                None,
+            );
+
+            for i in 0..100 {
+                let i = (i * 83) % 100; // mess with the ordering just a little
+
+                client.select(
+                    &format!("INSERT INTO data VALUES ('2020-1-1 UTC'::timestamptz + {} * '1d'::interval, {})", i, i % 4),
+                    None,
+                    None,
+                );
+            }
+
+            // Test into_values
+            let mut result =
+                client.select("SELECT toolkit_experimental.into_values(toolkit_experimental.max_n_by(val, data, 3), NULL::data)::TEXT from data",
+                    None, None,
+                );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(\"2020-04-09 00:00:00+00\",\"(\"\"2020-04-09 00:00:00+00\"\",3)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(\"2020-04-08 00:00:00+00\",\"(\"\"2020-04-08 00:00:00+00\"\",2)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(\"2020-04-07 00:00:00+00\",\"(\"\"2020-04-07 00:00:00+00\"\",1)\")")
+            );
+            assert!(result.next().is_none());
+
+            // Test rollup
+            let mut result =
+                client.select(
+                    "WITH aggs as (SELECT category, toolkit_experimental.max_n_by(val, data, 5) as agg from data GROUP BY category)
+                        SELECT toolkit_experimental.into_values(toolkit_experimental.rollup(agg), NULL::data)::TEXT FROM aggs",
+                        None, None,
+                    );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(\"2020-04-09 00:00:00+00\",\"(\"\"2020-04-09 00:00:00+00\"\",3)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(\"2020-04-08 00:00:00+00\",\"(\"\"2020-04-08 00:00:00+00\"\",2)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(\"2020-04-07 00:00:00+00\",\"(\"\"2020-04-07 00:00:00+00\"\",1)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(\"2020-04-06 00:00:00+00\",\"(\"\"2020-04-06 00:00:00+00\"\",0)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(\"2020-04-05 00:00:00+00\",\"(\"\"2020-04-05 00:00:00+00\"\",3)\")")
+            );
+            assert!(result.next().is_none());
+        })
+    }
+}

--- a/extension/src/nmost/max_float.rs
+++ b/extension/src/nmost/max_float.rs
@@ -1,0 +1,240 @@
+use pgx::{iter::SetOfIterator, *};
+
+use crate::nmost::*;
+
+use crate::{
+    flatten,
+    palloc::{Inner, Internal, InternalAsValue, ToInternal},
+    pg_type,
+    raw::bytea,
+    ron_inout_funcs,
+};
+
+use ordered_float::NotNan;
+use std::cmp::Reverse;
+
+type MaxFloatTransType = NMostTransState<Reverse<NotNan<f64>>>;
+
+#[pg_schema]
+pub mod toolkit_experimental {
+    use super::*;
+
+    pg_type! {
+        #[derive(Debug)]
+        struct MaxFloats <'input> {
+            capacity : u32,
+            elements : u32,
+            values : [f64; self.elements],
+        }
+    }
+    ron_inout_funcs!(MaxFloats);
+
+    impl<'input> From<&mut MaxFloatTransType> for MaxFloats<'input> {
+        fn from(item: &mut MaxFloatTransType) -> Self {
+            let heap = std::mem::take(&mut item.heap);
+            unsafe {
+                flatten!(MaxFloats {
+                    capacity: item.capacity as u32,
+                    elements: heap.len() as u32,
+                    values: heap
+                        .into_sorted_vec()
+                        .into_iter()
+                        .map(|x| f64::from(x.0))
+                        .collect::<Vec<f64>>()
+                        .into()
+                })
+            }
+        }
+    }
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_float_trans(
+    state: Internal,
+    value: f64,
+    capacity: i64,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    nmost_trans_function(
+        unsafe { state.to_inner::<MaxFloatTransType>() },
+        Reverse(NotNan::new(value).unwrap()),
+        capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_float_rollup_trans(
+    state: Internal,
+    value: toolkit_experimental::MaxFloats<'static>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    let values: Vec<Reverse<NotNan<f64>>> = value
+        .values
+        .clone()
+        .into_iter()
+        .map(|x| Reverse(NotNan::new(x).unwrap()))
+        .collect();
+    nmost_rollup_trans_function(
+        unsafe { state.to_inner::<MaxFloatTransType>() },
+        &values,
+        value.capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_float_combine(state1: Internal, state2: Internal) -> Option<Internal> {
+    nmost_trans_combine(unsafe { state1.to_inner::<MaxFloatTransType>() }, unsafe {
+        state2.to_inner::<MaxFloatTransType>()
+    })
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_float_serialize(state: Internal) -> bytea {
+    let state: Inner<MaxFloatTransType> = unsafe { state.to_inner().unwrap() };
+    crate::do_serialize!(state)
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_float_deserialize(bytes: bytea, _internal: Internal) -> Option<Internal> {
+    let i: MaxFloatTransType = crate::do_deserialize!(bytes, MaxFloatTransType);
+    Internal::new(i).into()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_float_final(state: Internal) -> toolkit_experimental::MaxFloats<'static> {
+    unsafe { &mut *state.to_inner::<MaxFloatTransType>().unwrap() }.into()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_array",
+    immutable,
+    parallel_safe
+)]
+pub fn max_n_float_to_array(agg: toolkit_experimental::MaxFloats<'static>) -> Vec<f64> {
+    agg.values.clone().into_vec()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_values",
+    immutable,
+    parallel_safe
+)]
+pub fn max_n_float_to_values(agg: toolkit_experimental::MaxFloats<'static>) -> SetOfIterator<f64> {
+    SetOfIterator::new(agg.values.clone().into_iter())
+}
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.max_n(\n\
+        value double precision, capacity bigint\n\
+    ) (\n\
+        sfunc = toolkit_experimental.max_n_float_trans,\n\
+        stype = internal,\n\
+        combinefunc = toolkit_experimental.max_n_float_combine,\n\
+        parallel = safe,\n\
+        serialfunc = toolkit_experimental.max_n_float_serialize,\n\
+        deserialfunc = toolkit_experimental.max_n_float_deserialize,\n\
+        finalfunc = toolkit_experimental.max_n_float_final\n\
+    );\n\
+",
+    name = "max_n_float",
+    requires = [
+        max_n_float_trans,
+        max_n_float_final,
+        max_n_float_combine,
+        max_n_float_serialize,
+        max_n_float_deserialize
+    ],
+);
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.rollup(\n\
+        value toolkit_experimental.MaxFloats\n\
+    ) (\n\
+        sfunc = toolkit_experimental.max_n_float_rollup_trans,\n\
+        stype = internal,\n\
+        combinefunc = toolkit_experimental.max_n_float_combine,\n\
+        parallel = safe,\n\
+        serialfunc = toolkit_experimental.max_n_float_serialize,\n\
+        deserialfunc = toolkit_experimental.max_n_float_deserialize,\n\
+        finalfunc = toolkit_experimental.max_n_float_final\n\
+    );\n\
+",
+    name = "max_n_float_rollup",
+    requires = [
+        max_n_float_rollup_trans,
+        max_n_float_final,
+        max_n_float_combine,
+        max_n_float_serialize,
+        max_n_float_deserialize
+    ],
+);
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+    use pgx_macros::pg_test;
+
+    #[pg_test]
+    fn max_float_correctness() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            client.select(
+                "CREATE TABLE data(val DOUBLE PRECISION, category INT)",
+                None,
+                None,
+            );
+
+            for i in 0..100 {
+                let i = (i * 83) % 100; // mess with the ordering just a little
+
+                client.select(
+                    &format!("INSERT INTO data VALUES ({}.0/128, {})", i, i % 4),
+                    None,
+                    None,
+                );
+            }
+
+            // Test into_array
+            let result =
+                client.select("SELECT toolkit_experimental.into_array(toolkit_experimental.max_n(val, 5)) from data",
+                    None, None,
+                ).first().get_one::<Vec<f64>>();
+            assert_eq!(
+                result.unwrap(),
+                vec![99. / 128., 98. / 128., 97. / 128., 96. / 128., 95. / 128.]
+            );
+
+            // Test into_values
+            let mut result =
+                client.select("SELECT toolkit_experimental.into_values(toolkit_experimental.max_n(val, 3))::TEXT from data",
+                    None, None,
+                );
+            assert_eq!(result.next().unwrap()[1].value(), Some("0.7734375"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("0.765625"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("0.7578125"));
+            assert!(result.next().is_none());
+
+            // Test rollup
+            let result =
+                client.select(
+                    "WITH aggs as (SELECT category, toolkit_experimental.max_n(val, 5) as agg from data GROUP BY category)
+                        SELECT toolkit_experimental.into_array(toolkit_experimental.rollup(agg)) FROM aggs",
+                        None, None,
+                    ).first().get_one::<Vec<f64>>();
+            assert_eq!(
+                result.unwrap(),
+                vec![99. / 128., 98. / 128., 97. / 128., 96. / 128., 95. / 128.]
+            );
+        })
+    }
+}

--- a/extension/src/nmost/max_int.rs
+++ b/extension/src/nmost/max_int.rs
@@ -1,0 +1,224 @@
+use pgx::{iter::SetOfIterator, *};
+
+use crate::nmost::*;
+
+use crate::{
+    flatten,
+    palloc::{Inner, Internal, InternalAsValue, ToInternal},
+    pg_type,
+    raw::bytea,
+    ron_inout_funcs,
+};
+
+use std::cmp::Reverse;
+
+type MaxIntTransType = NMostTransState<Reverse<i64>>;
+
+#[pg_schema]
+pub mod toolkit_experimental {
+    use super::*;
+
+    pg_type! {
+        #[derive(Debug)]
+        struct MaxInts <'input> {
+            capacity : u32,
+            elements : u32,
+            values : [i64; self.elements],
+        }
+    }
+    ron_inout_funcs!(MaxInts);
+
+    impl<'input> From<&mut MaxIntTransType> for MaxInts<'input> {
+        fn from(item: &mut MaxIntTransType) -> Self {
+            let heap = std::mem::take(&mut item.heap);
+            unsafe {
+                flatten!(MaxInts {
+                    capacity: item.capacity as u32,
+                    elements: heap.len() as u32,
+                    values: heap
+                        .into_sorted_vec()
+                        .into_iter()
+                        .map(|x| x.0)
+                        .collect::<Vec<i64>>()
+                        .into()
+                })
+            }
+        }
+    }
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_int_trans(
+    state: Internal,
+    value: i64,
+    capacity: i64,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    nmost_trans_function(
+        unsafe { state.to_inner::<MaxIntTransType>() },
+        Reverse(value),
+        capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_int_rollup_trans(
+    state: Internal,
+    value: toolkit_experimental::MaxInts<'static>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    let values: Vec<Reverse<i64>> = value.values.clone().into_iter().map(Reverse).collect();
+    nmost_rollup_trans_function(
+        unsafe { state.to_inner::<MaxIntTransType>() },
+        &values,
+        value.capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_int_combine(state1: Internal, state2: Internal) -> Option<Internal> {
+    nmost_trans_combine(unsafe { state1.to_inner::<MaxIntTransType>() }, unsafe {
+        state2.to_inner::<MaxIntTransType>()
+    })
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_int_serialize(state: Internal) -> bytea {
+    let state: Inner<MaxIntTransType> = unsafe { state.to_inner().unwrap() };
+    crate::do_serialize!(state)
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_int_deserialize(bytes: bytea, _internal: Internal) -> Option<Internal> {
+    let i: MaxIntTransType = crate::do_deserialize!(bytes, MaxIntTransType);
+    Internal::new(i).into()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_int_final(state: Internal) -> toolkit_experimental::MaxInts<'static> {
+    unsafe { &mut *state.to_inner::<MaxIntTransType>().unwrap() }.into()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_array",
+    immutable,
+    parallel_safe
+)]
+pub fn max_n_int_to_array(agg: toolkit_experimental::MaxInts<'static>) -> Vec<i64> {
+    agg.values.clone().into_vec()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_values",
+    immutable,
+    parallel_safe
+)]
+pub fn max_n_int_to_values(agg: toolkit_experimental::MaxInts<'static>) -> SetOfIterator<i64> {
+    SetOfIterator::new(agg.values.clone().into_iter())
+}
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.max_n(\n\
+        value bigint, capacity bigint\n\
+    ) (\n\
+        sfunc = toolkit_experimental.max_n_int_trans,\n\
+        stype = internal,\n\
+        combinefunc = toolkit_experimental.max_n_int_combine,\n\
+        parallel = safe,\n\
+        serialfunc = toolkit_experimental.max_n_int_serialize,\n\
+        deserialfunc = toolkit_experimental.max_n_int_deserialize,\n\
+        finalfunc = toolkit_experimental.max_n_int_final\n\
+    );\n\
+",
+    name = "max_n_int",
+    requires = [
+        max_n_int_trans,
+        max_n_int_final,
+        max_n_int_combine,
+        max_n_int_serialize,
+        max_n_int_deserialize
+    ],
+);
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.rollup(\n\
+        value toolkit_experimental.MaxInts\n\
+    ) (\n\
+        sfunc = toolkit_experimental.max_n_int_rollup_trans,\n\
+        stype = internal,\n\
+        combinefunc = toolkit_experimental.max_n_int_combine,\n\
+        parallel = safe,\n\
+        serialfunc = toolkit_experimental.max_n_int_serialize,\n\
+        deserialfunc = toolkit_experimental.max_n_int_deserialize,\n\
+        finalfunc = toolkit_experimental.max_n_int_final\n\
+    );\n\
+",
+    name = "max_n_int_rollup",
+    requires = [
+        max_n_int_rollup_trans,
+        max_n_int_final,
+        max_n_int_combine,
+        max_n_int_serialize,
+        max_n_int_deserialize
+    ],
+);
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+    use pgx_macros::pg_test;
+
+    #[pg_test]
+    fn max_int_correctness() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            client.select("CREATE TABLE data(val INT8, category INT)", None, None);
+
+            for i in 0..100 {
+                let i = (i * 83) % 100; // mess with the ordering just a little
+
+                client.select(
+                    &format!("INSERT INTO data VALUES ({}, {})", i, i % 4),
+                    None,
+                    None,
+                );
+            }
+
+            // Test into_array
+            let result =
+                client.select("SELECT toolkit_experimental.into_array(toolkit_experimental.max_n(val, 5)) from data",
+                    None, None,
+                ).first().get_one::<Vec<i64>>();
+            assert_eq!(result.unwrap(), vec![99, 98, 97, 96, 95]);
+
+            // Test into_values
+            let mut result =
+                client.select("SELECT toolkit_experimental.into_values(toolkit_experimental.max_n(val, 3))::TEXT from data",
+                    None, None,
+                );
+            assert_eq!(result.next().unwrap()[1].value(), Some("99"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("98"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("97"));
+            assert!(result.next().is_none());
+
+            // Test rollup
+            let result =
+                client.select(
+                    "WITH aggs as (SELECT category, toolkit_experimental.max_n(val, 5) as agg from data GROUP BY category)
+                        SELECT toolkit_experimental.into_array(toolkit_experimental.rollup(agg)) FROM aggs",
+                        None, None,
+                    ).first().get_one::<Vec<i64>>();
+            assert_eq!(result.unwrap(), vec![99, 98, 97, 96, 95]);
+        })
+    }
+}

--- a/extension/src/nmost/max_time.rs
+++ b/extension/src/nmost/max_time.rs
@@ -1,0 +1,251 @@
+use pgx::{iter::SetOfIterator, *};
+
+use crate::nmost::*;
+
+use crate::{
+    flatten,
+    palloc::{Inner, Internal, InternalAsValue, ToInternal},
+    pg_type,
+    raw::bytea,
+    ron_inout_funcs,
+};
+
+use std::cmp::Reverse;
+
+type MaxTimeTransType = NMostTransState<Reverse<pg_sys::TimestampTz>>;
+
+#[pg_schema]
+pub mod toolkit_experimental {
+    use super::*;
+
+    pg_type! {
+        #[derive(Debug)]
+        struct MaxTimes <'input> {
+            capacity : u32,
+            elements : u32,
+            values : [pg_sys::TimestampTz; self.elements],
+        }
+    }
+    ron_inout_funcs!(MaxTimes);
+
+    impl<'input> From<&mut MaxTimeTransType> for MaxTimes<'input> {
+        fn from(item: &mut MaxTimeTransType) -> Self {
+            let heap = std::mem::take(&mut item.heap);
+            unsafe {
+                flatten!(MaxTimes {
+                    capacity: item.capacity as u32,
+                    elements: heap.len() as u32,
+                    values: heap
+                        .into_sorted_vec()
+                        .into_iter()
+                        .map(|x| x.0)
+                        .collect::<Vec<pg_sys::TimestampTz>>()
+                        .into()
+                })
+            }
+        }
+    }
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_time_trans(
+    state: Internal,
+    value: crate::raw::TimestampTz,
+    capacity: i64,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    nmost_trans_function(
+        unsafe { state.to_inner::<MaxTimeTransType>() },
+        Reverse(value.into()),
+        capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_time_rollup_trans(
+    state: Internal,
+    value: toolkit_experimental::MaxTimes<'static>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    let values: Vec<Reverse<pg_sys::TimestampTz>> =
+        value.values.clone().into_iter().map(Reverse).collect();
+    nmost_rollup_trans_function(
+        unsafe { state.to_inner::<MaxTimeTransType>() },
+        &values,
+        value.capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_time_combine(state1: Internal, state2: Internal) -> Option<Internal> {
+    nmost_trans_combine(unsafe { state1.to_inner::<MaxTimeTransType>() }, unsafe {
+        state2.to_inner::<MaxTimeTransType>()
+    })
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_time_serialize(state: Internal) -> bytea {
+    let state: Inner<MaxTimeTransType> = unsafe { state.to_inner().unwrap() };
+    crate::do_serialize!(state)
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_time_deserialize(bytes: bytea, _internal: Internal) -> Option<Internal> {
+    let i: MaxTimeTransType = crate::do_deserialize!(bytes, MaxTimeTransType);
+    Internal::new(i).into()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn max_n_time_final(state: Internal) -> toolkit_experimental::MaxTimes<'static> {
+    unsafe { &mut *state.to_inner::<MaxTimeTransType>().unwrap() }.into()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_array",
+    immutable,
+    parallel_safe
+)]
+pub fn max_n_time_to_array(
+    agg: toolkit_experimental::MaxTimes<'static>,
+) -> Vec<crate::raw::TimestampTz> {
+    agg.values
+        .clone()
+        .into_iter()
+        .map(crate::raw::TimestampTz::from)
+        .collect()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_values",
+    immutable,
+    parallel_safe
+)]
+pub fn max_n_time_to_values(
+    agg: toolkit_experimental::MaxTimes<'static>,
+) -> SetOfIterator<crate::raw::TimestampTz> {
+    SetOfIterator::new(
+        agg.values
+            .clone()
+            .into_iter()
+            .map(crate::raw::TimestampTz::from),
+    )
+}
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.max_n(\n\
+        value timestamptz, capacity bigint\n\
+    ) (\n\
+        sfunc = toolkit_experimental.max_n_time_trans,\n\
+        stype = internal,\n\
+        combinefunc = toolkit_experimental.max_n_time_combine,\n\
+        parallel = safe,\n\
+        serialfunc = toolkit_experimental.max_n_time_serialize,\n\
+        deserialfunc = toolkit_experimental.max_n_time_deserialize,\n\
+        finalfunc = toolkit_experimental.max_n_time_final\n\
+    );\n\
+",
+    name = "max_n_time",
+    requires = [
+        max_n_time_trans,
+        max_n_time_final,
+        max_n_time_combine,
+        max_n_time_serialize,
+        max_n_time_deserialize
+    ],
+);
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.rollup(\n\
+        value toolkit_experimental.MaxTimes\n\
+    ) (\n\
+        sfunc = toolkit_experimental.max_n_time_rollup_trans,\n\
+        stype = internal,\n\
+        combinefunc = toolkit_experimental.max_n_time_combine,\n\
+        parallel = safe,\n\
+        serialfunc = toolkit_experimental.max_n_time_serialize,\n\
+        deserialfunc = toolkit_experimental.max_n_time_deserialize,\n\
+        finalfunc = toolkit_experimental.max_n_time_final\n\
+    );\n\
+",
+    name = "max_n_time_rollup",
+    requires = [
+        max_n_time_rollup_trans,
+        max_n_time_final,
+        max_n_time_combine,
+        max_n_time_serialize,
+        max_n_time_deserialize
+    ],
+);
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+    use pgx_macros::pg_test;
+
+    #[pg_test]
+    fn max_time_correctness() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            client.select(
+                "CREATE TABLE data(val TIMESTAMPTZ, category INT)",
+                None,
+                None,
+            );
+
+            for i in 0..100 {
+                let i = (i * 83) % 100; // mess with the ordering just a little
+
+                client.select(
+                    &format!("INSERT INTO data VALUES ('2020-1-1 UTC'::timestamptz + {} * '1d'::interval, {})", i, i % 4),
+                    None,
+                    None,
+                );
+            }
+
+            // Test into_array
+            let result =
+                client.select("SELECT toolkit_experimental.into_array(toolkit_experimental.max_n(val, 5))::TEXT from data",
+                    None, None,
+                ).first().get_one::<&str>();
+            assert_eq!(result.unwrap(), "{\"2020-04-09 00:00:00+00\",\"2020-04-08 00:00:00+00\",\"2020-04-07 00:00:00+00\",\"2020-04-06 00:00:00+00\",\"2020-04-05 00:00:00+00\"}");
+
+            // Test into_values
+            let mut result =
+                client.select("SELECT toolkit_experimental.into_values(toolkit_experimental.max_n(val, 3))::TEXT from data",
+                    None, None,
+                );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("2020-04-09 00:00:00+00")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("2020-04-08 00:00:00+00")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("2020-04-07 00:00:00+00")
+            );
+            assert!(result.next().is_none());
+
+            // Test rollup
+            let result =
+                client.select(
+                    "WITH aggs as (SELECT category, toolkit_experimental.max_n(val, 5) as agg from data GROUP BY category)
+                        SELECT toolkit_experimental.into_array(toolkit_experimental.rollup(agg))::TEXT FROM aggs",
+                        None, None,
+                    ).first().get_one::<&str>();
+            assert_eq!(result.unwrap(), "{\"2020-04-09 00:00:00+00\",\"2020-04-08 00:00:00+00\",\"2020-04-07 00:00:00+00\",\"2020-04-06 00:00:00+00\",\"2020-04-05 00:00:00+00\"}");
+        })
+    }
+}

--- a/extension/src/nmost/min_by_float.rs
+++ b/extension/src/nmost/min_by_float.rs
@@ -1,0 +1,213 @@
+use pgx::{iter::TableIterator, *};
+
+use crate::nmost::min_float::toolkit_experimental::*;
+use crate::nmost::*;
+
+use crate::{
+    build, flatten,
+    palloc::{Internal, InternalAsValue, ToInternal},
+    pg_type, ron_inout_funcs,
+};
+
+use ordered_float::NotNan;
+
+type MinByFloatTransType = NMostByTransState<NotNan<f64>>;
+
+#[pg_schema]
+pub mod toolkit_experimental {
+    use super::*;
+
+    pg_type! {
+        #[derive(Debug)]
+        struct MinByFloats<'input> {
+            values: MinFloatsData<'input>,  // Nesting pg_types adds 8 bytes of header
+            data: DatumStore<'input>,
+        }
+    }
+    ron_inout_funcs!(MinByFloats);
+
+    impl<'input> From<MinByFloatTransType> for MinByFloats<'input> {
+        fn from(item: MinByFloatTransType) -> Self {
+            let (capacity, val_ary, data) = item.into_sorted_parts();
+            unsafe {
+                flatten!(MinByFloats {
+                    values: build!(MinFloats {
+                        capacity: capacity as u32,
+                        elements: val_ary.len() as u32,
+                        values: val_ary
+                            .into_iter()
+                            .map(f64::from)
+                            .collect::<Vec<f64>>()
+                            .into()
+                    })
+                    .0,
+                    data,
+                })
+            }
+        }
+    }
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_by_float_trans(
+    state: Internal,
+    value: f64,
+    data: AnyElement,
+    capacity: i64,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    nmost_by_trans_function(
+        unsafe { state.to_inner::<MinByFloatTransType>() },
+        NotNan::new(value).unwrap(),
+        data,
+        capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_by_float_rollup_trans(
+    state: Internal,
+    value: toolkit_experimental::MinByFloats<'static>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    let values: Vec<NotNan<f64>> = value
+        .values
+        .values
+        .clone()
+        .into_iter()
+        .map(|x| NotNan::new(x).unwrap())
+        .collect();
+    nmost_by_rollup_trans_function(
+        unsafe { state.to_inner::<MinByFloatTransType>() },
+        &values,
+        &value.data,
+        value.values.capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_by_float_final(state: Internal) -> toolkit_experimental::MinByFloats<'static> {
+    unsafe { state.to_inner::<MinByFloatTransType>().unwrap().clone() }.into()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_values",
+    immutable,
+    parallel_safe
+)]
+pub fn min_n_by_float_to_values(
+    agg: toolkit_experimental::MinByFloats<'static>,
+    _dummy: Option<AnyElement>,
+) -> TableIterator<'static, (name!(value, f64), name!(data, AnyElement))> {
+    TableIterator::new(
+        agg.values
+            .values
+            .clone()
+            .into_iter()
+            .zip(agg.data.clone().into_anyelement_iter()),
+    )
+}
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.min_n_by(\n\
+        value double precision, data AnyElement, capacity bigint\n\
+    ) (\n\
+        sfunc = toolkit_experimental.min_n_by_float_trans,\n\
+        stype = internal,\n\
+        finalfunc = toolkit_experimental.min_n_by_float_final\n\
+    );\n\
+",
+    name = "min_n_by_float",
+    requires = [min_n_by_float_trans, min_n_by_float_final],
+);
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.rollup(\n\
+        toolkit_experimental.MinByFloats\n\
+    ) (\n\
+        sfunc = toolkit_experimental.min_n_by_float_rollup_trans,\n\
+        stype = internal,\n\
+        finalfunc = toolkit_experimental.min_n_by_float_final\n\
+    );\n\
+",
+    name = "min_n_by_float_rollup",
+    requires = [min_n_by_float_rollup_trans, min_n_by_float_final],
+);
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+    use pgx_macros::pg_test;
+
+    #[pg_test]
+    fn min_by_float_correctness() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            client.select(
+                "CREATE TABLE data(val DOUBLE PRECISION, category INT)",
+                None,
+                None,
+            );
+
+            for i in 0..100 {
+                let i = (i * 83) % 100; // mess with the ordering just a little
+
+                client.select(
+                    &format!("INSERT INTO data VALUES ({}.0/128, {})", i, i % 4),
+                    None,
+                    None,
+                );
+            }
+
+            // Test into_values
+            let mut result =
+                client.select("SELECT toolkit_experimental.into_values(toolkit_experimental.min_n_by(val, data, 3), NULL::data)::TEXT from data",
+                    None, None,
+                );
+            assert_eq!(result.next().unwrap()[1].value(), Some("(0,\"(0,0)\")"));
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(0.0078125,\"(0.0078125,1)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(0.015625,\"(0.015625,2)\")")
+            );
+            assert!(result.next().is_none());
+
+            // Test rollup
+            let mut result =
+                client.select(
+                    "WITH aggs as (SELECT category, toolkit_experimental.min_n_by(val, data, 5) as agg from data GROUP BY category)
+                        SELECT toolkit_experimental.into_values(toolkit_experimental.rollup(agg), NULL::data)::TEXT FROM aggs",
+                        None, None,
+                    );
+            assert_eq!(result.next().unwrap()[1].value(), Some("(0,\"(0,0)\")"));
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(0.0078125,\"(0.0078125,1)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(0.015625,\"(0.015625,2)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(0.0234375,\"(0.0234375,3)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(0.03125,\"(0.03125,0)\")")
+            );
+            assert!(result.next().is_none());
+        })
+    }
+}

--- a/extension/src/nmost/min_by_int.rs
+++ b/extension/src/nmost/min_by_int.rs
@@ -1,0 +1,178 @@
+use pgx::{iter::TableIterator, *};
+
+use crate::nmost::min_int::toolkit_experimental::*;
+use crate::nmost::*;
+
+use crate::{
+    build, flatten,
+    palloc::{Internal, InternalAsValue, ToInternal},
+    pg_type, ron_inout_funcs,
+};
+
+type MinByIntTransType = NMostByTransState<i64>;
+
+#[pg_schema]
+pub mod toolkit_experimental {
+    use super::*;
+
+    pg_type! {
+        #[derive(Debug)]
+        struct MinByInts<'input> {
+            values: MinIntsData<'input>,  // Nesting pg_types adds 8 bytes of header
+            data: DatumStore<'input>,
+        }
+    }
+    ron_inout_funcs!(MinByInts);
+
+    impl<'input> From<MinByIntTransType> for MinByInts<'input> {
+        fn from(item: MinByIntTransType) -> Self {
+            let (capacity, val_ary, data) = item.into_sorted_parts();
+            unsafe {
+                flatten!(MinByInts {
+                    values: build!(MinInts {
+                        capacity: capacity as u32,
+                        elements: val_ary.len() as u32,
+                        values: val_ary.into()
+                    })
+                    .0,
+                    data,
+                })
+            }
+        }
+    }
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_by_int_trans(
+    state: Internal,
+    value: i64,
+    data: AnyElement,
+    capacity: i64,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    nmost_by_trans_function(
+        unsafe { state.to_inner::<MinByIntTransType>() },
+        value,
+        data,
+        capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_by_int_rollup_trans(
+    state: Internal,
+    value: toolkit_experimental::MinByInts<'static>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    nmost_by_rollup_trans_function(
+        unsafe { state.to_inner::<MinByIntTransType>() },
+        value.values.values.as_slice(),
+        &value.data,
+        value.values.capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_by_int_final(state: Internal) -> toolkit_experimental::MinByInts<'static> {
+    unsafe { state.to_inner::<MinByIntTransType>().unwrap().clone() }.into()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_values",
+    immutable,
+    parallel_safe
+)]
+pub fn min_n_by_int_to_values(
+    agg: toolkit_experimental::MinByInts<'static>,
+    _dummy: Option<AnyElement>,
+) -> TableIterator<'static, (name!(value, i64), name!(data, AnyElement))> {
+    TableIterator::new(
+        agg.values
+            .values
+            .clone()
+            .into_iter()
+            .zip(agg.data.clone().into_anyelement_iter()),
+    )
+}
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.min_n_by(\n\
+        value bigint, data AnyElement, capacity bigint\n\
+    ) (\n\
+        sfunc = toolkit_experimental.min_n_by_int_trans,\n\
+        stype = internal,\n\
+        finalfunc = toolkit_experimental.min_n_by_int_final\n\
+    );\n\
+",
+    name = "min_n_by_int",
+    requires = [min_n_by_int_trans, min_n_by_int_final],
+);
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.rollup(\n\
+        toolkit_experimental.MinByInts\n\
+    ) (\n\
+        sfunc = toolkit_experimental.min_n_by_int_rollup_trans,\n\
+        stype = internal,\n\
+        finalfunc = toolkit_experimental.min_n_by_int_final\n\
+    );\n\
+",
+    name = "min_n_by_int_rollup",
+    requires = [min_n_by_int_rollup_trans, min_n_by_int_final],
+);
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+    use pgx_macros::pg_test;
+
+    #[pg_test]
+    fn min_by_int_correctness() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            client.select("CREATE TABLE data(val INT8, category INT)", None, None);
+
+            for i in 0..100 {
+                let i = (i * 83) % 100; // mess with the ordering just a little
+
+                client.select(
+                    &format!("INSERT INTO data VALUES ({}, {})", i, i % 4),
+                    None,
+                    None,
+                );
+            }
+
+            // Test into_values
+            let mut result =
+                client.select("SELECT toolkit_experimental.into_values(toolkit_experimental.min_n_by(val, data, 3), NULL::data)::TEXT from data",
+                    None, None,
+                );
+            assert_eq!(result.next().unwrap()[1].value(), Some("(0,\"(0,0)\")"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("(1,\"(1,1)\")"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("(2,\"(2,2)\")"));
+            assert!(result.next().is_none());
+
+            // Test rollup
+            let mut result =
+                client.select(
+                    "WITH aggs as (SELECT category, toolkit_experimental.min_n_by(val, data, 5) as agg from data GROUP BY category)
+                        SELECT toolkit_experimental.into_values(toolkit_experimental.rollup(agg), NULL::data)::TEXT FROM aggs",
+                        None, None,
+                    );
+            assert_eq!(result.next().unwrap()[1].value(), Some("(0,\"(0,0)\")"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("(1,\"(1,1)\")"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("(2,\"(2,2)\")"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("(3,\"(3,3)\")"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("(4,\"(4,0)\")"));
+            assert!(result.next().is_none());
+        })
+    }
+}

--- a/extension/src/nmost/min_by_time.rs
+++ b/extension/src/nmost/min_by_time.rs
@@ -1,0 +1,213 @@
+use pgx::{iter::TableIterator, *};
+
+use crate::nmost::min_time::toolkit_experimental::*;
+use crate::nmost::*;
+
+use crate::{
+    build, flatten,
+    palloc::{Internal, InternalAsValue, ToInternal},
+    pg_type, ron_inout_funcs,
+};
+
+type MinByTimeTransType = NMostByTransState<pg_sys::TimestampTz>;
+
+#[pg_schema]
+pub mod toolkit_experimental {
+    use super::*;
+
+    pg_type! {
+        #[derive(Debug)]
+        struct MinByTimes<'input> {
+            values: MinTimesData<'input>,  // Nesting pg_types adds 8 bytes of header
+            data: DatumStore<'input>,
+        }
+    }
+    ron_inout_funcs!(MinByTimes);
+
+    impl<'input> From<MinByTimeTransType> for MinByTimes<'input> {
+        fn from(item: MinByTimeTransType) -> Self {
+            let (capacity, val_ary, data) = item.into_sorted_parts();
+            unsafe {
+                flatten!(MinByTimes {
+                    values: build!(MinTimes {
+                        capacity: capacity as u32,
+                        elements: val_ary.len() as u32,
+                        values: val_ary.into()
+                    })
+                    .0,
+                    data,
+                })
+            }
+        }
+    }
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_by_time_trans(
+    state: Internal,
+    value: crate::raw::TimestampTz,
+    data: AnyElement,
+    capacity: i64,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    nmost_by_trans_function(
+        unsafe { state.to_inner::<MinByTimeTransType>() },
+        value.into(),
+        data,
+        capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_by_time_rollup_trans(
+    state: Internal,
+    value: toolkit_experimental::MinByTimes<'static>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    nmost_by_rollup_trans_function(
+        unsafe { state.to_inner::<MinByTimeTransType>() },
+        value.values.values.as_slice(),
+        &value.data,
+        value.values.capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_by_time_final(state: Internal) -> toolkit_experimental::MinByTimes<'static> {
+    unsafe { state.to_inner::<MinByTimeTransType>().unwrap().clone() }.into()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_values",
+    immutable,
+    parallel_safe
+)]
+pub fn min_n_by_time_to_values(
+    agg: toolkit_experimental::MinByTimes<'static>,
+    _dummy: Option<AnyElement>,
+) -> TableIterator<
+    'static,
+    (
+        name!(value, crate::raw::TimestampTz),
+        name!(data, AnyElement),
+    ),
+> {
+    TableIterator::new(
+        agg.values
+            .values
+            .clone()
+            .into_iter()
+            .map(crate::raw::TimestampTz::from)
+            .zip(agg.data.clone().into_anyelement_iter()),
+    )
+}
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.min_n_by(\n\
+        value timestamptz, data AnyElement, capacity bigint\n\
+    ) (\n\
+        sfunc = toolkit_experimental.min_n_by_time_trans,\n\
+        stype = internal,\n\
+        finalfunc = toolkit_experimental.min_n_by_time_final\n\
+    );\n\
+",
+    name = "min_n_by_time",
+    requires = [min_n_by_time_trans, min_n_by_time_final],
+);
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.rollup(\n\
+        toolkit_experimental.MinByTimes\n\
+    ) (\n\
+        sfunc = toolkit_experimental.min_n_by_time_rollup_trans,\n\
+        stype = internal,\n\
+        finalfunc = toolkit_experimental.min_n_by_time_final\n\
+    );\n\
+",
+    name = "min_n_by_time_rollup",
+    requires = [min_n_by_time_rollup_trans, min_n_by_time_final],
+);
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+    use pgx_macros::pg_test;
+
+    #[pg_test]
+    fn min_by_time_correctness() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            client.select(
+                "CREATE TABLE data(val TIMESTAMPTZ, category INT)",
+                None,
+                None,
+            );
+
+            for i in 0..100 {
+                let i = (i * 83) % 100; // mess with the ordering just a little
+
+                client.select(
+                    &format!("INSERT INTO data VALUES ('2020-1-1 UTC'::timestamptz + {} * '1d'::interval, {})", i, i % 4),
+                    None,
+                    None,
+                );
+            }
+
+            // Test into_values
+            let mut result =
+                client.select("SELECT toolkit_experimental.into_values(toolkit_experimental.min_n_by(val, data, 3), NULL::data)::TEXT from data",
+                    None, None,
+                );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(\"2020-01-01 00:00:00+00\",\"(\"\"2020-01-01 00:00:00+00\"\",0)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(\"2020-01-02 00:00:00+00\",\"(\"\"2020-01-02 00:00:00+00\"\",1)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(\"2020-01-03 00:00:00+00\",\"(\"\"2020-01-03 00:00:00+00\"\",2)\")")
+            );
+            assert!(result.next().is_none());
+
+            // Test rollup
+            let mut result =
+                client.select(
+                    "WITH aggs as (SELECT category, toolkit_experimental.min_n_by(val, data, 5) as agg from data GROUP BY category)
+                        SELECT toolkit_experimental.into_values(toolkit_experimental.rollup(agg), NULL::data)::TEXT FROM aggs",
+                        None, None,
+                    );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(\"2020-01-01 00:00:00+00\",\"(\"\"2020-01-01 00:00:00+00\"\",0)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(\"2020-01-02 00:00:00+00\",\"(\"\"2020-01-02 00:00:00+00\"\",1)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(\"2020-01-03 00:00:00+00\",\"(\"\"2020-01-03 00:00:00+00\"\",2)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(\"2020-01-04 00:00:00+00\",\"(\"\"2020-01-04 00:00:00+00\"\",3)\")")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("(\"2020-01-05 00:00:00+00\",\"(\"\"2020-01-05 00:00:00+00\"\",0)\")")
+            );
+            assert!(result.next().is_none());
+        })
+    }
+}

--- a/extension/src/nmost/min_float.rs
+++ b/extension/src/nmost/min_float.rs
@@ -1,0 +1,239 @@
+use pgx::{iter::SetOfIterator, *};
+
+use crate::nmost::*;
+
+use crate::{
+    flatten,
+    palloc::{Inner, Internal, InternalAsValue, ToInternal},
+    pg_type,
+    raw::bytea,
+    ron_inout_funcs,
+};
+
+use ordered_float::NotNan;
+
+type MinFloatTransType = NMostTransState<NotNan<f64>>;
+
+#[pg_schema]
+pub mod toolkit_experimental {
+    use super::*;
+
+    pg_type! {
+        #[derive(Debug)]
+        struct MinFloats <'input> {
+            capacity : u32,
+            elements : u32,
+            values : [f64; self.elements],
+        }
+    }
+    ron_inout_funcs!(MinFloats);
+
+    impl<'input> From<&mut MinFloatTransType> for MinFloats<'input> {
+        fn from(item: &mut MinFloatTransType) -> Self {
+            let heap = std::mem::take(&mut item.heap);
+            unsafe {
+                flatten!(MinFloats {
+                    capacity: item.capacity as u32,
+                    elements: heap.len() as u32,
+                    values: heap
+                        .into_sorted_vec()
+                        .into_iter()
+                        .map(f64::from)
+                        .collect::<Vec<f64>>()
+                        .into()
+                })
+            }
+        }
+    }
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_float_trans(
+    state: Internal,
+    value: f64,
+    capacity: i64,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    nmost_trans_function(
+        unsafe { state.to_inner::<MinFloatTransType>() },
+        NotNan::new(value).unwrap(),
+        capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_float_rollup_trans(
+    state: Internal,
+    value: toolkit_experimental::MinFloats<'static>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    let values: Vec<NotNan<f64>> = value
+        .values
+        .clone()
+        .into_iter()
+        .map(|x| NotNan::new(x).unwrap())
+        .collect();
+    nmost_rollup_trans_function(
+        unsafe { state.to_inner::<MinFloatTransType>() },
+        &values,
+        value.capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_float_combine(state1: Internal, state2: Internal) -> Option<Internal> {
+    nmost_trans_combine(unsafe { state1.to_inner::<MinFloatTransType>() }, unsafe {
+        state2.to_inner::<MinFloatTransType>()
+    })
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_float_serialize(state: Internal) -> bytea {
+    let state: Inner<MinFloatTransType> = unsafe { state.to_inner().unwrap() };
+    crate::do_serialize!(state)
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_float_deserialize(bytes: bytea, _internal: Internal) -> Option<Internal> {
+    let i: MinFloatTransType = crate::do_deserialize!(bytes, MinFloatTransType);
+    Internal::new(i).into()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_float_final(state: Internal) -> toolkit_experimental::MinFloats<'static> {
+    unsafe { &mut *state.to_inner::<MinFloatTransType>().unwrap() }.into()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_array",
+    immutable,
+    parallel_safe
+)]
+pub fn min_n_float_to_array(agg: toolkit_experimental::MinFloats<'static>) -> Vec<f64> {
+    agg.values.clone().into_vec()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_values",
+    immutable,
+    parallel_safe
+)]
+pub fn min_n_float_to_values(agg: toolkit_experimental::MinFloats<'static>) -> SetOfIterator<f64> {
+    SetOfIterator::new(agg.values.clone().into_iter())
+}
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.min_n(\n\
+        value double precision, capacity bigint\n\
+    ) (\n\
+        sfunc = toolkit_experimental.min_n_float_trans,\n\
+        stype = internal,\n\
+        combinefunc = toolkit_experimental.min_n_float_combine,\n\
+        parallel = safe,\n\
+        serialfunc = toolkit_experimental.min_n_float_serialize,\n\
+        deserialfunc = toolkit_experimental.min_n_float_deserialize,\n\
+        finalfunc = toolkit_experimental.min_n_float_final\n\
+    );\n\
+",
+    name = "min_n_float",
+    requires = [
+        min_n_float_trans,
+        min_n_float_final,
+        min_n_float_combine,
+        min_n_float_serialize,
+        min_n_float_deserialize
+    ],
+);
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.rollup(\n\
+        value toolkit_experimental.MinFloats\n\
+    ) (\n\
+        sfunc = toolkit_experimental.min_n_float_rollup_trans,\n\
+        stype = internal,\n\
+        combinefunc = toolkit_experimental.min_n_float_combine,\n\
+        parallel = safe,\n\
+        serialfunc = toolkit_experimental.min_n_float_serialize,\n\
+        deserialfunc = toolkit_experimental.min_n_float_deserialize,\n\
+        finalfunc = toolkit_experimental.min_n_float_final\n\
+    );\n\
+",
+    name = "min_n_float_rollup",
+    requires = [
+        min_n_float_rollup_trans,
+        min_n_float_final,
+        min_n_float_combine,
+        min_n_float_serialize,
+        min_n_float_deserialize
+    ],
+);
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+    use pgx_macros::pg_test;
+
+    #[pg_test]
+    fn min_float_correctness() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            client.select(
+                "CREATE TABLE data(val DOUBLE PRECISION, category INT)",
+                None,
+                None,
+            );
+
+            for i in 0..100 {
+                let i = (i * 83) % 100; // mess with the ordering just a little
+
+                client.select(
+                    &format!("INSERT INTO data VALUES ({}.0/128, {})", i, i % 4),
+                    None,
+                    None,
+                );
+            }
+
+            // Test into_array
+            let result =
+                client.select("SELECT toolkit_experimental.into_array(toolkit_experimental.min_n(val, 5)) from data",
+                    None, None,
+                ).first().get_one::<Vec<f64>>();
+            assert_eq!(
+                result.unwrap(),
+                vec![0. / 128., 1. / 128., 2. / 128., 3. / 128., 4. / 128.]
+            );
+
+            // Test into_values
+            let mut result =
+                client.select("SELECT toolkit_experimental.into_values(toolkit_experimental.min_n(val, 3))::TEXT from data",
+                    None, None,
+                );
+            assert_eq!(result.next().unwrap()[1].value(), Some("0"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("0.0078125"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("0.015625"));
+            assert!(result.next().is_none());
+
+            // Test rollup
+            let result =
+                client.select(
+                    "WITH aggs as (SELECT category, toolkit_experimental.min_n(val, 5) as agg from data GROUP BY category)
+                        SELECT toolkit_experimental.into_array(toolkit_experimental.rollup(agg)) FROM aggs",
+                        None, None,
+                    ).first().get_one::<Vec<f64>>();
+            assert_eq!(
+                result.unwrap(),
+                vec![0. / 128., 1. / 128., 2. / 128., 3. / 128., 4. / 128.]
+            );
+        })
+    }
+}

--- a/extension/src/nmost/min_int.rs
+++ b/extension/src/nmost/min_int.rs
@@ -1,0 +1,216 @@
+use pgx::{iter::SetOfIterator, *};
+
+use crate::nmost::*;
+
+use crate::{
+    flatten,
+    palloc::{Inner, Internal, InternalAsValue, ToInternal},
+    pg_type,
+    raw::bytea,
+    ron_inout_funcs,
+};
+
+type MinIntTransType = NMostTransState<i64>;
+
+#[pg_schema]
+pub mod toolkit_experimental {
+    use super::*;
+
+    pg_type! {
+        #[derive(Debug)]
+        struct MinInts <'input> {
+            capacity : u32,
+            elements : u32,
+            values : [i64; self.elements],
+        }
+    }
+    ron_inout_funcs!(MinInts);
+
+    impl<'input> From<&mut MinIntTransType> for MinInts<'input> {
+        fn from(item: &mut MinIntTransType) -> Self {
+            let heap = std::mem::take(&mut item.heap);
+            unsafe {
+                flatten!(MinInts {
+                    capacity: item.capacity as u32,
+                    elements: heap.len() as u32,
+                    values: heap.into_sorted_vec().into()
+                })
+            }
+        }
+    }
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_int_trans(
+    state: Internal,
+    value: i64,
+    capacity: i64,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    nmost_trans_function(
+        unsafe { state.to_inner::<MinIntTransType>() },
+        value,
+        capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_int_rollup_trans(
+    state: Internal,
+    value: toolkit_experimental::MinInts<'static>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    nmost_rollup_trans_function(
+        unsafe { state.to_inner::<MinIntTransType>() },
+        value.values.as_slice(),
+        value.capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_int_combine(state1: Internal, state2: Internal) -> Option<Internal> {
+    nmost_trans_combine(unsafe { state1.to_inner::<MinIntTransType>() }, unsafe {
+        state2.to_inner::<MinIntTransType>()
+    })
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_int_serialize(state: Internal) -> bytea {
+    let state: Inner<MinIntTransType> = unsafe { state.to_inner().unwrap() };
+    crate::do_serialize!(state)
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_int_deserialize(bytes: bytea, _internal: Internal) -> Option<Internal> {
+    let i: MinIntTransType = crate::do_deserialize!(bytes, MinIntTransType);
+    Internal::new(i).into()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_int_final(state: Internal) -> toolkit_experimental::MinInts<'static> {
+    unsafe { &mut *state.to_inner::<MinIntTransType>().unwrap() }.into()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_array",
+    immutable,
+    parallel_safe
+)]
+pub fn min_n_int_to_array(agg: toolkit_experimental::MinInts<'static>) -> Vec<i64> {
+    agg.values.clone().into_vec()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_values",
+    immutable,
+    parallel_safe
+)]
+pub fn min_n_int_to_values(agg: toolkit_experimental::MinInts<'static>) -> SetOfIterator<i64> {
+    SetOfIterator::new(agg.values.clone().into_iter())
+}
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.min_n(\n\
+        value bigint, capacity bigint\n\
+    ) (\n\
+        sfunc = toolkit_experimental.min_n_int_trans,\n\
+        stype = internal,\n\
+        combinefunc = toolkit_experimental.min_n_int_combine,\n\
+        parallel = safe,\n\
+        serialfunc = toolkit_experimental.min_n_int_serialize,\n\
+        deserialfunc = toolkit_experimental.min_n_int_deserialize,\n\
+        finalfunc = toolkit_experimental.min_n_int_final\n\
+    );\n\
+",
+    name = "min_n_int",
+    requires = [
+        min_n_int_trans,
+        min_n_int_final,
+        min_n_int_combine,
+        min_n_int_serialize,
+        min_n_int_deserialize
+    ],
+);
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.rollup(\n\
+        value toolkit_experimental.MinInts\n\
+    ) (\n\
+        sfunc = toolkit_experimental.min_n_int_rollup_trans,\n\
+        stype = internal,\n\
+        combinefunc = toolkit_experimental.min_n_int_combine,\n\
+        parallel = safe,\n\
+        serialfunc = toolkit_experimental.min_n_int_serialize,\n\
+        deserialfunc = toolkit_experimental.min_n_int_deserialize,\n\
+        finalfunc = toolkit_experimental.min_n_int_final\n\
+    );\n\
+",
+    name = "min_n_int_rollup",
+    requires = [
+        min_n_int_rollup_trans,
+        min_n_int_final,
+        min_n_int_combine,
+        min_n_int_serialize,
+        min_n_int_deserialize
+    ],
+);
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+    use pgx_macros::pg_test;
+
+    #[pg_test]
+    fn min_int_correctness() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            client.select("CREATE TABLE data(val INT8, category INT)", None, None);
+
+            for i in 0..100 {
+                let i = (i * 83) % 100; // mess with the ordering just a little
+
+                client.select(
+                    &format!("INSERT INTO data VALUES ({}, {})", i, i % 4),
+                    None,
+                    None,
+                );
+            }
+
+            // Test into_array
+            let result =
+                client.select("SELECT toolkit_experimental.into_array(toolkit_experimental.min_n(val, 5)) from data",
+                    None, None,
+                ).first().get_one::<Vec<i64>>();
+            assert_eq!(result.unwrap(), vec![0, 1, 2, 3, 4]);
+
+            // Test into_values
+            let mut result =
+                client.select("SELECT toolkit_experimental.into_values(toolkit_experimental.min_n(val, 3))::TEXT from data",
+                    None, None,
+                );
+            assert_eq!(result.next().unwrap()[1].value(), Some("0"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("1"));
+            assert_eq!(result.next().unwrap()[1].value(), Some("2"));
+            assert!(result.next().is_none());
+
+            // Test rollup
+            let result =
+                client.select(
+                    "WITH aggs as (SELECT category, toolkit_experimental.min_n(val, 5) as agg from data GROUP BY category)
+                        SELECT toolkit_experimental.into_array(toolkit_experimental.rollup(agg)) FROM aggs",
+                        None, None,
+                    ).first().get_one::<Vec<i64>>();
+            assert_eq!(result.unwrap(), vec![0, 1, 2, 3, 4]);
+        })
+    }
+}

--- a/extension/src/nmost/min_time.rs
+++ b/extension/src/nmost/min_time.rs
@@ -1,0 +1,242 @@
+use pgx::{iter::SetOfIterator, *};
+
+use crate::nmost::*;
+
+use crate::{
+    flatten,
+    palloc::{Inner, Internal, InternalAsValue, ToInternal},
+    pg_type,
+    raw::bytea,
+    ron_inout_funcs,
+};
+
+type MinTimeTransType = NMostTransState<pg_sys::TimestampTz>;
+
+#[pg_schema]
+pub mod toolkit_experimental {
+    use super::*;
+
+    pg_type! {
+        #[derive(Debug)]
+        struct MinTimes <'input> {
+            capacity : u32,
+            elements : u32,
+            values : [pg_sys::TimestampTz; self.elements],
+        }
+    }
+    ron_inout_funcs!(MinTimes);
+
+    impl<'input> From<&mut MinTimeTransType> for MinTimes<'input> {
+        fn from(item: &mut MinTimeTransType) -> Self {
+            let heap = std::mem::take(&mut item.heap);
+            unsafe {
+                flatten!(MinTimes {
+                    capacity: item.capacity as u32,
+                    elements: heap.len() as u32,
+                    values: heap.into_sorted_vec().into()
+                })
+            }
+        }
+    }
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_time_trans(
+    state: Internal,
+    value: crate::raw::TimestampTz,
+    capacity: i64,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    nmost_trans_function(
+        unsafe { state.to_inner::<MinTimeTransType>() },
+        value.into(),
+        capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_time_rollup_trans(
+    state: Internal,
+    value: toolkit_experimental::MinTimes<'static>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    nmost_rollup_trans_function(
+        unsafe { state.to_inner::<MinTimeTransType>() },
+        value.values.as_slice(),
+        value.capacity as usize,
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_time_combine(state1: Internal, state2: Internal) -> Option<Internal> {
+    nmost_trans_combine(unsafe { state1.to_inner::<MinTimeTransType>() }, unsafe {
+        state2.to_inner::<MinTimeTransType>()
+    })
+    .internal()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_time_serialize(state: Internal) -> bytea {
+    let state: Inner<MinTimeTransType> = unsafe { state.to_inner().unwrap() };
+    crate::do_serialize!(state)
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_time_deserialize(bytes: bytea, _internal: Internal) -> Option<Internal> {
+    let i: MinTimeTransType = crate::do_deserialize!(bytes, MinTimeTransType);
+    Internal::new(i).into()
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn min_n_time_final(state: Internal) -> toolkit_experimental::MinTimes<'static> {
+    unsafe { &mut *state.to_inner::<MinTimeTransType>().unwrap() }.into()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_array",
+    immutable,
+    parallel_safe
+)]
+pub fn min_n_time_to_array(
+    agg: toolkit_experimental::MinTimes<'static>,
+) -> Vec<crate::raw::TimestampTz> {
+    agg.values
+        .clone()
+        .into_iter()
+        .map(crate::raw::TimestampTz::from)
+        .collect()
+}
+
+#[pg_extern(
+    schema = "toolkit_experimental",
+    name = "into_values",
+    immutable,
+    parallel_safe
+)]
+pub fn min_n_time_to_values(
+    agg: toolkit_experimental::MinTimes<'static>,
+) -> SetOfIterator<crate::raw::TimestampTz> {
+    SetOfIterator::new(
+        agg.values
+            .clone()
+            .into_iter()
+            .map(crate::raw::TimestampTz::from),
+    )
+}
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.min_n(\n\
+        value timestamptz, capacity bigint\n\
+    ) (\n\
+        sfunc = toolkit_experimental.min_n_time_trans,\n\
+        stype = internal,\n\
+        combinefunc = toolkit_experimental.min_n_time_combine,\n\
+        parallel = safe,\n\
+        serialfunc = toolkit_experimental.min_n_time_serialize,\n\
+        deserialfunc = toolkit_experimental.min_n_time_deserialize,\n\
+        finalfunc = toolkit_experimental.min_n_time_final\n\
+    );\n\
+",
+    name = "min_n_time",
+    requires = [
+        min_n_time_trans,
+        min_n_time_final,
+        min_n_time_combine,
+        min_n_time_serialize,
+        min_n_time_deserialize
+    ],
+);
+
+extension_sql!(
+    "\n\
+    CREATE AGGREGATE toolkit_experimental.rollup(\n\
+        value toolkit_experimental.MinTimes\n\
+    ) (\n\
+        sfunc = toolkit_experimental.min_n_time_rollup_trans,\n\
+        stype = internal,\n\
+        combinefunc = toolkit_experimental.min_n_time_combine,\n\
+        parallel = safe,\n\
+        serialfunc = toolkit_experimental.min_n_time_serialize,\n\
+        deserialfunc = toolkit_experimental.min_n_time_deserialize,\n\
+        finalfunc = toolkit_experimental.min_n_time_final\n\
+    );\n\
+",
+    name = "min_n_time_rollup",
+    requires = [
+        min_n_time_rollup_trans,
+        min_n_time_final,
+        min_n_time_combine,
+        min_n_time_serialize,
+        min_n_time_deserialize
+    ],
+);
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+    use pgx_macros::pg_test;
+
+    #[pg_test]
+    fn min_time_correctness() {
+        Spi::execute(|client| {
+            client.select("SET timezone TO 'UTC'", None, None);
+            client.select(
+                "CREATE TABLE data(val TIMESTAMPTZ, category INT)",
+                None,
+                None,
+            );
+
+            for i in 0..100 {
+                let i = (i * 83) % 100; // mess with the ordering just a little
+
+                client.select(
+                    &format!("INSERT INTO data VALUES ('2020-1-1 UTC'::timestamptz + {} * '1d'::interval, {})", i, i % 4),
+                    None,
+                    None,
+                );
+            }
+
+            // Test into_array
+            let result =
+                client.select("SELECT toolkit_experimental.into_array(toolkit_experimental.min_n(val, 5))::TEXT from data",
+                    None, None,
+                ).first().get_one::<&str>();
+            assert_eq!(result.unwrap(), "{\"2020-01-01 00:00:00+00\",\"2020-01-02 00:00:00+00\",\"2020-01-03 00:00:00+00\",\"2020-01-04 00:00:00+00\",\"2020-01-05 00:00:00+00\"}");
+
+            // Test into_values
+            let mut result =
+                client.select("SELECT toolkit_experimental.into_values(toolkit_experimental.min_n(val, 3))::TEXT from data",
+                    None, None,
+                );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("2020-01-01 00:00:00+00")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("2020-01-02 00:00:00+00")
+            );
+            assert_eq!(
+                result.next().unwrap()[1].value(),
+                Some("2020-01-03 00:00:00+00")
+            );
+            assert!(result.next().is_none());
+
+            // Test rollup
+            let result =
+                client.select(
+                    "WITH aggs as (SELECT category, toolkit_experimental.min_n(val, 5) as agg from data GROUP BY category)
+                        SELECT toolkit_experimental.into_array(toolkit_experimental.rollup(agg))::TEXT FROM aggs",
+                        None, None,
+                    ).first().get_one::<&str>();
+            assert_eq!(result.unwrap(), "{\"2020-01-01 00:00:00+00\",\"2020-01-02 00:00:00+00\",\"2020-01-03 00:00:00+00\",\"2020-01-04 00:00:00+00\",\"2020-01-05 00:00:00+00\"}");
+        })
+    }
+}


### PR DESCRIPTION
This adds new aggregates `min_n` and `max_n` for getting the n largest or smallest values from a column.  It will work with `integer`, `float`, and `timestamptz` values.  These functions will return an aggregate object which can be combined with other such objects via `rollup`.  The data can be extracted from the aggregate via `into_array` or `into_values` methods, which return either an array of the values, or a table containing them.

It further adds `min_n_by` and `max_n_by` functions that take one of the above types plus an associated piece of data (takes this as an `AnyElement`, so can be any type).  This will behave the same as the `min_n`/`max_n` above, but will also return the associated data for the smallest or largest elements.  `into_array` is not implemented for these aggregates, as it's not clear what that array would look like, and `into_values` will require a value of the appropriate type as an input to allow postgres to determine the function output (suggested approach is to just cast a `NULL` to the type of the associated data).

Fixes #511 
