### PR TITLE
Revert now unneeded pgx workaround

### DIFF
--- a/extension/src/state_aggregate.rs
+++ b/extension/src/state_aggregate.rs
@@ -374,22 +374,15 @@ pub fn interpolated_duration_in<'a>(
 }
 
 #[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
-pub fn into_values<'a, 'b>(
+pub fn into_values<'a>(
     agg: StateAgg<'a>,
-) -> TableIterator<'b, (pgx::name!(state, String), pgx::name!(duration, i64))> {
+) -> TableIterator<'a, (pgx::name!(state, String), pgx::name!(duration, i64))> {
     let states: String = agg.states_as_str().to_owned();
-    TableIterator::new(
-        agg.durations
-            .clone()
-            .into_iter()
-            .map(move |record| {
-                let beg = record.state_beg as usize;
-                let end = record.state_end as usize;
-                (states[beg..end].to_owned(), record.duration)
-            })
-            .collect::<Vec<_>>()
-            .into_iter(),
-    )
+    TableIterator::new(agg.durations.clone().into_iter().map(move |record| {
+        let beg = record.state_beg as usize;
+        let end = record.state_end as usize;
+        (states[beg..end].to_owned(), record.duration)
+    }))
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, FlatSerializable, PartialEq, Serialize)]

--- a/extension/src/time_vector.rs
+++ b/extension/src/time_vector.rs
@@ -105,15 +105,13 @@ pub static TIMEVECTOR_OID: once_cell::sync::Lazy<pg_sys::Oid> =
     once_cell::sync::Lazy::new(Timevector_TSTZ_F64::type_oid);
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn unnest<'a, 'b>(
+pub fn unnest<'a>(
     series: Timevector_TSTZ_F64<'a>,
-) -> TableIterator<'b, (name!(time, crate::raw::TimestampTz), name!(value, f64))> {
+) -> TableIterator<'a, (name!(time, crate::raw::TimestampTz), name!(value, f64))> {
     TableIterator::new(
         series
             .into_iter()
-            .map(|points| (points.ts.into(), points.val))
-            .collect::<Vec<_>>()
-            .into_iter(),
+            .map(|points| (points.ts.into(), points.val)),
     )
 }
 

--- a/extension/src/time_vector/pipeline/lambda.rs
+++ b/extension/src/time_vector/pipeline/lambda.rs
@@ -170,9 +170,7 @@ pub fn trace_lambda<'a>(
     SetOfIterator::new(
         trace
             .into_iter()
-            .map(move |(e, v)| format!("{:>width$}: {:?}", e, v, width = col1_size))
-            .collect::<Vec<_>>()
-            .into_iter(),
+            .map(move |(e, v)| format!("{:>width$}: {:?}", e, v, width = col1_size)),
     )
 }
 

--- a/extension/src/utilities.rs
+++ b/extension/src/utilities.rs
@@ -83,9 +83,7 @@ pub fn generate_periodic_normal_series(
                         * periodic_magnitude;
                 let error = distribution.sample(&mut rng);
                 (time.into(), base + error)
-            })
-            .collect::<Vec<_>>()
-            .into_iter(),
+            }),
     )
 }
 


### PR DESCRIPTION
We don't need copy everything into memory owned by Rust anymore, since pgx 0.5.4 fixed the bug that made doing that necessary (https://github.com/tcdi/pgx/pull/784).

This reverts commit fe8b3861ee12b1cebedfb32a0c4fce2b9ce508df.

I didn't add anything to the changelog since this an internal change that doesn't affect end users.