### PR TITLE
Use TwoFloats when using `stats_agg` in moving-aggregate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hexf"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6618f4550dcd7d9ddb5126ab18d48dfa31aa952159cb832390bda464d3bc827e"
+dependencies = [
+ "hexf-parse",
+ "syn",
+]
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,7 +1839,9 @@ dependencies = [
  "approx 0.4.0",
  "flat_serialize",
  "flat_serialize_macro",
+ "num-traits",
  "serde",
+ "twofloat",
 ]
 
 [[package]]
@@ -1986,6 +2004,7 @@ dependencies = [
  "flat_serialize",
  "flat_serialize_macro",
  "hyperloglogplusplus",
+ "num-traits",
  "once_cell",
  "ordered-float",
  "paste",
@@ -2005,6 +2024,7 @@ dependencies = [
  "tdigest",
  "time_weighted_average",
  "tspoint",
+ "twofloat",
  "uddsketch",
 ]
 
@@ -2176,6 +2196,17 @@ version = "0.1.0"
 dependencies = [
  "flat_serialize",
  "flat_serialize_macro",
+ "serde",
+]
+
+[[package]]
+name = "twofloat"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eda3d5fa47bbd7c7fa3d2caae7a5ba1a58b1c3fc1c00ac4b1cce05eae85ef93"
+dependencies = [
+ "hexf",
+ "num-traits",
  "serde",
 ]
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -21,6 +21,7 @@ This changelog should be updated as part of a PR if the work is worth noting (mo
 
 - [#547](https://github.com/timescale/timescaledb-toolkit/pull/547): Update pgx to 0.5.0. This is necessary for adding Postgres 15 support coming soon.
 - [#571](https://github.com/timescale/timescaledb-toolkit/pull/571): Update CI docker image for pgx 0.5.0.
+- [#599](https://github.com/timescale/timescaledb-toolkit/pull/599): Reduce floating point error when using `stats_agg` in moving aggregate mode
 
 #### Shout-outs
 

--- a/crates/counter-agg/src/lib.rs
+++ b/crates/counter-agg/src/lib.rs
@@ -39,7 +39,7 @@ pub struct MetricSummary {
     // TODO Protect from deserialization?  Is there any risk other than giving
     //  nonsensical results?  If so, maybe it's fine to just accept garbage
     //  out upon garbage in.
-    pub stats: StatsSummary2D,
+    pub stats: StatsSummary2D<f64>,
     // TODO See TODOs in I64Range about protecting from deserialization.
     pub bounds: Option<range::I64Range>,
 }
@@ -49,7 +49,7 @@ pub struct MetricSummary {
 // you can always subtract a common near value from all your times, then add it back in, the regression analysis will be unchanged.
 // Note that convert the timestamp into seconds rather than microseconds here so that the slope and any other regression analysis, is done on a per-second basis.
 // For instance, the slope will be the per-second slope, not the per-microsecond slope. The x intercept value will need to be converted back to microseconds so you get a timestamp out.
-fn ts_to_xy(pt: TSPoint) -> XYPair {
+fn ts_to_xy(pt: TSPoint) -> XYPair<f64> {
     XYPair {
         x: to_seconds(pt.ts as f64),
         y: pt.val,

--- a/crates/stats-agg/Cargo.toml
+++ b/crates/stats-agg/Cargo.toml
@@ -10,6 +10,8 @@ edition = "2021"
 flat_serialize = {path="../flat_serialize/flat_serialize"}
 flat_serialize_macro = {path="../flat_serialize/flat_serialize_macro"}
 serde = { version = "1.0", features = ["derive"] }
+twofloat = { version = "0.6.0", features = ["serde"] }
+num-traits = "0.2.15"
 
 [dev-dependencies]
 approx = "0.4.0"

--- a/crates/stats-agg/src/lib.rs
+++ b/crates/stats-agg/src/lib.rs
@@ -190,3 +190,15 @@ impl M4 {
                 + T::lit(4.) * (new_na * sx3b - nb * new_sx3a) * delta / nx)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use twofloat::TwoFloat;
+
+    #[test]
+    fn floatlike_lit() {
+        assert_eq!(f64::lit(3.), 3.);
+        assert_eq!(TwoFloat::lit(3.), TwoFloat::new_add(3., 0.));
+    }
+}

--- a/crates/stats-agg/src/lib.rs
+++ b/crates/stats-agg/src/lib.rs
@@ -5,15 +5,35 @@
 // https://github.com/postgres/postgres/blob/472e518a44eacd9caac7d618f1b6451672ca4481/src/backend/utils/adt/float.c#L3260
 //
 
+pub trait FloatLike:
+    num_traits::NumOps + num_traits::NumAssignOps + num_traits::Float + From<f64>
+{
+    /// Shorthand for `<T as From<f64>>::from(val)`
+    fn lit(val: f64) -> Self {
+        <Self as From<f64>>::from(val)
+    }
+    fn from_u64(n: u64) -> Self;
+}
+impl FloatLike for f64 {
+    fn from_u64(n: u64) -> Self {
+        n as f64
+    }
+}
+impl FloatLike for twofloat::TwoFloat {
+    fn from_u64(n: u64) -> Self {
+        (n as f64).into()
+    }
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum StatsError {
     DoubleOverflow,
 }
 
 #[derive(Debug, PartialEq)]
-pub struct XYPair {
-    pub x: f64,
-    pub y: f64,
+pub struct XYPair<T: FloatLike> {
+    pub x: T,
+    pub y: T,
 }
 
 // The threshold at which we should re-calculate when we're doing the inverse transition in a windowed aggregate
@@ -38,55 +58,58 @@ pub mod stats2d;
 pub(crate) struct M3 {}
 impl M3 {
     // Add a value x to the set.  n, sx, sxx, sx3 are the values from prior to including x.
-    pub(crate) fn accum(n: f64, sx: f64, sxx: f64, sx3: f64, x: f64) -> f64 {
+    pub(crate) fn accum<T: FloatLike>(n: T, sx: T, sxx: T, sx3: T, x: T) -> T {
         let delta = x - (sx / n);
-        let n = n + 1.;
-        sx3 + delta.powi(3) * (n - 1.) * (n - 2.) / n.powi(2) - (3. * delta * sxx / n)
+        let n = n + T::one();
+        sx3 + delta.powi(3) * (n - T::one()) * (n - T::lit(2.)) / n.powi(2)
+            - (T::lit(3.) * delta * sxx / n)
     }
     // Remove a value x from the set.  Here n, sx, sxx are all the values from the set after x has been removed.
     // old_sx3 is the current value prior to the remove (sx3 after the removal is the returned value)
-    pub(crate) fn remove(new_n: f64, new_sx: f64, new_sxx: f64, old_sx3: f64, x: f64) -> f64 {
+    pub(crate) fn remove<T: FloatLike>(new_n: T, new_sx: T, new_sxx: T, old_sx3: T, x: T) -> T {
         let delta = x - (new_sx / new_n);
-        let n = new_n + 1.;
-        old_sx3 - (delta.powi(3) * (n - 1.) * (n - 2.) / n.powi(2) - (3. * delta * new_sxx / n))
+        let n = new_n + T::one();
+        old_sx3
+            - (delta.powi(3) * (n - T::one()) * (n - T::lit(2.)) / n.powi(2)
+                - (T::lit(3.) * delta * new_sxx / n))
     }
     // Combine two sets a and b and returns the sx3 for the combined set.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn combine(
-        na: f64,
-        nb: f64,
-        sxa: f64,
-        sxb: f64,
-        sxxa: f64,
-        sxxb: f64,
-        sx3a: f64,
-        sx3b: f64,
-    ) -> f64 {
+    pub(crate) fn combine<T: FloatLike>(
+        na: T,
+        nb: T,
+        sxa: T,
+        sxb: T,
+        sxxa: T,
+        sxxb: T,
+        sx3a: T,
+        sx3b: T,
+    ) -> T {
         let nx = na + nb;
         let delta = sxb / nb - sxa / na;
         sx3a + sx3b
             + delta.powi(3) * na * nb * (na - nb) / nx.powi(2)
-            + 3. * (na * sxxb - (nb * sxxa)) * delta / nx
+            + (na * sxxb - (nb * sxxa)) * T::lit(3.) * delta / nx
     }
     // This removes set b from a combined set, returning the sx3 of the remaining set a.
     // Note that na, sxa, sxxa are all the values computed on the remaining set.  old_sx3 is the sx3 of the combined set.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn remove_combined(
-        new_na: f64,
-        nb: f64,
-        new_sxa: f64,
-        sxb: f64,
-        new_sxxa: f64,
-        sxxb: f64,
-        old_sx3: f64,
-        sx3b: f64,
-    ) -> f64 {
+    pub(crate) fn remove_combined<T: FloatLike>(
+        new_na: T,
+        nb: T,
+        new_sxa: T,
+        sxb: T,
+        new_sxxa: T,
+        sxxb: T,
+        old_sx3: T,
+        sx3b: T,
+    ) -> T {
         let nx = new_na + nb;
         let delta = sxb / nb - new_sxa / new_na;
         old_sx3
             - (sx3b
                 + delta.powi(3) * new_na * nb * (new_na - nb) / nx.powi(2)
-                + 3. * (new_na * sxxb - (nb * new_sxxa)) * delta / nx)
+                + T::lit(3.) * (new_na * sxxb - (nb * new_sxxa)) * delta / nx)
     }
 }
 
@@ -95,73 +118,75 @@ impl M3 {
 pub(crate) struct M4 {}
 impl M4 {
     // Add a value x to the set.  n, sx, sxx, sx3, sx4 are the values from prior to including x.
-    pub(crate) fn accum(n: f64, sx: f64, sxx: f64, sx3: f64, sx4: f64, x: f64) -> f64 {
+    pub(crate) fn accum<T: FloatLike>(n: T, sx: T, sxx: T, sx3: T, sx4: T, x: T) -> T {
         let delta = x - (sx / n);
-        let n = n + 1.;
-        sx4 + delta.powi(4) * (n - 1.) * (n.powi(2) - 3. * n + 3.) / n.powi(3)
-            + 6. * delta.powi(2) * sxx / n.powi(2)
-            - 4. * delta * sx3 / n
+        let n = n + T::one();
+        sx4 + delta.powi(4) * (n - T::one()) * (n.powi(2) - T::lit(3.) * n + T::lit(3.)) / n.powi(3)
+            + T::lit(6.) * delta.powi(2) * sxx / n.powi(2)
+            - T::lit(4.) * delta * sx3 / n
     }
     // Remove a value x from the set.  Here n, sx, sxx, sx3 are all the values from the set after x has been removed.
     // old_sx4 is the current value prior to the remove (sx4 after the removal is the returned value)
-    pub(crate) fn remove(
-        new_n: f64,
-        new_sx: f64,
-        new_sxx: f64,
-        new_sx3: f64,
-        old_sx4: f64,
-        x: f64,
-    ) -> f64 {
+    pub(crate) fn remove<T: FloatLike>(
+        new_n: T,
+        new_sx: T,
+        new_sxx: T,
+        new_sx3: T,
+        old_sx4: T,
+        x: T,
+    ) -> T {
         let delta = x - (new_sx / new_n);
-        let n = new_n + 1.;
+        let n = new_n + T::one();
         old_sx4
-            - (delta.powi(4) * (n - 1.) * (n.powi(2) - 3. * n + 3.) / n.powi(3)
-                + 6. * delta.powi(2) * new_sxx / n.powi(2)
-                - 4. * delta * new_sx3 / n)
+            - (delta.powi(4) * (n - T::one()) * (n.powi(2) - T::lit(3.) * n + T::lit(3.))
+                / n.powi(3)
+                + T::lit(6.) * delta.powi(2) * new_sxx / n.powi(2)
+                - T::lit(4.) * delta * new_sx3 / n)
     }
     // Combine two sets a and b and returns the sx4 for the combined set.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn combine(
-        na: f64,
-        nb: f64,
-        sxa: f64,
-        sxb: f64,
-        sxxa: f64,
-        sxxb: f64,
-        sx3a: f64,
-        sx3b: f64,
-        sx4a: f64,
-        sx4b: f64,
-    ) -> f64 {
+    pub(crate) fn combine<T: FloatLike>(
+        na: T,
+        nb: T,
+        sxa: T,
+        sxb: T,
+        sxxa: T,
+        sxxb: T,
+        sx3a: T,
+        sx3b: T,
+        sx4a: T,
+        sx4b: T,
+    ) -> T {
         let nx = na + nb;
         let delta = sxb / nb - sxa / na;
         sx4a + sx4b
             + delta.powi(4) * na * nb * (na.powi(2) - na * nb + nb.powi(2)) / nx.powi(3)
-            + 6. * (na.powi(2) * sxxb + nb.powi(2) * sxxa) * delta.powi(2) / nx.powi(2)
-            + 4. * (na * sx3b - nb * sx3a) * delta / nx
+            + T::lit(6.) * (na.powi(2) * sxxb + nb.powi(2) * sxxa) * delta.powi(2) / nx.powi(2)
+            + T::lit(4.) * (na * sx3b - nb * sx3a) * delta / nx
     }
     // This removes set b from a combined set, returning the sx4 of the remaining set a.
     // Note that na, sxa, sxxa, sx3a are all the values computed on the remaining set.  old_sx4 is the sx4 of the combined set.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn remove_combined(
-        new_na: f64,
-        nb: f64,
-        new_sxa: f64,
-        sxb: f64,
-        new_sxxa: f64,
-        sxxb: f64,
-        new_sx3a: f64,
-        sx3b: f64,
-        old_sx4: f64,
-        sx4b: f64,
-    ) -> f64 {
+    pub(crate) fn remove_combined<T: FloatLike>(
+        new_na: T,
+        nb: T,
+        new_sxa: T,
+        sxb: T,
+        new_sxxa: T,
+        sxxb: T,
+        new_sx3a: T,
+        sx3b: T,
+        old_sx4: T,
+        sx4b: T,
+    ) -> T {
         let nx = new_na + nb;
         let delta = sxb / nb - new_sxa / new_na;
         old_sx4
             - (sx4b
                 + delta.powi(4) * new_na * nb * (new_na.powi(2) - new_na * nb + nb.powi(2))
                     / nx.powi(3)
-                + 6. * (new_na.powi(2) * sxxb + nb.powi(2) * new_sxxa) * delta.powi(2) / nx.powi(2)
-                + 4. * (new_na * sx3b - nb * new_sx3a) * delta / nx)
+                + T::lit(6.) * (new_na.powi(2) * sxxb + nb.powi(2) * new_sxxa) * delta.powi(2)
+                    / nx.powi(2)
+                + T::lit(4.) * (new_na * sx3b - nb * new_sx3a) * delta / nx)
     }
 }

--- a/crates/stats-agg/src/lib.rs
+++ b/crates/stats-agg/src/lib.rs
@@ -49,7 +49,11 @@ pub struct XYPair<T: FloatLike> {
 // but then the cost of recalculation is low, compared to when there are many values in a rolling calculation, so we
 // test early in the function for whether we need to recalculate and pass NULL quickly so that we don't affect those
 // cases too heavily.
+#[cfg(not(any(test, feature = "pg_test")))]
 const INV_FLOATING_ERROR_THRESHOLD: f64 = 0.99;
+#[cfg(any(test, feature = "pg_test"))] // don't have a threshold for tests, to ensure the inverse function is better tested
+const INV_FLOATING_ERROR_THRESHOLD: f64 = f64::INFINITY;
+
 pub mod stats1d;
 pub mod stats2d;
 

--- a/crates/stats-agg/src/stats1d.rs
+++ b/crates/stats-agg/src/stats1d.rs
@@ -1,34 +1,67 @@
-use crate::{StatsError, INV_FLOATING_ERROR_THRESHOLD, M3, M4};
+use crate::{FloatLike, StatsError, INV_FLOATING_ERROR_THRESHOLD, M3, M4};
 use serde::{Deserialize, Serialize};
+use twofloat::TwoFloat;
 
 #[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
 #[repr(C)]
-pub struct StatsSummary1D {
+pub struct StatsSummary1D<T: FloatLike> {
     pub n: u64,
-    pub sx: f64,
-    pub sx2: f64,
-    pub sx3: f64,
-    pub sx4: f64,
+    pub sx: T,
+    pub sx2: T,
+    pub sx3: T,
+    pub sx4: T,
 }
-
-impl Default for StatsSummary1D {
+impl<T> Default for StatsSummary1D<T>
+where
+    T: FloatLike,
+{
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl StatsSummary1D {
-    fn n64(&self) -> f64 {
-        self.n as f64
+// can't make this impl generic without conflicting with the stdlib implementation of From<T> for T
+impl From<StatsSummary1D<f64>> for StatsSummary1D<TwoFloat> {
+    fn from(input_summary: StatsSummary1D<f64>) -> Self {
+        StatsSummary1D {
+            n: input_summary.n,
+            sx: input_summary.sx.into(),
+            sx2: input_summary.sx2.into(),
+            sx3: input_summary.sx3.into(),
+            sx4: input_summary.sx4.into(),
+        }
+    }
+}
+pub fn convert_tf_to_f64(tf: TwoFloat) -> f64 {
+    tf.hi() + tf.lo()
+}
+impl From<StatsSummary1D<TwoFloat>> for StatsSummary1D<f64> {
+    fn from(input_summary: StatsSummary1D<TwoFloat>) -> Self {
+        StatsSummary1D {
+            n: input_summary.n,
+            sx: input_summary.sx.into(),
+            sx2: input_summary.sx2.into(),
+            sx3: input_summary.sx3.into(),
+            sx4: input_summary.sx4.into(),
+        }
+    }
+}
+
+impl<T> StatsSummary1D<T>
+where
+    T: FloatLike,
+{
+    fn n64(&self) -> T {
+        T::from_u64(self.n)
     }
 
     pub fn new() -> Self {
         StatsSummary1D {
             n: 0,
-            sx: 0.0,
-            sx2: 0.0,
-            sx3: 0.0,
-            sx4: 0.0,
+            sx: T::zero(),
+            sx2: T::zero(),
+            sx3: T::zero(),
+            sx4: T::zero(),
         }
     }
 
@@ -36,13 +69,13 @@ impl StatsSummary1D {
     // for this part, we've essentially copied the Postgres implementation found: // https://github.com/postgres/postgres/blob/8bdd6f563aa2456de602e78991e6a9f61b8ec86d/src/backend/utils/adt/float.c#L2813
     // Note that the Youngs-Cramer method relies on the sum((x - Sx/n)^2) for which they derive a recurrence relation which is reflected in the algorithm here:
     // the recurrence relation is: sum((x - Sx/n)^2) = Sxx = Sxx_n-1 + 1/(n(n-1)) * (nx - Sx)^2
-    pub fn accum(&mut self, p: f64) -> Result<(), StatsError> {
+    pub fn accum(&mut self, p: T) -> Result<(), StatsError> {
         let old = *self;
         self.n += 1;
         self.sx += p;
         if old.n > 0 {
             let tmpx = p * self.n64() - self.sx;
-            let scale = 1.0 / (self.n64() * old.n64());
+            let scale = T::one() / (self.n64() * old.n64());
             self.sx2 += tmpx * tmpx * scale;
             self.sx3 = M3::accum(old.n64(), old.sx, old.sx2, old.sx3, p);
             self.sx4 = M4::accum(old.n64(), old.sx, old.sx2, old.sx3, old.sx4, p);
@@ -57,21 +90,21 @@ impl StatsSummary1D {
                 // infinite input (because they necessarily involve multiplications of
                 // infinites, which are NaNs)
                 if self.sx2.is_infinite() {
-                    self.sx2 = f64::NAN;
+                    self.sx2 = T::nan();
                 }
                 if self.sx3.is_infinite() {
-                    self.sx3 = f64::NAN;
+                    self.sx3 = T::nan();
                 }
                 if self.sx4.is_infinite() {
-                    self.sx4 = f64::NAN;
+                    self.sx4 = T::nan();
                 }
             }
         } else {
             // first input, leave sxx alone unless we have infinite inputs
             if !p.is_finite() {
-                self.sx2 = f64::NAN;
-                self.sx3 = f64::NAN;
-                self.sx4 = f64::NAN;
+                self.sx2 = T::nan();
+                self.sx3 = T::nan();
+                self.sx4 = T::nan();
             }
         }
         Result::Ok(())
@@ -84,7 +117,7 @@ impl StatsSummary1D {
             || self.sx4.is_infinite()
     }
 
-    fn check_overflow(&self, old: &StatsSummary1D, p: f64) -> bool {
+    fn check_overflow(&self, old: &Self, p: T) -> bool {
         //Only report overflow if we have finite inputs that lead to infinite results.
         self.has_infinite() && old.sx.is_finite() && p.is_finite()
     }
@@ -105,7 +138,7 @@ impl StatsSummary1D {
     // Sx = Sx_old + x -> Sx_old = Sx - x
     // sum((x - Sx/n)^2) = Sxx = Sxx_old + 1/(n * n_old) * (nx - Sx)^2  -> Sxx_old = Sxx - 1/(n * n_old) * (nx - Sx)^2
 
-    pub fn remove(&self, p: f64) -> Option<Self> {
+    pub fn remove(&self, p: T) -> Option<Self> {
         // if we are trying to remove a nan/infinite input, it's time to recalculate.
         if p.is_nan() || p.is_infinite() {
             return None;
@@ -113,7 +146,7 @@ impl StatsSummary1D {
         // if we are removing a value that is very large compared to the sum of the values that we're removing it from,
         // we should probably recalculate to avoid accumulating error. We might want a different test for this, if there
         // is a  way to calculate the error directly, that might be best...
-        if p / self.sx > INV_FLOATING_ERROR_THRESHOLD {
+        if p / self.sx > <T as From<f64>>::from(INV_FLOATING_ERROR_THRESHOLD) {
             return None;
         }
 
@@ -129,13 +162,13 @@ impl StatsSummary1D {
         let mut new = StatsSummary1D {
             n: self.n - 1,
             sx: self.sx - p,
-            sx2: 0.0, // initialize this for now.
-            sx3: 0.0, // initialize this for now.
-            sx4: 0.0, // initialize this for now.
+            sx2: T::zero(), // initialize this for now.
+            sx3: T::zero(), // initialize this for now.
+            sx4: T::zero(), // initialize this for now.
         };
 
         let tmpx = p * self.n64() - self.sx;
-        let scale = 1.0 / (self.n64() * new.n64());
+        let scale = (self.n64() * new.n64()).recip();
         new.sx2 = self.sx2 - tmpx * tmpx * scale;
         new.sx3 = M3::remove(new.n64(), new.sx, new.sx2, self.sx3, p);
         new.sx4 = M4::remove(new.n64(), new.sx, new.sx2, new.sx3, self.sx4, p);
@@ -144,7 +177,7 @@ impl StatsSummary1D {
     }
 
     // convenience function for creating an aggregate from a vector, currently used mostly for testing.
-    pub fn new_from_vec(v: Vec<f64>) -> Result<Self, StatsError> {
+    pub fn new_from_vec(v: Vec<T>) -> Result<Self, StatsError> {
         let mut r = StatsSummary1D::new();
         for p in v {
             r.accum(p)?;
@@ -152,7 +185,7 @@ impl StatsSummary1D {
         Result::Ok(r)
     }
 
-    pub fn combine(&self, other: StatsSummary1D) -> Result<Self, StatsError> {
+    pub fn combine(&self, other: Self) -> Result<Self, StatsError> {
         // TODO: think about whether we want to just modify &self in place here for perf
         // reasons. This is also a set of weird questions around the Rust compiler, so
         // easier to just add the copy trait here, may need to adjust or may make things
@@ -170,7 +203,10 @@ impl StatsSummary1D {
         let r = StatsSummary1D {
             n,
             sx: self.sx + other.sx,
-            sx2: self.sx2 + other.sx2 + self.n64() * other.n64() * tmp * tmp / n as f64,
+            sx2: self.sx2
+                + other.sx2
+                + self.n64() * other.n64() * tmp * tmp
+                    / <T as num_traits::cast::NumCast>::from(n).unwrap(),
             sx3: M3::combine(
                 self.n64(),
                 other.n64(),
@@ -204,7 +240,7 @@ impl StatsSummary1D {
     // for re-aggregation over a window, this is what will get called in tumbling window averages for instance.
     // As with any window function, returning None will cause a re-calculation, so we do that in several cases where either we're dealing with infinites or we have some potential problems with outlying sums
     // so here, self is the previously combined StatsSummary, and we're removing the input and returning the part that would have been there before.
-    pub fn remove_combined(&self, remove: StatsSummary1D) -> Option<Self> {
+    pub fn remove_combined(&self, remove: Self) -> Option<Self> {
         let combined = &self; // just to lessen confusion with naming
                               // handle the trivial n = 0 and equal n cases here, and don't worry about divide by zero errors later.
         if combined.n == remove.n {
@@ -215,15 +251,15 @@ impl StatsSummary1D {
             panic!(); // given that we're always removing things that we've previously added, we shouldn't be able to get a case where we're removing an n that's larger.
         }
         // if the sum we're removing is very large compared to the overall value we need to recalculate, see note on the remove function
-        if remove.sx / combined.sx > INV_FLOATING_ERROR_THRESHOLD {
+        if remove.sx / combined.sx > <T as From<f64>>::from(INV_FLOATING_ERROR_THRESHOLD) {
             return None;
         }
         let mut part = StatsSummary1D {
             n: combined.n - remove.n,
             sx: combined.sx - remove.sx,
-            sx2: 0.0, //just initialize this, for now.
-            sx3: 0.0, //just initialize this, for now.
-            sx4: 0.0, //just initialize this, for now.
+            sx2: T::zero(), //just initialize this, for now.
+            sx3: T::zero(), //just initialize this, for now.
+            sx4: T::zero(), //just initialize this, for now.
         };
         let tmp = part.sx / part.n64() - remove.sx / remove.n64(); //gets squared so order doesn't matter
         part.sx2 =
@@ -254,7 +290,7 @@ impl StatsSummary1D {
         Some(part)
     }
 
-    pub fn avg(&self) -> Option<f64> {
+    pub fn avg(&self) -> Option<T> {
         if self.n == 0 {
             return None;
         }
@@ -265,49 +301,49 @@ impl StatsSummary1D {
         self.n as i64
     }
 
-    pub fn sum(&self) -> Option<f64> {
+    pub fn sum(&self) -> Option<T> {
         if self.n == 0 {
             return None;
         }
         Some(self.sx)
     }
 
-    pub fn var_pop(&self) -> Option<f64> {
+    pub fn var_pop(&self) -> Option<T> {
         if self.n == 0 {
             return None;
         }
         Some(self.sx2 / self.n64())
     }
 
-    pub fn var_samp(&self) -> Option<f64> {
+    pub fn var_samp(&self) -> Option<T> {
         if self.n == 0 {
             return None;
         }
-        Some(self.sx2 / (self.n64() - 1.0))
+        Some(self.sx2 / (self.n64() - T::one()))
     }
 
-    pub fn stddev_pop(&self) -> Option<f64> {
+    pub fn stddev_pop(&self) -> Option<T> {
         Some(self.var_pop()?.sqrt())
     }
 
-    pub fn stddev_samp(&self) -> Option<f64> {
+    pub fn stddev_samp(&self) -> Option<T> {
         Some(self.var_samp()?.sqrt())
     }
 
-    pub fn skewness_pop(&self) -> Option<f64> {
+    pub fn skewness_pop(&self) -> Option<T> {
         Some(self.sx3 / self.n64() / self.stddev_pop()?.powi(3))
     }
 
-    pub fn skewness_samp(&self) -> Option<f64> {
-        Some(self.sx3 / (self.n64() - 1.0) / self.stddev_samp()?.powi(3))
+    pub fn skewness_samp(&self) -> Option<T> {
+        Some(self.sx3 / (self.n64() - T::one()) / self.stddev_samp()?.powi(3))
     }
 
-    pub fn kurtosis_pop(&self) -> Option<f64> {
+    pub fn kurtosis_pop(&self) -> Option<T> {
         Some(self.sx4 / self.n64() / self.stddev_pop()?.powi(4))
     }
 
-    pub fn kurtosis_samp(&self) -> Option<f64> {
-        Some(self.sx4 / (self.n64() - 1.0) / self.stddev_samp()?.powi(4))
+    pub fn kurtosis_samp(&self) -> Option<T> {
+        Some(self.sx4 / (self.n64() - T::one()) / self.stddev_samp()?.powi(4))
     }
 }
 
@@ -316,13 +352,26 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
 
+    fn tf(f: f64) -> TwoFloat {
+        TwoFloat::new_add(f, 0.0)
+    }
+
     #[track_caller]
-    fn assert_close_enough(s1: &StatsSummary1D, s2: &StatsSummary1D) {
+    fn assert_close_enough(s1: &StatsSummary1D<f64>, s2: &StatsSummary1D<f64>) {
         assert_eq!(s1.n, s2.n);
         assert_relative_eq!(s1.sx, s2.sx);
         assert_relative_eq!(s1.sx2, s2.sx2);
         assert_relative_eq!(s1.sx3, s2.sx3);
         assert_relative_eq!(s1.sx4, s2.sx4);
+    }
+
+    #[track_caller]
+    fn assert_close_enough_tf(s1: &StatsSummary1D<TwoFloat>, s2: &StatsSummary1D<TwoFloat>) {
+        assert_eq!(s1.n, s2.n);
+        assert!((s1.sx - s2.sx).abs() < 10.0 * f64::EPSILON);
+        assert!((s1.sx2 - s2.sx2).abs() < 10.0 * f64::EPSILON);
+        assert!((s1.sx3 - s2.sx3).abs() < 10.0 * f64::EPSILON);
+        assert!((s1.sx4 - s2.sx4).abs() < 10.0 * f64::EPSILON);
     }
 
     #[test]
@@ -365,10 +414,85 @@ mod tests {
     }
 
     #[test]
+    fn test_against_known_vals_tf() {
+        let p = StatsSummary1D::new_from_vec(vec![tf(7.0), tf(18.0), tf(-2.0), tf(5.0), tf(3.0)])
+            .unwrap();
+
+        assert_eq!(p.n, 5);
+        assert_relative_eq!(Into::<f64>::into(p.sx), 31.);
+        assert_relative_eq!(Into::<f64>::into(p.sx2), 218.8);
+        assert_relative_eq!(Into::<f64>::into(p.sx3), 1057.68);
+        assert_relative_eq!(Into::<f64>::into(p.sx4), 24016.336);
+
+        let p = p.remove(tf(18.0)).unwrap();
+
+        assert_eq!(p.n, 4);
+        assert_relative_eq!(Into::<f64>::into(p.sx), 13.);
+        // value is slightly off
+        assert_relative_eq!(Into::<f64>::into(p.sx2), 44.75, epsilon = 0.000000000001);
+        assert_relative_eq!(Into::<f64>::into(p.sx3), -86.625, epsilon = 0.000000000001);
+        assert_relative_eq!(
+            Into::<f64>::into(p.sx4),
+            966.8281249999964,
+            epsilon = 0.000000000001
+        );
+
+        let p = p
+            .combine(StatsSummary1D::new_from_vec(vec![tf(0.5), tf(11.0), tf(6.123)]).unwrap())
+            .unwrap();
+
+        assert_eq!(p.n, 7);
+        assert_relative_eq!(Into::<f64>::into(p.sx), 30.623);
+        assert_relative_eq!(Into::<f64>::into(p.sx2), 111.77425342857143);
+        // slight difference in values here – not sure if twofloat or f64 is more accurate
+        assert_relative_eq!(
+            Into::<f64>::into(p.sx3),
+            -5.324891254897949,
+            epsilon = 0.0000000001
+        );
+        assert_relative_eq!(
+            Into::<f64>::into(p.sx4),
+            3864.054085451184,
+            epsilon = 0.0000000001
+        );
+
+        let p = p
+            .remove_combined(
+                StatsSummary1D::new_from_vec(vec![tf(5.0), tf(11.0), tf(3.0)]).unwrap(),
+            )
+            .unwrap();
+
+        assert_eq!(p.n, 4);
+        assert_relative_eq!(Into::<f64>::into(p.sx), 11.623);
+        // f64 gets this slightly over, TF gets this slightly under
+        assert_relative_eq!(
+            Into::<f64>::into(p.sx2),
+            56.96759675000001,
+            epsilon = 0.000000000001
+        );
+        // slight difference in values here – not sure if twofloat or f64 is more accurate
+        assert_relative_eq!(
+            Into::<f64>::into(p.sx3),
+            -30.055041237374915,
+            epsilon = 0.0000000001
+        );
+        assert_relative_eq!(
+            Into::<f64>::into(p.sx4),
+            1000.8186787745212,
+            epsilon = 0.0000000001
+        );
+    }
+
+    #[test]
     fn test_combine() {
         let p = StatsSummary1D::new_from_vec(vec![1.0, 2.0, 3.0, 4.0]).unwrap();
         let q = StatsSummary1D::new_from_vec(vec![1.0, 2.0]).unwrap();
         let r = StatsSummary1D::new_from_vec(vec![3.0, 4.0]).unwrap();
         assert_close_enough(&q.combine(r).unwrap(), &p);
+
+        let p = StatsSummary1D::new_from_vec(vec![tf(1.0), tf(2.0), tf(3.0), tf(4.0)]).unwrap();
+        let q = StatsSummary1D::new_from_vec(vec![tf(1.0), tf(2.0)]).unwrap();
+        let r = StatsSummary1D::new_from_vec(vec![tf(3.0), tf(4.0)]).unwrap();
+        assert_close_enough_tf(&q.combine(r).unwrap(), &p);
     }
 }

--- a/crates/stats-agg/src/stats2d.rs
+++ b/crates/stats-agg/src/stats2d.rs
@@ -1,48 +1,67 @@
 // 2D stats are based on the Youngs-Cramer implementation in PG here:
 // https://github.com/postgres/postgres/blob/472e518a44eacd9caac7d618f1b6451672ca4481/src/backend/utils/adt/float.c#L3260
-use crate::{StatsError, XYPair, INV_FLOATING_ERROR_THRESHOLD, M3, M4};
-use flat_serialize_macro::FlatSerializable;
+use crate::{FloatLike, StatsError, XYPair, INV_FLOATING_ERROR_THRESHOLD, M3, M4};
 use serde::{Deserialize, Serialize};
+use twofloat::TwoFloat;
 
-#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize, FlatSerializable)]
+mod stats2d_flat_serialize;
+
+#[derive(Debug, PartialEq, Copy, Clone, Serialize, Deserialize)]
 #[repr(C)]
-pub struct StatsSummary2D {
-    pub n: u64,   // count
-    pub sx: f64,  // sum(x)
-    pub sx2: f64, // sum((x-sx/n)^2) (sum of squares)
-    pub sx3: f64, // sum((x-sx/n)^3)
-    pub sx4: f64, // sum((x-sx/n)^4)
-    pub sy: f64,  // sum(y)
-    pub sy2: f64, // sum((y-sy/n)^2) (sum of squares)
-    pub sy3: f64, // sum((y-sy/n)^3)
-    pub sy4: f64, // sum((y-sy/n)^4)
-    pub sxy: f64, // sum((x-sx/n)*(y-sy/n)) (sum of products)
+pub struct StatsSummary2D<T: FloatLike> {
+    pub n: u64, // count
+    pub sx: T,  // sum(x)
+    pub sx2: T, // sum((x-sx/n)^2) (sum of squares)
+    pub sx3: T, // sum((x-sx/n)^3)
+    pub sx4: T, // sum((x-sx/n)^4)
+    pub sy: T,  // sum(y)
+    pub sy2: T, // sum((y-sy/n)^2) (sum of squares)
+    pub sy3: T, // sum((y-sy/n)^3)
+    pub sy4: T, // sum((y-sy/n)^4)
+    pub sxy: T, // sum((x-sx/n)*(y-sy/n)) (sum of products)
 }
 
-impl Default for StatsSummary2D {
+impl From<StatsSummary2D<TwoFloat>> for StatsSummary2D<f64> {
+    fn from(input_summary: StatsSummary2D<TwoFloat>) -> Self {
+        StatsSummary2D {
+            n: input_summary.n,
+            sx: input_summary.sx.into(),
+            sx2: input_summary.sx2.into(),
+            sx3: input_summary.sx3.into(),
+            sx4: input_summary.sx4.into(),
+            sy: input_summary.sy.into(),
+            sy2: input_summary.sy2.into(),
+            sy3: input_summary.sy3.into(),
+            sy4: input_summary.sy4.into(),
+            sxy: input_summary.sxy.into(),
+        }
+    }
+}
+
+impl<T: FloatLike> Default for StatsSummary2D<T> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl StatsSummary2D {
+impl<T: FloatLike> StatsSummary2D<T> {
     pub fn new() -> Self {
         StatsSummary2D {
             n: 0,
-            sx: 0.0,
-            sx2: 0.0,
-            sx3: 0.0,
-            sx4: 0.0,
-            sy: 0.0,
-            sy2: 0.0,
-            sy3: 0.0,
-            sy4: 0.0,
-            sxy: 0.0,
+            sx: T::zero(),
+            sx2: T::zero(),
+            sx3: T::zero(),
+            sx4: T::zero(),
+            sy: T::zero(),
+            sy2: T::zero(),
+            sy3: T::zero(),
+            sy4: T::zero(),
+            sxy: T::zero(),
         }
     }
 
-    fn n64(&self) -> f64 {
-        self.n as f64
+    fn n64(&self) -> T {
+        T::from_u64(self.n)
     }
     /// accumulate an XYPair into a StatsSummary2D
     /// ```
@@ -59,7 +78,7 @@ impl StatsSummary2D {
     /// assert_eq!(p.accum(XYPair{y:f64::MAX, x:1.0,}), Err(StatsError::DoubleOverflow)); // we do error if we actually overflow however
     ///
     ///```
-    pub fn accum(&mut self, p: XYPair) -> Result<(), StatsError> {
+    pub fn accum(&mut self, p: XYPair<T>) -> Result<(), StatsError> {
         let old = *self;
         self.n += 1;
         self.sx += p.x;
@@ -67,7 +86,7 @@ impl StatsSummary2D {
         if old.n > 0 {
             let tmpx = p.x * self.n64() - self.sx;
             let tmpy = p.y * self.n64() - self.sy;
-            let scale = 1.0 / (self.n64() * old.n64());
+            let scale = (self.n64() * old.n64()).recip();
             self.sx2 += tmpx * tmpx * scale;
             self.sx3 = M3::accum(old.n64(), old.sx, old.sx2, old.sx3, p.x);
             self.sx4 = M4::accum(old.n64(), old.sx, old.sx2, old.sx3, old.sx4, p.x);
@@ -85,40 +104,40 @@ impl StatsSummary2D {
                 // infinite input (because they necessarily involve multiplications of
                 // infinites, which are NaNs)
                 if self.sx2.is_infinite() {
-                    self.sx2 = f64::NAN;
+                    self.sx2 = T::nan();
                 }
                 if self.sx3.is_infinite() {
-                    self.sx3 = f64::NAN;
+                    self.sx3 = T::nan();
                 }
                 if self.sx4.is_infinite() {
-                    self.sx4 = f64::NAN;
+                    self.sx4 = T::nan();
                 }
                 if self.sy2.is_infinite() {
-                    self.sy2 = f64::NAN;
+                    self.sy2 = T::nan();
                 }
                 if self.sy3.is_infinite() {
-                    self.sy3 = f64::NAN;
+                    self.sy3 = T::nan();
                 }
                 if self.sy4.is_infinite() {
-                    self.sy4 = f64::NAN;
+                    self.sy4 = T::nan();
                 }
                 if self.sxy.is_infinite() {
-                    self.sxy = f64::NAN;
+                    self.sxy = T::nan();
                 }
             }
         } else {
             // first input, leave sxx/syy/sxy alone unless we have infinite inputs
             if !p.x.is_finite() {
-                self.sx2 = f64::NAN;
-                self.sx3 = f64::NAN;
-                self.sx4 = f64::NAN;
-                self.sxy = f64::NAN;
+                self.sx2 = T::nan();
+                self.sx3 = T::nan();
+                self.sx4 = T::nan();
+                self.sxy = T::nan();
             }
             if !p.y.is_finite() {
-                self.sy2 = f64::NAN;
-                self.sy3 = f64::NAN;
-                self.sy4 = f64::NAN;
-                self.sxy = f64::NAN;
+                self.sy2 = T::nan();
+                self.sy3 = T::nan();
+                self.sy4 = T::nan();
+                self.sxy = T::nan();
             }
         }
         Result::Ok(())
@@ -134,7 +153,7 @@ impl StatsSummary2D {
             || self.sy4.is_infinite()
             || self.sxy.is_infinite()
     }
-    fn check_overflow(&self, old: &StatsSummary2D, p: XYPair) -> bool {
+    fn check_overflow(&self, old: &StatsSummary2D<T>, p: XYPair<T>) -> bool {
         //Only report overflow if we have finite inputs that lead to infinite results.
         ((self.sx.is_infinite()
             || self.sx2.is_infinite()
@@ -172,7 +191,7 @@ impl StatsSummary2D {
     // sum((x - Sx/n)^2) = Sxx = Sxx_old + 1/(n * n_old) * (nx - Sx)^2  -> Sxx_old = Sxx - 1/(n * n_old) * (nx - Sx)^2
     // Sy / Syy analogous
     // sum((x - Sx/n)(y - Sy/n)) = Sxy = Sxy_old + 1/(n * n_old) * (nx - Sx) * (ny - Sy)  -> Sxy_old = Sxy - 1/(n * n_old) * (nx - Sx) * (ny - Sy)
-    pub fn remove(&self, p: XYPair) -> Option<Self> {
+    pub fn remove(&self, p: XYPair<T>) -> Option<Self> {
         // if we are trying to remove a nan/infinite input, it's time to recalculate.
         if !p.x.is_finite() || !p.y.is_finite() {
             return None;
@@ -180,9 +199,8 @@ impl StatsSummary2D {
         // if we are removing a value that is very large compared to the sum of the values that we're removing it from,
         // we should probably recalculate to avoid accumulating error. We might want a different test for this, if there
         // is a  way to calculate the error directly, that might be best...
-        if p.x / self.sx > INV_FLOATING_ERROR_THRESHOLD
-            || p.y / self.sy > INV_FLOATING_ERROR_THRESHOLD
-        {
+        let thresh = <T as From<f64>>::from(INV_FLOATING_ERROR_THRESHOLD);
+        if p.x / self.sx > thresh || p.y / self.sy > thresh {
             return None;
         }
 
@@ -200,17 +218,17 @@ impl StatsSummary2D {
             n: self.n - 1,
             sx: self.sx - p.x,
             sy: self.sy - p.y,
-            sx2: 0.0, // initialize these for now.
-            sx3: 0.0,
-            sx4: 0.0,
-            sy2: 0.0,
-            sy3: 0.0,
-            sy4: 0.0,
-            sxy: 0.0,
+            sx2: T::zero(), // initialize these for now.
+            sx3: T::zero(),
+            sx4: T::zero(),
+            sy2: T::zero(),
+            sy3: T::zero(),
+            sy4: T::zero(),
+            sxy: T::zero(),
         };
         let tmpx = p.x * self.n64() - self.sx;
         let tmpy = p.y * self.n64() - self.sy;
-        let scale = 1.0 / (self.n64() * new.n64());
+        let scale = (self.n64() * new.n64()).recip();
         new.sx2 = self.sx2 - tmpx * tmpx * scale;
         new.sx3 = M3::remove(new.n64(), new.sx, new.sx2, self.sx3, p.x);
         new.sx4 = M4::remove(new.n64(), new.sx, new.sx2, new.sx3, self.sx4, p.x);
@@ -232,7 +250,7 @@ impl StatsSummary2D {
     /// let q = StatsSummary2D::new_from_vec(vec![XYPair{x:1.0, y:1.0,}, XYPair{x:2.0, y:2.0,}, XYPair{x:3.0, y:3.0,}]).unwrap();
     /// assert_eq!(p, q);
     ///```
-    pub fn new_from_vec(v: Vec<XYPair>) -> Result<Self, StatsError> {
+    pub fn new_from_vec(v: Vec<XYPair<T>>) -> Result<Self, StatsError> {
         let mut r = StatsSummary2D::new();
         for p in v {
             r.accum(p)?;
@@ -255,7 +273,7 @@ impl StatsSummary2D {
     //      sxx = sxx1 + sxx2 + n1 * n2 * (sx1/n1 - sx2/n2)^2 / n
     //      sy / syy analogous
     //      sxy = sxy1 + sxy2 + n1 * n2 * (sx1/n1 - sx2/n2) * (sy1/n1 - sy2/n2) / n
-    pub fn combine(&self, other: StatsSummary2D) -> Result<Self, StatsError> {
+    pub fn combine(&self, other: StatsSummary2D<T>) -> Result<Self, StatsError> {
         // TODO: think about whether we want to just modify &self in place here for perf
         // reasons. This is also a set of weird questions around the Rust compiler, so
         // easier to just add the copy trait here, may need to adjust or may make things
@@ -274,7 +292,7 @@ impl StatsSummary2D {
         let r = StatsSummary2D {
             n,
             sx: self.sx + other.sx,
-            sx2: self.sx2 + other.sx2 + self.n64() * other.n64() * tmpx * tmpx / n as f64,
+            sx2: self.sx2 + other.sx2 + self.n64() * other.n64() * tmpx * tmpx / T::from_u64(n),
             sx3: M3::combine(
                 self.n64(),
                 other.n64(),
@@ -298,7 +316,7 @@ impl StatsSummary2D {
                 other.sx4,
             ),
             sy: self.sy + other.sy,
-            sy2: self.sy2 + other.sy2 + self.n64() * other.n64() * tmpy * tmpy / n as f64,
+            sy2: self.sy2 + other.sy2 + self.n64() * other.n64() * tmpy * tmpy / T::from_u64(n),
             sy3: M3::combine(
                 self.n64(),
                 other.n64(),
@@ -321,7 +339,7 @@ impl StatsSummary2D {
                 self.sy4,
                 other.sy4,
             ),
-            sxy: self.sxy + other.sxy + self.n64() * other.n64() * tmpx * tmpy / n as f64,
+            sxy: self.sxy + other.sxy + self.n64() * other.n64() * tmpx * tmpy / T::from_u64(n),
         };
         if r.has_infinite() && !self.has_infinite() && !other.has_infinite() {
             return Err(StatsError::DoubleOverflow);
@@ -333,7 +351,7 @@ impl StatsSummary2D {
     // for re-aggregation over a window, this is what will get called in tumbling window averages for instance.
     // As with any window function, returning None will cause a re-calculation, so we do that in several cases where either we're dealing with infinites or we have some potential problems with outlying sums
     // so here, self is the previously combined StatsSummary, and we're removing the input and returning the part that would have been there before.
-    pub fn remove_combined(&self, remove: StatsSummary2D) -> Option<Self> {
+    pub fn remove_combined(&self, remove: StatsSummary2D<T>) -> Option<Self> {
         let combined = &self; // just to lessen confusion with naming
                               // handle the trivial n = 0 and equal n cases here, and don't worry about divide by zero errors later.
         if combined.n == remove.n {
@@ -344,22 +362,21 @@ impl StatsSummary2D {
             panic!(); //  given that we're always removing things that we've previously added, we shouldn't be able to get a case where we're removing an n that's larger.
         }
         // if the sum we're removing is very large compared to the overall value we need to recalculate, see note on the remove function
-        if remove.sx / combined.sx > INV_FLOATING_ERROR_THRESHOLD
-            || remove.sy / combined.sy > INV_FLOATING_ERROR_THRESHOLD
-        {
+        let thresh = <T as From<f64>>::from(INV_FLOATING_ERROR_THRESHOLD);
+        if remove.sx / combined.sx > thresh || remove.sy / combined.sy > thresh {
             return None;
         }
         let mut part = StatsSummary2D {
             n: combined.n - remove.n,
             sx: combined.sx - remove.sx,
             sy: combined.sy - remove.sy,
-            sx2: 0.0, //just initialize these, for now.
-            sx3: 0.0,
-            sx4: 0.0,
-            sy2: 0.0,
-            sy3: 0.0,
-            sy4: 0.0,
-            sxy: 0.0,
+            sx2: T::zero(), //just initialize these, for now.
+            sx3: T::zero(),
+            sx4: T::zero(),
+            sy2: T::zero(),
+            sy3: T::zero(),
+            sy4: T::zero(),
+            sxy: T::zero(),
         };
         let tmpx = part.sx / part.n64() - remove.sx / remove.n64(); //gets squared so order doesn't matter
         let tmpy = part.sy / part.n64() - remove.sy / remove.n64();
@@ -430,7 +447,7 @@ impl StatsSummary2D {
     // Y + C - Sy/N - NC/N
     // Y + C - Sy/N - C
     // Y - Sy/N
-    pub fn offset(&mut self, offset: XYPair) -> Result<(), StatsError> {
+    pub fn offset(&mut self, offset: XYPair<T>) -> Result<(), StatsError> {
         self.sx += self.n64() * offset.x;
         self.sy += self.n64() * offset.y;
         if self.has_infinite() && offset.x.is_finite() && offset.y.is_finite() {
@@ -453,9 +470,9 @@ impl StatsSummary2D {
     /// assert_eq!(ssp.x, ssx);
     /// assert_eq!(ssp.y, ssy);
     /// //empty StatsSummary2Ds return None
-    /// assert!(StatsSummary2D::new().sum_squares().is_none());
+    /// assert!(StatsSummary2D::<f64>::new().sum_squares().is_none());
     /// ```
-    pub fn sum_squares(&self) -> Option<XYPair> {
+    pub fn sum_squares(&self) -> Option<XYPair<T>> {
         if self.n == 0 {
             return None;
         }
@@ -472,9 +489,9 @@ impl StatsSummary2D {
     /// let s = (2.0 * 1.0 + 4.0 * 2.0 + 6.0 * 3.0) - (2.0 + 4.0 + 6.0)*(1.0 + 2.0 + 3.0)/3.0;
     /// assert_eq!(p.sumxy().unwrap(), s);
     /// //empty StatsSummary2Ds return None
-    /// assert!(StatsSummary2D::new().sumxy().is_none());
+    /// assert!(StatsSummary2D::<f64>::new().sumxy().is_none());
     /// ```
-    pub fn sumxy(&self) -> Option<f64> {
+    pub fn sumxy(&self) -> Option<T> {
         if self.n == 0 {
             return None;
         }
@@ -491,9 +508,9 @@ impl StatsSummary2D {
     /// assert_eq!(avgp.x, avgx);
     /// assert_eq!(avgp.y, avgy);
     /// //empty StatsSummary2Ds return None
-    /// assert!(StatsSummary2D::new().avg().is_none());
+    /// assert!(StatsSummary2D::<f64>::new().avg().is_none());
     /// ```
-    pub fn avg(&self) -> Option<XYPair> {
+    pub fn avg(&self) -> Option<XYPair<T>> {
         if self.n == 0 {
             return None;
         }
@@ -511,7 +528,7 @@ impl StatsSummary2D {
     /// let s = 3;
     /// assert_eq!(p.count(), s);
     /// //empty StatsSummary2Ds return 0 count
-    /// assert_eq!(StatsSummary2D::new().count(), 0);
+    /// assert_eq!(StatsSummary2D::<f64>::new().count(), 0);
     /// ```
     pub fn count(&self) -> i64 {
         self.n as i64
@@ -527,9 +544,9 @@ impl StatsSummary2D {
     /// assert_eq!(sump.x, sumx);
     /// assert_eq!(sump.y, sumy);
     /// //empty StatsSummary2Ds return None
-    /// assert!(StatsSummary2D::new().sum().is_none());
+    /// assert!(StatsSummary2D::<f64>::new().sum().is_none());
     /// ```
-    pub fn sum(&self) -> Option<XYPair> {
+    pub fn sum(&self) -> Option<XYPair<T>> {
         if self.n == 0 {
             return None;
         }
@@ -539,7 +556,7 @@ impl StatsSummary2D {
         })
     }
 
-    pub fn var_pop(&self) -> Option<XYPair> {
+    pub fn var_pop(&self) -> Option<XYPair<T>> {
         if self.n == 0 {
             return None;
         }
@@ -549,18 +566,18 @@ impl StatsSummary2D {
         })
     }
 
-    pub fn var_samp(&self) -> Option<XYPair> {
+    pub fn var_samp(&self) -> Option<XYPair<T>> {
         if self.n <= 1 {
             return None;
         }
         Some(XYPair {
-            x: self.sx2 / (self.n64() - 1.0),
-            y: self.sy2 / (self.n64() - 1.0),
+            x: self.sx2 / (self.n64() - T::one()),
+            y: self.sy2 / (self.n64() - T::one()),
         })
     }
 
     ///returns the population standard deviation of both the independent and dependent variables as an XYPair
-    pub fn stddev_pop(&self) -> Option<XYPair> {
+    pub fn stddev_pop(&self) -> Option<XYPair<T>> {
         let var = self.var_pop()?;
         Some(XYPair {
             x: var.x.sqrt(),
@@ -569,7 +586,7 @@ impl StatsSummary2D {
     }
 
     ///returns the sample standard deviation of both the independent and dependent variables as an XYPair
-    pub fn stddev_samp(&self) -> Option<XYPair> {
+    pub fn stddev_samp(&self) -> Option<XYPair<T>> {
         let var = self.var_samp()?;
         Some(XYPair {
             x: var.x.sqrt(),
@@ -577,7 +594,7 @@ impl StatsSummary2D {
         })
     }
 
-    pub fn skewness_pop(&self) -> Option<XYPair> {
+    pub fn skewness_pop(&self) -> Option<XYPair<T>> {
         let stddev = self.stddev_pop()?;
         Some(XYPair {
             x: self.sx3 / self.n64() / stddev.x.powi(3),
@@ -585,15 +602,15 @@ impl StatsSummary2D {
         })
     }
 
-    pub fn skewness_samp(&self) -> Option<XYPair> {
+    pub fn skewness_samp(&self) -> Option<XYPair<T>> {
         let stddev = self.stddev_samp()?;
         Some(XYPair {
-            x: self.sx3 / (self.n64() - 1.0) / stddev.x.powi(3),
-            y: self.sy3 / (self.n64() - 1.0) / stddev.y.powi(3),
+            x: self.sx3 / (self.n64() - T::one()) / stddev.x.powi(3),
+            y: self.sy3 / (self.n64() - T::one()) / stddev.y.powi(3),
         })
     }
 
-    pub fn kurtosis_pop(&self) -> Option<XYPair> {
+    pub fn kurtosis_pop(&self) -> Option<XYPair<T>> {
         let stddev = self.stddev_pop()?;
         Some(XYPair {
             x: self.sx4 / self.n64() / stddev.x.powi(4),
@@ -601,11 +618,11 @@ impl StatsSummary2D {
         })
     }
 
-    pub fn kurtosis_samp(&self) -> Option<XYPair> {
+    pub fn kurtosis_samp(&self) -> Option<XYPair<T>> {
         let stddev = self.stddev_samp()?;
         Some(XYPair {
-            x: self.sx4 / (self.n64() - 1.0) / stddev.x.powi(4),
-            y: self.sy4 / (self.n64() - 1.0) / stddev.y.powi(4),
+            x: self.sx4 / (self.n64() - T::one()) / stddev.x.powi(4),
+            y: self.sy4 / (self.n64() - T::one()) / stddev.y.powi(4),
         })
     }
 
@@ -613,27 +630,27 @@ impl StatsSummary2D {
     /// Note that it makes no difference whether we choose the sample or
     /// population covariance and stddev, because we end up with a canceling n or n-1 term. This
     /// also allows us to reduce our calculation to the sumxy / sqrt(sum_squares(x)*sum_squares(y))
-    pub fn corr(&self) -> Option<f64> {
+    pub fn corr(&self) -> Option<T> {
         // empty StatsSummary2Ds, horizontal or vertical lines should return None
-        if self.n == 0 || self.sx2 == 0.0 || self.sy2 == 0.0 {
+        if self.n == 0 || self.sx2 == T::zero() || self.sy2 == T::zero() {
             return None;
         }
         Some(self.sxy / (self.sx2 * self.sy2).sqrt())
     }
 
     /// returns the slope of the least squares fit line
-    pub fn slope(&self) -> Option<f64> {
+    pub fn slope(&self) -> Option<T> {
         // the case of a single point will usually be triggered by the the second branch of this (which is also a test for a vertical line)
         //however, in cases where we had an infinite input, we will end up with NaN which is the expected behavior.
-        if self.n == 0 || self.sx2 == 0.0 {
+        if self.n == 0 || self.sx2 == T::zero() {
             return None;
         }
         Some(self.sxy / self.sx2)
     }
 
     /// returns the intercept of the least squares fit line
-    pub fn intercept(&self) -> Option<f64> {
-        if self.n == 0 || self.sx2 == 0.0 {
+    pub fn intercept(&self) -> Option<T> {
+        if self.n == 0 || self.sx2 == T::zero() {
             return None;
         }
         Some((self.sy - self.sx * self.sxy / self.sx2) / self.n64())
@@ -643,26 +660,26 @@ impl StatsSummary2D {
     // y = mx + b (y = 0)
     // -b = mx
     // x = -b / m
-    pub fn x_intercept(&self) -> Option<f64> {
+    pub fn x_intercept(&self) -> Option<T> {
         // vertical line does have an x intercept
-        if self.n > 1 && self.sx2 == 0.0 {
+        if self.n > 1 && self.sx2 == T::zero() {
             return Some(self.sx / self.n64());
         }
         // horizontal lines have no x intercepts
-        if self.sy2 == 0.0 {
+        if self.sy2 == T::zero() {
             return None;
         }
-        Some(-1.0 * self.intercept()? / self.slope()?)
+        Some(-self.intercept()? / self.slope()?)
     }
 
     /// returns the square of the correlation coefficent (aka the coefficient of determination)
-    pub fn determination_coeff(&self) -> Option<f64> {
-        if self.n == 0 || self.sx2 == 0.0 {
+    pub fn determination_coeff(&self) -> Option<T> {
+        if self.n == 0 || self.sx2 == T::zero() {
             return None;
         }
         //horizontal lines return 1.0 error
-        if self.sy2 == 0.0 {
-            return Some(1.0);
+        if self.sy2 == T::zero() {
+            return Some(T::one());
         }
         Some(self.sxy * self.sxy / (self.sx2 * self.sy2))
     }
@@ -676,13 +693,13 @@ impl StatsSummary2D {
     /// let s = s/2.0;
     /// assert_eq!(p.covar_samp().unwrap(), s);
     /// //empty StatsSummary2Ds return None
-    /// assert!(StatsSummary2D::new().covar_samp().is_none());
+    /// assert!(StatsSummary2D::<f64>::new().covar_samp().is_none());
     /// ```
-    pub fn covar_samp(&self) -> Option<f64> {
+    pub fn covar_samp(&self) -> Option<T> {
         if self.n <= 1 {
             return None;
         }
-        Some(self.sxy / (self.n64() - 1.0))
+        Some(self.sxy / (self.n64() - T::one()))
     }
 
     ///returns the population covariance: (sumxy()/n)
@@ -694,9 +711,9 @@ impl StatsSummary2D {
     /// let s = s/3.0;
     /// assert_eq!(p.covar_pop().unwrap(), s);
     /// //empty StatsSummary2Ds return None
-    /// assert!(StatsSummary2D::new().covar_pop().is_none());
+    /// assert!(StatsSummary2D::<f64>::new().covar_pop().is_none());
     /// ```
-    pub fn covar_pop(&self) -> Option<f64> {
+    pub fn covar_pop(&self) -> Option<T> {
         if self.n == 0 {
             return None;
         }
@@ -707,6 +724,10 @@ impl StatsSummary2D {
 #[cfg(test)]
 mod tests {
     use super::*;
+    fn tf(f: f64) -> TwoFloat {
+        TwoFloat::new_add(f, 0.0)
+    }
+
     #[test]
     fn test_linear() {
         let p = StatsSummary2D::new_from_vec(vec![
@@ -730,7 +751,7 @@ mod tests {
         assert_eq!(p.x_intercept().unwrap(), 1.0);
 
         // empty
-        let p = StatsSummary2D::new();
+        let p: StatsSummary2D<f64> = StatsSummary2D::new();
         assert_eq!(p.slope(), None);
         assert_eq!(p.intercept(), None);
         assert_eq!(p.x_intercept(), None);
@@ -756,6 +777,94 @@ mod tests {
         .unwrap();
         assert_eq!(p.slope().unwrap(), 0.0);
         assert_eq!(p.intercept().unwrap(), 2.0);
+        assert_eq!(p.x_intercept(), None);
+    }
+
+    #[test]
+    fn test_linear_tf() {
+        let p = StatsSummary2D::new_from_vec(vec![
+            XYPair {
+                y: tf(2.0),
+                x: tf(1.0),
+            },
+            XYPair {
+                y: tf(4.0),
+                x: tf(2.0),
+            },
+            XYPair {
+                y: tf(6.0),
+                x: tf(3.0),
+            },
+        ])
+        .unwrap();
+        assert_eq!(p.slope().unwrap(), tf(2.0));
+        assert_eq!(p.intercept().unwrap(), tf(0.0));
+        assert_eq!(p.x_intercept().unwrap(), tf(0.0));
+
+        let p = StatsSummary2D::new_from_vec(vec![
+            XYPair {
+                y: tf(2.0),
+                x: tf(2.0),
+            },
+            XYPair {
+                y: tf(4.0),
+                x: tf(3.0),
+            },
+            XYPair {
+                y: tf(6.0),
+                x: tf(4.0),
+            },
+        ])
+        .unwrap();
+        assert_eq!(p.slope().unwrap(), tf(2.0));
+        assert_eq!(p.intercept().unwrap().hi(), -2.0);
+        assert!(p.intercept().unwrap().lo().abs() < f64::EPSILON);
+        assert_eq!(p.x_intercept().unwrap().hi(), 1.0);
+        assert!(p.x_intercept().unwrap().lo().abs() < f64::EPSILON);
+
+        // empty
+        let p: StatsSummary2D<TwoFloat> = StatsSummary2D::new();
+        assert_eq!(p.slope(), None);
+        assert_eq!(p.intercept(), None);
+        assert_eq!(p.x_intercept(), None);
+        // singleton
+        let p = StatsSummary2D::new_from_vec(vec![XYPair {
+            y: tf(2.0),
+            x: tf(2.0),
+        }])
+        .unwrap();
+        assert_eq!(p.slope(), None);
+        assert_eq!(p.intercept(), None);
+        assert_eq!(p.x_intercept(), None);
+        //vertical
+        let p = StatsSummary2D::new_from_vec(vec![
+            XYPair {
+                y: tf(2.0),
+                x: tf(2.0),
+            },
+            XYPair {
+                y: tf(4.0),
+                x: tf(2.0),
+            },
+        ])
+        .unwrap();
+        assert_eq!(p.slope(), None);
+        assert_eq!(p.intercept(), None);
+        assert_eq!(p.x_intercept().unwrap(), tf(2.0));
+        //horizontal
+        let p = StatsSummary2D::new_from_vec(vec![
+            XYPair {
+                y: tf(2.0),
+                x: tf(2.0),
+            },
+            XYPair {
+                y: tf(2.0),
+                x: tf(4.0),
+            },
+        ])
+        .unwrap();
+        assert_eq!(p.slope().unwrap(), tf(0.0));
+        assert_eq!(p.intercept().unwrap(), tf(2.0));
         assert_eq!(p.x_intercept(), None);
     }
 }

--- a/crates/stats-agg/src/stats2d/stats2d_flat_serialize.rs
+++ b/crates/stats-agg/src/stats2d/stats2d_flat_serialize.rs
@@ -1,0 +1,425 @@
+use super::*;
+
+// expanded from FlatSerializable derive macro and made to work right with generic arg
+#[allow(warnings, clippy::all)]
+unsafe impl<'a> flat_serialize::FlatSerializable<'a> for StatsSummary2D<f64> {
+    const REQUIRED_ALIGNMENT: usize = {
+        use std::mem::align_of;
+        let mut required_alignment = 1;
+        let alignment = <u64 as flat_serialize::FlatSerializable>::REQUIRED_ALIGNMENT;
+        if alignment > required_alignment {
+            required_alignment = alignment;
+        }
+        let alignment = <f64 as flat_serialize::FlatSerializable>::REQUIRED_ALIGNMENT;
+        if alignment > required_alignment {
+            required_alignment = alignment;
+        }
+        let alignment = <f64 as flat_serialize::FlatSerializable>::REQUIRED_ALIGNMENT;
+        if alignment > required_alignment {
+            required_alignment = alignment;
+        }
+        let alignment = <f64 as flat_serialize::FlatSerializable>::REQUIRED_ALIGNMENT;
+        if alignment > required_alignment {
+            required_alignment = alignment;
+        }
+        let alignment = <f64 as flat_serialize::FlatSerializable>::REQUIRED_ALIGNMENT;
+        if alignment > required_alignment {
+            required_alignment = alignment;
+        }
+        let alignment = <f64 as flat_serialize::FlatSerializable>::REQUIRED_ALIGNMENT;
+        if alignment > required_alignment {
+            required_alignment = alignment;
+        }
+        let alignment = <f64 as flat_serialize::FlatSerializable>::REQUIRED_ALIGNMENT;
+        if alignment > required_alignment {
+            required_alignment = alignment;
+        }
+        let alignment = <f64 as flat_serialize::FlatSerializable>::REQUIRED_ALIGNMENT;
+        if alignment > required_alignment {
+            required_alignment = alignment;
+        }
+        let alignment = <f64 as flat_serialize::FlatSerializable>::REQUIRED_ALIGNMENT;
+        if alignment > required_alignment {
+            required_alignment = alignment;
+        }
+        let alignment = <f64 as flat_serialize::FlatSerializable>::REQUIRED_ALIGNMENT;
+        if alignment > required_alignment {
+            required_alignment = alignment;
+        }
+        required_alignment
+    };
+    const MAX_PROVIDED_ALIGNMENT: Option<usize> = {
+        use std::mem::align_of;
+        let mut min_align: Option<usize> = None;
+        let ty_align = <u64 as flat_serialize::FlatSerializable>::MAX_PROVIDED_ALIGNMENT;
+        match (ty_align, min_align) {
+            (None, _) => {}
+            (Some(align), None) => min_align = Some(align),
+            (Some(align), Some(min)) if align < min => min_align = Some(align),
+            _ => {}
+        }
+        let ty_align = <f64 as flat_serialize::FlatSerializable>::MAX_PROVIDED_ALIGNMENT;
+        match (ty_align, min_align) {
+            (None, _) => {}
+            (Some(align), None) => min_align = Some(align),
+            (Some(align), Some(min)) if align < min => min_align = Some(align),
+            _ => {}
+        }
+        let ty_align = <f64 as flat_serialize::FlatSerializable>::MAX_PROVIDED_ALIGNMENT;
+        match (ty_align, min_align) {
+            (None, _) => {}
+            (Some(align), None) => min_align = Some(align),
+            (Some(align), Some(min)) if align < min => min_align = Some(align),
+            _ => {}
+        }
+        let ty_align = <f64 as flat_serialize::FlatSerializable>::MAX_PROVIDED_ALIGNMENT;
+        match (ty_align, min_align) {
+            (None, _) => {}
+            (Some(align), None) => min_align = Some(align),
+            (Some(align), Some(min)) if align < min => min_align = Some(align),
+            _ => {}
+        }
+        let ty_align = <f64 as flat_serialize::FlatSerializable>::MAX_PROVIDED_ALIGNMENT;
+        match (ty_align, min_align) {
+            (None, _) => {}
+            (Some(align), None) => min_align = Some(align),
+            (Some(align), Some(min)) if align < min => min_align = Some(align),
+            _ => {}
+        }
+        let ty_align = <f64 as flat_serialize::FlatSerializable>::MAX_PROVIDED_ALIGNMENT;
+        match (ty_align, min_align) {
+            (None, _) => {}
+            (Some(align), None) => min_align = Some(align),
+            (Some(align), Some(min)) if align < min => min_align = Some(align),
+            _ => {}
+        }
+        let ty_align = <f64 as flat_serialize::FlatSerializable>::MAX_PROVIDED_ALIGNMENT;
+        match (ty_align, min_align) {
+            (None, _) => {}
+            (Some(align), None) => min_align = Some(align),
+            (Some(align), Some(min)) if align < min => min_align = Some(align),
+            _ => {}
+        }
+        let ty_align = <f64 as flat_serialize::FlatSerializable>::MAX_PROVIDED_ALIGNMENT;
+        match (ty_align, min_align) {
+            (None, _) => {}
+            (Some(align), None) => min_align = Some(align),
+            (Some(align), Some(min)) if align < min => min_align = Some(align),
+            _ => {}
+        }
+        let ty_align = <f64 as flat_serialize::FlatSerializable>::MAX_PROVIDED_ALIGNMENT;
+        match (ty_align, min_align) {
+            (None, _) => {}
+            (Some(align), None) => min_align = Some(align),
+            (Some(align), Some(min)) if align < min => min_align = Some(align),
+            _ => {}
+        }
+        let ty_align = <f64 as flat_serialize::FlatSerializable>::MAX_PROVIDED_ALIGNMENT;
+        match (ty_align, min_align) {
+            (None, _) => {}
+            (Some(align), None) => min_align = Some(align),
+            (Some(align), Some(min)) if align < min => min_align = Some(align),
+            _ => {}
+        }
+        match min_align {
+            None => None,
+            Some(min_align) => {
+                let min_size = Self::MIN_LEN;
+                if min_size % 8 == 0 && min_align >= 8 {
+                    Some(8)
+                } else if min_size % 4 == 0 && min_align >= 4 {
+                    Some(4)
+                } else if min_size % 2 == 0 && min_align >= 2 {
+                    Some(2)
+                } else {
+                    Some(1)
+                }
+            }
+        }
+    };
+    const MIN_LEN: usize = {
+        use std::mem::size_of;
+        let mut size = 0;
+        size += <u64 as flat_serialize::FlatSerializable>::MIN_LEN;
+        size += <f64 as flat_serialize::FlatSerializable>::MIN_LEN;
+        size += <f64 as flat_serialize::FlatSerializable>::MIN_LEN;
+        size += <f64 as flat_serialize::FlatSerializable>::MIN_LEN;
+        size += <f64 as flat_serialize::FlatSerializable>::MIN_LEN;
+        size += <f64 as flat_serialize::FlatSerializable>::MIN_LEN;
+        size += <f64 as flat_serialize::FlatSerializable>::MIN_LEN;
+        size += <f64 as flat_serialize::FlatSerializable>::MIN_LEN;
+        size += <f64 as flat_serialize::FlatSerializable>::MIN_LEN;
+        size += <f64 as flat_serialize::FlatSerializable>::MIN_LEN;
+        size
+    };
+    const TRIVIAL_COPY: bool = true;
+    type SLICE = flat_serialize::Slice<'a, StatsSummary2D<f64>>;
+    type OWNED = Self;
+    #[allow(unused_assignments, unused_variables)]
+    #[inline(always)]
+    unsafe fn try_ref(mut input: &[u8]) -> Result<(Self, &[u8]), flat_serialize::WrapErr> {
+        if input.len() < Self::MIN_LEN {
+            return Err(flat_serialize::WrapErr::NotEnoughBytes(Self::MIN_LEN));
+        }
+        let __packet_macro_read_len = 0usize;
+        let mut n: Option<u64> = None;
+        let mut sx: Option<f64> = None;
+        let mut sx2: Option<f64> = None;
+        let mut sx3: Option<f64> = None;
+        let mut sx4: Option<f64> = None;
+        let mut sy: Option<f64> = None;
+        let mut sy2: Option<f64> = None;
+        let mut sy3: Option<f64> = None;
+        let mut sy4: Option<f64> = None;
+        let mut sxy: Option<f64> = None;
+        'tryref: loop {
+            {
+                let (field, rem) = match <u64>::try_ref(input) {
+                    Ok((f, b)) => (f, b),
+                    Err(flat_serialize::WrapErr::InvalidTag(offset)) => {
+                        return Err(flat_serialize::WrapErr::InvalidTag(
+                            __packet_macro_read_len + offset,
+                        ));
+                    }
+                    Err(..) => break 'tryref,
+                };
+                input = rem;
+                n = Some(field);
+            }
+            {
+                let (field, rem) = match <f64>::try_ref(input) {
+                    Ok((f, b)) => (f, b),
+                    Err(flat_serialize::WrapErr::InvalidTag(offset)) => {
+                        return Err(flat_serialize::WrapErr::InvalidTag(
+                            __packet_macro_read_len + offset,
+                        ));
+                    }
+                    Err(..) => break 'tryref,
+                };
+                input = rem;
+                sx = Some(field);
+            }
+            {
+                let (field, rem) = match <f64>::try_ref(input) {
+                    Ok((f, b)) => (f, b),
+                    Err(flat_serialize::WrapErr::InvalidTag(offset)) => {
+                        return Err(flat_serialize::WrapErr::InvalidTag(
+                            __packet_macro_read_len + offset,
+                        ));
+                    }
+                    Err(..) => break 'tryref,
+                };
+                input = rem;
+                sx2 = Some(field);
+            }
+            {
+                let (field, rem) = match <f64>::try_ref(input) {
+                    Ok((f, b)) => (f, b),
+                    Err(flat_serialize::WrapErr::InvalidTag(offset)) => {
+                        return Err(flat_serialize::WrapErr::InvalidTag(
+                            __packet_macro_read_len + offset,
+                        ));
+                    }
+                    Err(..) => break 'tryref,
+                };
+                input = rem;
+                sx3 = Some(field);
+            }
+            {
+                let (field, rem) = match <f64>::try_ref(input) {
+                    Ok((f, b)) => (f, b),
+                    Err(flat_serialize::WrapErr::InvalidTag(offset)) => {
+                        return Err(flat_serialize::WrapErr::InvalidTag(
+                            __packet_macro_read_len + offset,
+                        ));
+                    }
+                    Err(..) => break 'tryref,
+                };
+                input = rem;
+                sx4 = Some(field);
+            }
+            {
+                let (field, rem) = match <f64>::try_ref(input) {
+                    Ok((f, b)) => (f, b),
+                    Err(flat_serialize::WrapErr::InvalidTag(offset)) => {
+                        return Err(flat_serialize::WrapErr::InvalidTag(
+                            __packet_macro_read_len + offset,
+                        ));
+                    }
+                    Err(..) => break 'tryref,
+                };
+                input = rem;
+                sy = Some(field);
+            }
+            {
+                let (field, rem) = match <f64>::try_ref(input) {
+                    Ok((f, b)) => (f, b),
+                    Err(flat_serialize::WrapErr::InvalidTag(offset)) => {
+                        return Err(flat_serialize::WrapErr::InvalidTag(
+                            __packet_macro_read_len + offset,
+                        ));
+                    }
+                    Err(..) => break 'tryref,
+                };
+                input = rem;
+                sy2 = Some(field);
+            }
+            {
+                let (field, rem) = match <f64>::try_ref(input) {
+                    Ok((f, b)) => (f, b),
+                    Err(flat_serialize::WrapErr::InvalidTag(offset)) => {
+                        return Err(flat_serialize::WrapErr::InvalidTag(
+                            __packet_macro_read_len + offset,
+                        ));
+                    }
+                    Err(..) => break 'tryref,
+                };
+                input = rem;
+                sy3 = Some(field);
+            }
+            {
+                let (field, rem) = match <f64>::try_ref(input) {
+                    Ok((f, b)) => (f, b),
+                    Err(flat_serialize::WrapErr::InvalidTag(offset)) => {
+                        return Err(flat_serialize::WrapErr::InvalidTag(
+                            __packet_macro_read_len + offset,
+                        ));
+                    }
+                    Err(..) => break 'tryref,
+                };
+                input = rem;
+                sy4 = Some(field);
+            }
+            {
+                let (field, rem) = match <f64>::try_ref(input) {
+                    Ok((f, b)) => (f, b),
+                    Err(flat_serialize::WrapErr::InvalidTag(offset)) => {
+                        return Err(flat_serialize::WrapErr::InvalidTag(
+                            __packet_macro_read_len + offset,
+                        ));
+                    }
+                    Err(..) => break 'tryref,
+                };
+                input = rem;
+                sxy = Some(field);
+            }
+            let _ref = StatsSummary2D {
+                n: n.unwrap(),
+                sx: sx.unwrap(),
+                sx2: sx2.unwrap(),
+                sx3: sx3.unwrap(),
+                sx4: sx4.unwrap(),
+                sy: sy.unwrap(),
+                sy2: sy2.unwrap(),
+                sy3: sy3.unwrap(),
+                sy4: sy4.unwrap(),
+                sxy: sxy.unwrap(),
+            };
+            return Ok((_ref, input));
+        }
+        Err(flat_serialize::WrapErr::NotEnoughBytes(
+            0 + <u64>::MIN_LEN
+                + <f64>::MIN_LEN
+                + <f64>::MIN_LEN
+                + <f64>::MIN_LEN
+                + <f64>::MIN_LEN
+                + <f64>::MIN_LEN
+                + <f64>::MIN_LEN
+                + <f64>::MIN_LEN
+                + <f64>::MIN_LEN
+                + <f64>::MIN_LEN,
+        ))
+    }
+    #[allow(unused_assignments, unused_variables)]
+    #[inline(always)]
+    unsafe fn fill_slice<'out>(
+        &self,
+        input: &'out mut [std::mem::MaybeUninit<u8>],
+    ) -> &'out mut [std::mem::MaybeUninit<u8>] {
+        let total_len = self.num_bytes();
+        let (mut input, rem) = input.split_at_mut(total_len);
+        let StatsSummary2D {
+            n,
+            sx,
+            sx2,
+            sx3,
+            sx4,
+            sy,
+            sy2,
+            sy3,
+            sy4,
+            sxy,
+        } = self;
+        unsafe {
+            input = n.fill_slice(input);
+        };
+        unsafe {
+            input = sx.fill_slice(input);
+        };
+        unsafe {
+            input = sx2.fill_slice(input);
+        };
+        unsafe {
+            input = sx3.fill_slice(input);
+        };
+        unsafe {
+            input = sx4.fill_slice(input);
+        };
+        unsafe {
+            input = sy.fill_slice(input);
+        };
+        unsafe {
+            input = sy2.fill_slice(input);
+        };
+        unsafe {
+            input = sy3.fill_slice(input);
+        };
+        unsafe {
+            input = sy4.fill_slice(input);
+        };
+        unsafe {
+            input = sxy.fill_slice(input);
+        }
+        if true {
+            match (&input.len(), &0) {
+                (left_val, right_val) => {
+                    debug_assert_eq!(input.len(), 0);
+                }
+            };
+        }
+        rem
+    }
+    #[allow(unused_assignments, unused_variables)]
+    #[inline(always)]
+    fn num_bytes(&self) -> usize {
+        let StatsSummary2D {
+            n,
+            sx,
+            sx2,
+            sx3,
+            sx4,
+            sy,
+            sy2,
+            sy3,
+            sy4,
+            sxy,
+        } = self;
+        0usize
+            + <u64 as flat_serialize::FlatSerializable>::num_bytes(n)
+            + <f64 as flat_serialize::FlatSerializable>::num_bytes(sx)
+            + <f64 as flat_serialize::FlatSerializable>::num_bytes(sx2)
+            + <f64 as flat_serialize::FlatSerializable>::num_bytes(sx3)
+            + <f64 as flat_serialize::FlatSerializable>::num_bytes(sx4)
+            + <f64 as flat_serialize::FlatSerializable>::num_bytes(sy)
+            + <f64 as flat_serialize::FlatSerializable>::num_bytes(sy2)
+            + <f64 as flat_serialize::FlatSerializable>::num_bytes(sy3)
+            + <f64 as flat_serialize::FlatSerializable>::num_bytes(sy4)
+            + <f64 as flat_serialize::FlatSerializable>::num_bytes(sxy)
+    }
+    #[inline(always)]
+    fn make_owned(&mut self) {}
+    #[inline(always)]
+    fn into_owned(self) -> Self::OWNED {
+        self
+    }
+}

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -45,6 +45,8 @@ rand = { version = "0.8.3", features = ["getrandom", "small_rng"] }
 rand_distr = "0.4.0"
 rand_chacha = "0.3.0"
 ron="0.6.0"
+twofloat = { version = "0.6.0", features = ["serde"] }
+num-traits = "0.2.15"
 
 pest = "2.1"
 pest_derive = "2.1"

--- a/extension/src/counter_agg.rs
+++ b/extension/src/counter_agg.rs
@@ -29,11 +29,13 @@ use crate::raw::tstzrange;
 
 use crate::raw::bytea;
 
+// pg_type! can't handle generics so use a type alias to specify the type for `stats`
+type PgTypeHackStatsSummary2D = StatsSummary2D<f64>;
 // TODO wrap FlatSummary a la GaugeSummary - requires serialization version bump
 pg_type! {
     #[derive(Debug, PartialEq)]
     struct CounterSummary {
-        stats: StatsSummary2D,
+        stats: PgTypeHackStatsSummary2D,
         first: TSPoint,
         second: TSPoint,
         penultimate:TSPoint,

--- a/extension/src/gauge_agg.rs
+++ b/extension/src/gauge_agg.rs
@@ -27,7 +27,7 @@ use crate::{
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize, FlatSerializable)]
 #[repr(C)]
 pub struct FlatSummary {
-    stats: StatsSummary2D,
+    stats: StatsSummary2D<f64>,
     first: TSPoint,
     second: TSPoint,
     penultimate: TSPoint,

--- a/extension/src/stabilization_info.rs
+++ b/extension/src/stabilization_info.rs
@@ -11,6 +11,14 @@
 
 crate::functions_stabilized_at! {
     STABLE_FUNCTIONS
+    "1.12.0" => {
+        stats1d_tf_inv_trans(internal,double precision),
+        stats1d_tf_final(internal),
+        stats1d_tf_trans(internal,double precision),
+        stats2d_tf_final(internal),
+        stats2d_tf_trans(internal,double precision,double precision),
+        stats2d_tf_inv_trans(internal,double precision,double precision),
+    }
     "1.11.0" => {
         accessorfirsttime_in(cstring),
         accessorfirsttime_out(accessorfirsttime),


### PR DESCRIPTION
Makes `stats_agg` use `TwoFloat`s internally for keeping track of the state when in moving-aggregate mode to prevent floating-point error from accumulating. See #595 for some more details.