### PR TITLE
Fix combine_using_settings test broken by switch to INTERVAL.

### DIFF
--- a/extension/src/state_aggregate.rs
+++ b/extension/src/state_aggregate.rs
@@ -729,7 +729,7 @@ insert into test select '2020-01-02 UTC'::timestamptz + make_interval(days=>v), 
                 None,
             );
             assert_eq!(
-                "48:00:00",
+                "2 days",
                 select_one!(
                     client,
                     r#"


### PR DESCRIPTION
Broken by commit abcc17d9342c0c48e91bd82a3194877d9c5644f0 "Return INTERVAL from duration_in(TEXT, StateAgg)."

Really need to figure out how to run this...