### PR TITLE
Fix update-tester on Postgres 12

### DIFF
--- a/tools/update-tester/src/testrunner.rs
+++ b/tools/update-tester/src/testrunner.rs
@@ -256,7 +256,10 @@ impl TestClient {
                 db_creation_client
                     .simple_query(&drop)
                     .unwrap_or_else(|e| panic!("could not drop db {} due to {}", test_db_name, e));
-                let create = format!(r#"CREATE DATABASE "{}" LOCALE 'C'"#, test_db_name);
+                let create = format!(
+                    r#"CREATE DATABASE "{}" LC_COLLATE 'C' LC_CTYPE 'C'"#,
+                    test_db_name
+                );
                 db_creation_client
                     .simple_query(&create)
                     .unwrap_or_else(|e| {


### PR DESCRIPTION
Changes to update-tester so that locale can be set on version 12 without failing.