### PR TITLE
Drop unsupported Postgres versions from Cargo.toml

### DIFF
--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -8,8 +8,6 @@ crate-type = ["cdylib"]
 
 [features]
 default = ["pg14"]
-pg10 = ["pgx/pg10", "pgx-tests/pg10"]
-pg11 = ["pgx/pg11", "pgx-tests/pg11"]
 pg12 = ["pgx/pg12", "pgx-tests/pg12"]
 pg13 = ["pgx/pg13", "pgx-tests/pg13"]
 pg14 = ["pgx/pg14", "pgx-tests/pg14"]


### PR DESCRIPTION
We don't support building with the `pg10` or `pg11` features (trying to build Toolkit for those versions results in a compile error); this PR removes them from the Cargo manifest.

pgx 0.6.0 will remove pg10 support from pgx, so this helps bring us towards upgrading to pgx 0.6.0 once it's released.