### PR TITLE
GitHub Actions: bump actions/checkout and actions/cache to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
@@ -58,7 +58,7 @@ jobs:
     # TODO After the container image contains a primed target dir, is this still worth it?
     #   Only possible advantage is this one is per-pg-version but what's the impact?
     - name: Cache cargo target dir
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: target
         key: ${{ runner.os }}-test-pg${{ matrix.pgversion }}-target-${{ hashFiles('Cargo.lock', '.github/workflows/ci.yml') }}
@@ -89,7 +89,7 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
@@ -97,7 +97,7 @@ jobs:
       run: chown -R postgres .
 
     - name: Cache cargo target dir
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: target
         key: ${{ runner.os }}-test-crates-target-${{ hashFiles('Cargo.lock', '.github/workflows/ci.yml') }}
@@ -121,7 +121,7 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
@@ -129,7 +129,7 @@ jobs:
       run: chown -R postgres .
 
     - name: Cache cargo target dir
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: target
         key: ${{ runner.os }}-test-updates-target-${{ hashFiles('Cargo.lock', '.github/workflows/ci.yml') }}
@@ -137,7 +137,7 @@ jobs:
 
     # TODO Drop this.
     - name: Cache old versions dir
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: old-versions
         key: ${{ runner.os }}-test-old-versions-${{ hashFiles('Cargo.lock', '.github/workflows/ci.yml') }}

--- a/.github/workflows/clippy_rustfmt.yml
+++ b/.github/workflows/clippy_rustfmt.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
@@ -36,7 +36,7 @@ jobs:
       run: chown -R postgres .
 
     - name: Cache cargo target dir
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: target
         key: ${{ runner.os }}-clippy-target-${{ hashFiles('Cargo.lock', '.github/workflows/clippy_rustfmt.yml') }}


### PR DESCRIPTION
We're seeing  a lot of deprecation warnings on our CI runs lately e.g. https://github.com/timescale/timescaledb-toolkit/actions/runs/3359573483

which point to this [blog post](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) about deprecations in some GitHub Actions commands.

Bumping the checkout and cache actions appears to make many of these warnings go away.