### PR TITLE
Use pg_sys::Datum instead of pgx::Datum

### DIFF
--- a/extension/src/counter_agg.rs
+++ b/extension/src/counter_agg.rs
@@ -1156,8 +1156,9 @@ mod tests {
             assert_eq!(buffer, expected);
 
             let expected = pgx::varlena::rust_byte_slice_to_bytea(&expected);
-            let new_state =
-                counter_summary_trans_deserialize_inner(bytea(pgx::Datum::from(expected.as_ptr())));
+            let new_state = counter_summary_trans_deserialize_inner(bytea(pg_sys::Datum::from(
+                expected.as_ptr(),
+            )));
 
             control.combine_summaries(); // Serialized form is always combined
             assert_eq!(&*new_state, &*control);

--- a/extension/src/datum_utils.rs
+++ b/extension/src/datum_utils.rs
@@ -25,9 +25,9 @@ pub(crate) unsafe fn deep_copy_datum(datum: Datum, typoid: Oid) -> Datum {
         let size = (*tentry).typlen as usize;
         let copy = pg_sys::palloc0(size);
         std::ptr::copy(datum.cast_mut_ptr(), copy as *mut u8, size);
-        pgx::Datum::from(copy)
+        pg_sys::Datum::from(copy)
     } else {
-        pgx::Datum::from(pg_sys::pg_detoast_datum_copy(datum.cast_mut_ptr()))
+        pg_sys::Datum::from(pg_sys::pg_detoast_datum_copy(datum.cast_mut_ptr()))
     }
 }
 
@@ -464,7 +464,7 @@ impl<'a, 'b> Iterator for DatumStoreIterator<'a, 'b> {
                     unsafe {
                         let va = store.data.slice().as_ptr().offset(*next_offset as _);
                         *next_offset += padded_va_len(va as *const _) as u32;
-                        Some(pgx::Datum::from(va))
+                        Some(pg_sys::Datum::from(va))
                     }
                 }
             }
@@ -478,7 +478,7 @@ impl<'a, 'b> Iterator for DatumStoreIterator<'a, 'b> {
                     None
                 } else {
                     *next_index += 1;
-                    Some(pgx::Datum::from(unsafe {
+                    Some(pg_sys::Datum::from(unsafe {
                         store.data.slice().as_ptr().offset(idx as _)
                     }))
                 }
@@ -578,7 +578,7 @@ impl<'a> Iterator for DatumStoreIntoIterator<'a> {
                     unsafe {
                         let va = store.data.slice().as_ptr().offset(*next_offset as _);
                         *next_offset += padded_va_len(va as *const _) as u32;
-                        Some(pgx::Datum::from(va))
+                        Some(pg_sys::Datum::from(va))
                     }
                 }
             }
@@ -592,7 +592,7 @@ impl<'a> Iterator for DatumStoreIntoIterator<'a> {
                     None
                 } else {
                     *next_index += 1;
-                    Some(pgx::Datum::from(unsafe {
+                    Some(pg_sys::Datum::from(unsafe {
                         store.data.slice().as_ptr().offset(idx as _)
                     }))
                 }

--- a/extension/src/frequency.rs
+++ b/extension/src/frequency.rs
@@ -563,7 +563,7 @@ pub fn topn_agg_with_skew_bigint_trans(
     let value = match value {
         None => None,
         Some(val) => unsafe {
-            AnyElement::from_polymorphic_datum(pgx::Datum::from(val), false, pg_sys::INT8OID)
+            AnyElement::from_polymorphic_datum(pg_sys::Datum::from(val), false, pg_sys::INT8OID)
         },
     };
 
@@ -590,7 +590,7 @@ pub fn topn_agg_with_skew_text_trans(
     let value = match txt {
         None => None,
         Some(val) => unsafe {
-            AnyElement::from_polymorphic_datum(pgx::Datum::from(val), false, pg_sys::TEXTOID)
+            AnyElement::from_polymorphic_datum(pg_sys::Datum::from(val), false, pg_sys::TEXTOID)
         },
     };
 
@@ -635,7 +635,7 @@ pub fn freq_agg_bigint_trans(
     let value = match value {
         None => None,
         Some(val) => unsafe {
-            AnyElement::from_polymorphic_datum(pgx::Datum::from(val), false, pg_sys::INT8OID)
+            AnyElement::from_polymorphic_datum(pg_sys::Datum::from(val), false, pg_sys::INT8OID)
         },
     };
     freq_agg_trans(state, freq, value, fcinfo)
@@ -652,7 +652,7 @@ pub fn freq_agg_text_trans(
     let value = match txt {
         None => None,
         Some(val) => unsafe {
-            AnyElement::from_polymorphic_datum(pgx::Datum::from(val), false, pg_sys::TEXTOID)
+            AnyElement::from_polymorphic_datum(pg_sys::Datum::from(val), false, pg_sys::TEXTOID)
         },
     };
     freq_agg_trans(state, freq, value, fcinfo)
@@ -1453,7 +1453,11 @@ mod tests {
         for i in 11..=20 {
             for j in i..=20 {
                 let value = unsafe {
-                    AnyElement::from_polymorphic_datum(pgx::Datum::from(j), false, pg_sys::INT4OID)
+                    AnyElement::from_polymorphic_datum(
+                        pg_sys::Datum::from(j),
+                        false,
+                        pg_sys::INT4OID,
+                    )
                 };
                 state = super::freq_agg_trans(state, freq, value, fcinfo).unwrap();
             }
@@ -1513,7 +1517,11 @@ mod tests {
             // reverse here introduces less error in the aggregate
             for j in i..=20 {
                 let value = unsafe {
-                    AnyElement::from_polymorphic_datum(pgx::Datum::from(j), false, pg_sys::INT4OID)
+                    AnyElement::from_polymorphic_datum(
+                        pg_sys::Datum::from(j),
+                        false,
+                        pg_sys::INT4OID,
+                    )
                 };
                 state = super::freq_agg_trans(state, freq, value, fcinfo).unwrap();
             }
@@ -1848,7 +1856,7 @@ mod tests {
         for _ in 0..200 {
             let v = rand100.sample(&mut rng);
             let value = unsafe {
-                AnyElement::from_polymorphic_datum(pgx::Datum::from(v), false, pg_sys::INT4OID)
+                AnyElement::from_polymorphic_datum(pg_sys::Datum::from(v), false, pg_sys::INT4OID)
             };
             state = super::freq_agg_trans(state, freq, value, fcinfo).unwrap();
             counts[v] += 1;
@@ -1892,7 +1900,7 @@ mod tests {
                 continue; // These tail values can start to add up at low skew values
             }
             let value = unsafe {
-                AnyElement::from_polymorphic_datum(pgx::Datum::from(v), false, pg_sys::INT4OID)
+                AnyElement::from_polymorphic_datum(pg_sys::Datum::from(v), false, pg_sys::INT4OID)
             };
             state = super::topn_agg_with_skew_trans(state, n as i32, skew, value, fcinfo).unwrap();
             if v < 100 {

--- a/extension/src/hyperloglog.rs
+++ b/extension/src/hyperloglog.rs
@@ -649,7 +649,7 @@ mod tests {
 
             let expected = pgx::varlena::rust_byte_slice_to_bytea(&expected);
             let new_state =
-                hyperloglog_deserialize_inner(bytea(pgx::Datum::from(expected.as_ptr())));
+                hyperloglog_deserialize_inner(bytea(pg_sys::Datum::from(expected.as_ptr())));
 
             control.logger.merge_all(); // Sparse representation buffers always merged on serialization
             assert!(*new_state == control);
@@ -675,7 +675,7 @@ mod tests {
 
             let expected = pgx::varlena::rust_byte_slice_to_bytea(&expected);
             let new_state =
-                hyperloglog_deserialize_inner(bytea(pgx::Datum::from(expected.as_ptr())));
+                hyperloglog_deserialize_inner(bytea(pg_sys::Datum::from(expected.as_ptr())));
 
             assert!(*new_state == control);
         }

--- a/extension/src/nmost.rs
+++ b/extension/src/nmost.rs
@@ -140,7 +140,7 @@ fn nmost_trans_combine<T: Clone + Ord + Copy>(
 #[derive(Clone, Debug)]
 pub struct NMostByTransState<T: Ord> {
     values: NMostTransState<(T, usize)>,
-    data: Vec<Datum>,
+    data: Vec<pg_sys::Datum>,
     oid: pg_sys::Oid,
 }
 

--- a/extension/src/palloc.rs
+++ b/extension/src/palloc.rs
@@ -72,13 +72,13 @@ impl<T> DerefMut for Inner<T> {
 
 unsafe impl<T> ToInternal for Option<Inner<T>> {
     fn internal(self) -> Option<Internal> {
-        self.map(|p| Internal::from(Some(pgx::Datum::from(p.0.as_ptr()))))
+        self.map(|p| Internal::from(Some(pg_sys::Datum::from(p.0.as_ptr()))))
     }
 }
 
 unsafe impl<T> ToInternal for Inner<T> {
     fn internal(self) -> Option<Internal> {
-        Some(Internal::from(Some(pgx::Datum::from(self.0.as_ptr()))))
+        Some(Internal::from(Some(pg_sys::Datum::from(self.0.as_ptr()))))
     }
 }
 
@@ -91,13 +91,13 @@ impl<T> From<T> for Inner<T> {
 // TODO these last two should probably be `unsafe`
 unsafe impl<T> ToInternal for *mut T {
     fn internal(self) -> Option<Internal> {
-        Some(Internal::from(Some(pgx::Datum::from(self))))
+        Some(Internal::from(Some(pg_sys::Datum::from(self))))
     }
 }
 
 unsafe impl<T> ToInternal for *const T {
     fn internal(self) -> Option<Internal> {
-        Some(Internal::from(Some(pgx::Datum::from(self))))
+        Some(Internal::from(Some(pg_sys::Datum::from(self))))
     }
 }
 

--- a/extension/src/raw.rs
+++ b/extension/src/raw.rs
@@ -106,7 +106,7 @@ impl From<TimestampTz> for pg_sys::TimestampTz {
 
 impl From<pg_sys::TimestampTz> for TimestampTz {
     fn from(ts: pg_sys::TimestampTz) -> Self {
-        Self(pgx::Datum::from(ts))
+        Self(pg_sys::Datum::from(ts))
     }
 }
 

--- a/extension/src/serialization/collations.rs
+++ b/extension/src/serialization/collations.rs
@@ -79,7 +79,7 @@ type Form_pg_database = *mut FormData_pg_database;
 static DEFAULT_COLLATION_NAME: Lazy<CString> = Lazy::new(|| unsafe {
     let tuple = pg_sys::SearchSysCache1(
         pg_sys::SysCacheIdentifier_DATABASEOID as _,
-        pgx::Datum::from(pg_sys::MyDatabaseId),
+        pg_sys::Datum::from(pg_sys::MyDatabaseId),
     );
     if tuple.is_null() {
         pgx::error!("no database info");
@@ -111,7 +111,7 @@ impl Serialize for PgCollationId {
 
             let tuple = pg_sys::SearchSysCache1(
                 pg_sys::SysCacheIdentifier_COLLOID as _,
-                pgx::Datum::from(self.0),
+                pg_sys::Datum::from(self.0),
             );
             if tuple.is_null() {
                 pgx::error!("no collation info for oid {}", self.0);
@@ -208,20 +208,20 @@ impl<'de> Deserialize<'de> for PgCollationId {
             let mut collation_id = pg_sys::GetSysCacheOid(
                 pg_sys::SysCacheIdentifier_COLLNAMEENCNSP as _,
                 Anum_pg_collation_oid as _,
-                pgx::Datum::from(name.as_ptr()),
-                pgx::Datum::from(pg_sys::GetDatabaseEncoding()),
-                pgx::Datum::from(namespace_id),
-                Datum::from(0), //unused
+                pg_sys::Datum::from(name.as_ptr()),
+                pg_sys::Datum::from(pg_sys::GetDatabaseEncoding()),
+                pg_sys::Datum::from(namespace_id),
+                pg_sys::Datum::from(0), //unused
             );
 
             if collation_id == pg_sys::InvalidOid {
                 collation_id = pg_sys::GetSysCacheOid(
                     pg_sys::SysCacheIdentifier_COLLNAMEENCNSP as _,
                     Anum_pg_collation_oid as _,
-                    pgx::Datum::from(name.as_ptr()),
-                    Datum::from((-1isize) as usize),
-                    pgx::Datum::from(namespace_id),
-                    Datum::from(0), //unused
+                    pg_sys::Datum::from(name.as_ptr()),
+                    pg_sys::Datum::from((-1isize) as usize),
+                    pg_sys::Datum::from(namespace_id),
+                    pg_sys::Datum::from(0), //unused
                 );
             }
 

--- a/extension/src/serialization/functions.rs
+++ b/extension/src/serialization/functions.rs
@@ -60,7 +60,7 @@ impl<'de> Deserialize<'de> for PgProcId {
             pg_sys::DirectFunctionCall1Coll(
                 Some(regprocedurein),
                 pg_sys::InvalidOid,
-                pgx::Datum::from(qualified_name.as_ptr()),
+                pg_sys::Datum::from(qualified_name.as_ptr()),
             )
         };
 

--- a/extension/src/serialization/types.rs
+++ b/extension/src/serialization/types.rs
@@ -215,7 +215,7 @@ impl Serialize for PgTypId {
         unsafe {
             let tuple = pg_sys::SearchSysCache1(
                 pg_sys::SysCacheIdentifier_TYPEOID as _,
-                pgx::Datum::from(self.0),
+                pg_sys::Datum::from(self.0),
             );
             if tuple.is_null() {
                 pgx::error!("no type info for oid {}", self.0);
@@ -291,10 +291,10 @@ impl<'de> Deserialize<'de> for PgTypId {
             let type_id = pg_sys::GetSysCacheOid(
                 pg_sys::SysCacheIdentifier_TYPENAMENSP as _,
                 pg_sys::Anum_pg_type_oid as _,
-                pgx::Datum::from(name.as_ptr()),
-                pgx::Datum::from(namespace_id),
-                Datum::from(0), //unused
-                Datum::from(0), //unused
+                pg_sys::Datum::from(name.as_ptr()),
+                pg_sys::Datum::from(namespace_id),
+                pg_sys::Datum::from(0), //unused
+                pg_sys::Datum::from(0), //unused
             );
             if type_id == pg_sys::InvalidOid {
                 return Err(D::Error::custom(format!(

--- a/extension/src/state_aggregate.rs
+++ b/extension/src/state_aggregate.rs
@@ -345,7 +345,7 @@ pub fn duration_in<'a>(state: String, aggregate: Option<StateAgg<'a>>) -> crate:
     //  result = DatumGetIntervalP(DirectFunctionCall1(interval_justify_hours,
     //                                                 IntervalPGetDatum(result)));
     // So if we want the same behavior, we need to call interval_justify_hours too:
-    let function_args = vec![Some(pgx::Datum::from(interval))];
+    let function_args = vec![Some(pg_sys::Datum::from(interval))];
     unsafe { pgx::direct_function_call(pg_sys::interval_justify_hours, function_args) }
         .expect("interval_justify_hours does not return None")
 }

--- a/extension/src/stats_agg.rs
+++ b/extension/src/stats_agg.rs
@@ -1624,7 +1624,7 @@ mod tests {
 
             let expected = pgx::varlena::rust_byte_slice_to_bytea(&expected);
             let new_state =
-                stats1d_trans_deserialize_inner(bytea(pgx::Datum::from(expected.as_ptr())));
+                stats1d_trans_deserialize_inner(bytea(pg_sys::Datum::from(expected.as_ptr())));
 
             assert_eq!(&*new_state, &*control);
         }

--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -655,7 +655,8 @@ mod tests {
             assert_eq!(buffer, expected);
 
             let expected = pgx::varlena::rust_byte_slice_to_bytea(&expected);
-            let new_state = tdigest_deserialize_inner(bytea(pgx::Datum::from(expected.as_ptr())));
+            let new_state =
+                tdigest_deserialize_inner(bytea(pg_sys::Datum::from(expected.as_ptr())));
 
             control.digest(); // Serialized form is always digested
             assert_eq!(&*new_state, &*control);

--- a/extension/src/time_vector/pipeline.rs
+++ b/extension/src/time_vector/pipeline.rs
@@ -268,13 +268,15 @@ pub(crate) unsafe fn pipeline_support_helper(
     new_executor_args.push(new_const.cast());
     (*new_executor).args = new_executor_args.into_pg();
 
-    Internal::from(Some(pgx::Datum::from(new_executor)))
+    Internal::from(Some(pg_sys::Datum::from(new_executor)))
 }
 
 // support functions are spec'd as returning NULL pointer if no simplification
 // can be made
 fn no_change() -> pgx::Internal {
-    Internal::from(Some(pgx::Datum::from(std::ptr::null_mut::<pg_sys::Expr>())))
+    Internal::from(Some(pg_sys::Datum::from(
+        std::ptr::null_mut::<pg_sys::Expr>(),
+    )))
 }
 
 // using this instead of pg_operator since the latter doesn't support schemas yet

--- a/extension/src/time_vector/pipeline/lambda.rs
+++ b/extension/src/time_vector/pipeline/lambda.rs
@@ -129,7 +129,7 @@ pub fn interval_lambda<'a>(
         panic!("invalid return type, must return a INTERVAL")
     }
     let mut executor = ExpressionExecutor::new(&expression);
-    pgx::Datum::from(executor.exec(value, time.into()).interval()).into()
+    pg_sys::Datum::from(executor.exec(value, time.into()).interval()).into()
 }
 
 #[pg_extern(stable, parallel_safe, schema = "toolkit_experimental")]
@@ -376,8 +376,8 @@ impl PartialOrd for Value {
                 let res = pg_sys::DirectFunctionCall2Coll(
                     Some(interval_cmp),
                     pg_sys::InvalidOid,
-                    pgx::Datum::from(*l0),
-                    pgx::Datum::from(*r0),
+                    pg_sys::Datum::from(*l0),
+                    pg_sys::Datum::from(*r0),
                 )
                 .value() as i32;
                 res.cmp(&0).into()
@@ -407,8 +407,8 @@ impl PartialEq for Value {
                 let res = pg_sys::DirectFunctionCall2Coll(
                     Some(interval_eq),
                     pg_sys::InvalidOid,
-                    pgx::Datum::from(*l0),
-                    pgx::Datum::from(*r0),
+                    pg_sys::Datum::from(*l0),
+                    pg_sys::Datum::from(*r0),
                 );
                 res.value() != 0
             },

--- a/extension/src/time_vector/pipeline/lambda/executor.rs
+++ b/extension/src/time_vector/pipeline/lambda/executor.rs
@@ -213,8 +213,8 @@ where
                     pg_sys::DirectFunctionCall2Coll(
                         Some($calc),
                         pg_sys::InvalidOid,
-                        pgx::Datum::from(left),
-                        pgx::Datum::from(right),
+                        pg_sys::Datum::from(left),
+                        pg_sys::Datum::from(right),
                     )
                     .cast_mut_ptr()
                 };
@@ -232,7 +232,7 @@ where
                     pg_sys::DirectFunctionCall2Coll(
                         Some($calc),
                         pg_sys::InvalidOid,
-                        pgx::Datum::from(left),
+                        pg_sys::Datum::from(left),
                         right.into_datum().unwrap(),
                     )
                     .value() as _
@@ -251,8 +251,8 @@ where
                     pg_sys::DirectFunctionCall2Coll(
                         Some($calc),
                         pg_sys::InvalidOid,
-                        pgx::Datum::from(left),
-                        pgx::Datum::from(right),
+                        pg_sys::Datum::from(left),
+                        pg_sys::Datum::from(right),
                     )
                     .value() as _
                 };

--- a/extension/src/time_vector/pipeline/lambda/parser.rs
+++ b/extension/src/time_vector/pipeline/lambda/parser.rs
@@ -377,9 +377,9 @@ fn parse_timestamptz(val: &str) -> i64 {
         pg_sys::DirectFunctionCall3Coll(
             Some(timestamptz_in),
             pg_sys::InvalidOid as _,
-            pgx::Datum::from(cstr.as_ptr()),
-            pgx::Datum::from(pg_sys::InvalidOid),
-            pgx::Datum::from(-1i32),
+            pg_sys::Datum::from(cstr.as_ptr()),
+            pg_sys::Datum::from(pg_sys::InvalidOid),
+            pg_sys::Datum::from(-1i32),
         )
     };
     parsed_time.value() as _
@@ -398,9 +398,9 @@ fn parse_interval(val: &str) -> *mut pg_sys::Interval {
         pg_sys::DirectFunctionCall3Coll(
             Some(interval_in),
             pg_sys::InvalidOid as _,
-            pgx::Datum::from(cstr.as_ptr()),
-            pgx::Datum::from(pg_sys::InvalidOid),
-            pgx::Datum::from(-1i32),
+            pg_sys::Datum::from(cstr.as_ptr()),
+            pg_sys::Datum::from(pg_sys::InvalidOid),
+            pg_sys::Datum::from(-1i32),
         )
     };
     parsed_interval.cast_mut_ptr()

--- a/extension/src/time_vector/pipeline/map.rs
+++ b/extension/src/time_vector/pipeline/map.rs
@@ -186,7 +186,7 @@ pub fn apply_to(
 ) -> Timevector_TSTZ_F64<'_> {
     let mut flinfo: pg_sys::FmgrInfo = unsafe { MaybeUninit::zeroed().assume_init() };
 
-    let fn_addr: unsafe extern "C" fn(*mut pg_sys::FunctionCallInfoBaseData) -> Datum;
+    let fn_addr: unsafe extern "C" fn(*mut pg_sys::FunctionCallInfoBaseData) -> pg_sys::Datum;
     let mut fc_info = unsafe {
         pg_sys::fmgr_info(func, &mut flinfo);
         fn_addr = flinfo.fn_addr.expect("null function in timevector map");
@@ -231,7 +231,7 @@ pub fn map_series(series: &mut Timevector_TSTZ_F64<'_>, mut func: impl FnMut(f64
     // call it
     // NOTE need to be careful that there's not allocation within the
     //      loop body so it cannot leak
-    pgx::guard(AssertUnwindSafe(|| {
+    pg_sys::guard(AssertUnwindSafe(|| {
         for point in points {
             *point = TSPoint {
                 ts: point.ts,

--- a/extension/src/time_weighted_average.rs
+++ b/extension/src/time_weighted_average.rs
@@ -798,7 +798,7 @@ mod tests {
 
             let expected = pgx::varlena::rust_byte_slice_to_bytea(&expected);
             let new_state =
-                time_weight_trans_deserialize_inner(bytea(pgx::Datum::from(expected.as_ptr())));
+                time_weight_trans_deserialize_inner(bytea(pg_sys::Datum::from(expected.as_ptr())));
 
             control.combine_summaries(); // Serialized form is always combined
             assert_eq!(&*new_state, &*control);

--- a/extension/src/type_builder.rs
+++ b/extension/src/type_builder.rs
@@ -128,7 +128,7 @@ macro_rules! pg_type_impl {
                             *self = self.0.flatten();
                             self.cached_datum_or_flatten()
                         },
-                        FromInput(bytes) | Flattened(bytes) => pgx::Datum::from(bytes.as_ptr()),
+                        FromInput(bytes) | Flattened(bytes) => pg_sys::Datum::from(bytes.as_ptr()),
                     }
                 }
             }
@@ -206,8 +206,8 @@ macro_rules! pg_type_impl {
                 fn into_datum(self) -> Option<pgx::pg_sys::Datum> {
                     use $crate::type_builder::CachedDatum::*;
                     let datum = match self.1 {
-                        Flattened(bytes) => pgx::Datum::from(bytes.as_ptr()),
-                        FromInput(..) | None => pgx::Datum::from(self.0.to_pg_bytes().as_ptr()),
+                        Flattened(bytes) => pg_sys::Datum::from(bytes.as_ptr()),
+                        FromInput(..) | None => pg_sys::Datum::from(self.0.to_pg_bytes().as_ptr()),
                     };
                     Some(datum)
                 }
@@ -362,7 +362,7 @@ macro_rules! do_serialize {
                 let len = writer.position().try_into().expect("serialized size too large");
                 ::pgx::set_varsize(writer.get_mut().as_mut_ptr() as *mut _, len);
             }
-            $crate::raw::bytea::from(pgx::Datum::from(writer.into_inner().as_mut_ptr()))
+            $crate::raw::bytea::from(pg_sys::Datum::from(writer.into_inner().as_mut_ptr()))
         }
     };
 }

--- a/extension/src/uddsketch.rs
+++ b/extension/src/uddsketch.rs
@@ -1020,7 +1020,8 @@ mod tests {
             assert_eq!(buffer, expected);
 
             let expected = pgx::varlena::rust_byte_slice_to_bytea(&expected);
-            let new_state = uddsketch_deserialize_inner(bytea(pgx::Datum::from(expected.as_ptr())));
+            let new_state =
+                uddsketch_deserialize_inner(bytea(pg_sys::Datum::from(expected.as_ptr())));
             assert_eq!(&*new_state, &*control);
         }
     }


### PR DESCRIPTION
pgx 0.6.0 will stop supporting the `pgx::Datum` import path. `pg_sys::Datum` works with both the current release and the upcoming 0.6.0 release.

This also gets us closer to [using the pgx prelude](https://github.com/timescale/timescaledb-toolkit/issues/586).