### PR TITLE
Add timeline_agg

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -30,6 +30,8 @@ This changelog should be updated as part of a PR if the work is worth noting (mo
 
   Users can use the new `toolkit_experimental.approx_percentile_array(percentiles)` to generate an array of percentile results instead of having to call and rebuild the aggregate multiple times.
   
+- [#636](https://github.com/timescale/timescaledb-toolkit/pull/636): New `timeline_agg` aggregate, which is similar to `state_agg` but tracks the entire state timeline instead of just the duration in each state.
+
 - [#638](https://github.com/timescale/timescaledb-toolkit/pull/638): Introducing Time Vector Templates.
 
 #### Bug fixes

--- a/docs/state_agg.md
+++ b/docs/state_agg.md
@@ -2,7 +2,7 @@
 
 # Test table
 
-Examples below are tested against the following table:
+Examples below are tested against the following tables:
 
 ```SQL ,non-transactional
 SET TIME ZONE 'UTC';
@@ -13,6 +13,16 @@ INSERT INTO states_test VALUES
     ('2020-01-01 00:01:00+00', 'ERROR'),
     ('2020-01-01 00:01:03+00', 'OK'),
     ('2020-01-01 00:02:00+00', 'STOP');
+CREATE TABLE states_test_2(ts TIMESTAMPTZ, state TEXT);
+INSERT INTO states_test_2 VALUES
+    ('2019-12-31 00:00:00+00', 'START'),
+    ('2019-12-31 00:00:11+00', 'OK'),
+    ('2019-12-31 00:02:00+00', 'STOP'),
+    ('2019-12-31 00:01:03+00', 'OK');
+CREATE TABLE states_test_3(ts TIMESTAMPTZ, state TEXT);
+INSERT INTO states_test_3 VALUES
+    ('2019-12-31 00:00:11+00', 'UNUSED'),
+    ('2019-12-31 00:01:00+00', 'START');
 ```
 
 ## Functions
@@ -59,4 +69,214 @@ SELECT state, duration FROM toolkit_experimental.into_values(
  OK    | 106000000
  START |  11000000
  STOP  |         0
+```
+
+### state_timeline
+
+```SQL
+SELECT state, start_time, end_time FROM toolkit_experimental.state_timeline(
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test))
+    ORDER BY start_time;
+```
+```output
+state | start_time             | end_time
+------+------------------------+-----------------------
+START | 2020-01-01 00:00:00+00 | 2020-01-01 00:00:11+00
+   OK | 2020-01-01 00:00:11+00 | 2020-01-01 00:01:00+00
+ERROR | 2020-01-01 00:01:00+00 | 2020-01-01 00:01:03+00
+   OK | 2020-01-01 00:01:03+00 | 2020-01-01 00:02:00+00
+ STOP | 2020-01-01 00:02:00+00 | 2020-01-01 00:02:00+00
+```
+
+```SQL
+SELECT state, start_time, end_time FROM toolkit_experimental.state_timeline(
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2))
+    ORDER BY start_time;
+```
+```output
+state | start_time             | end_time
+------+------------------------+-----------------------
+START | 2019-12-31 00:00:00+00 | 2019-12-31 00:00:11+00
+   OK | 2019-12-31 00:00:11+00 | 2019-12-31 00:02:00+00
+ STOP | 2019-12-31 00:02:00+00 | 2019-12-31 00:02:00+00
+```
+
+## state_periods
+
+```SQL
+SELECT start_time, end_time
+FROM toolkit_experimental.state_periods(
+    'OK',
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test)
+)
+ORDER BY start_time;
+```
+```output
+start_time             | end_time
+-----------------------+-----------------------
+2020-01-01 00:00:11+00 | 2020-01-01 00:01:00+00
+2020-01-01 00:01:03+00 | 2020-01-01 00:02:00+00
+```
+
+```SQL
+SELECT start_time, end_time
+FROM toolkit_experimental.state_periods(
+    'ANYTHING',
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test)
+)
+ORDER BY start_time;
+```
+```output
+start_time             | end_time
+-----------------------+-----------------------
+```
+
+## interpolated_state_timeline
+
+```SQL
+SELECT state, start_time, end_time FROM toolkit_experimental.interpolated_state_timeline(
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    '2019-12-31', '1 days',
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3),
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3)
+)
+ORDER BY start_time;
+```
+```output
+state | start_time             | end_time
+------+------------------------+-----------------------
+START | 2019-12-31 00:00:00+00 | 2020-01-01 00:00:11+00
+   OK | 2020-01-01 00:00:11+00 | 2020-01-01 00:01:00+00
+ERROR | 2020-01-01 00:01:00+00 | 2020-01-01 00:01:03+00
+   OK | 2020-01-01 00:01:03+00 | 2020-01-01 00:02:00+00
+ STOP | 2020-01-01 00:02:00+00 | 2020-01-01 00:02:00+00
+```
+
+```SQL
+SELECT state, start_time, end_time FROM toolkit_experimental.interpolated_state_timeline(
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    '2019-12-31', '5 days',
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3),
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3)
+)
+ORDER BY start_time;
+```
+```output
+state | start_time             | end_time
+------+------------------------+-----------------------
+START | 2019-12-31 00:00:00+00 | 2020-01-01 00:00:11+00
+   OK | 2020-01-01 00:00:11+00 | 2020-01-01 00:01:00+00
+ERROR | 2020-01-01 00:01:00+00 | 2020-01-01 00:01:03+00
+   OK | 2020-01-01 00:01:03+00 | 2020-01-01 00:02:00+00
+ STOP | 2020-01-01 00:02:00+00 | 2020-01-05 00:00:00+00
+```
+
+```SQL
+SELECT state, start_time, end_time FROM toolkit_experimental.interpolated_state_timeline(
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    '2019-12-31', '1 days',
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2),
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2)
+)
+ORDER BY start_time;
+```
+```output
+state | start_time             | end_time
+------+------------------------+-----------------------
+ STOP | 2019-12-31 00:00:00+00 | 2020-01-01 00:00:00+00
+START | 2020-01-01 00:00:00+00 | 2020-01-01 00:00:11+00
+   OK | 2020-01-01 00:00:11+00 | 2020-01-01 00:01:00+00
+ERROR | 2020-01-01 00:01:00+00 | 2020-01-01 00:01:03+00
+   OK | 2020-01-01 00:01:03+00 | 2020-01-01 00:02:00+00
+ STOP | 2020-01-01 00:02:00+00 | 2020-01-01 00:02:00+00
+```
+
+```SQL
+SELECT state, start_time, end_time FROM toolkit_experimental.interpolated_state_timeline(
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    '2019-12-31', '5 days',
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2),
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2)
+)
+ORDER BY start_time;
+```
+```output
+state | start_time             | end_time
+------+------------------------+-----------------------
+ STOP | 2019-12-31 00:00:00+00 | 2020-01-01 00:00:00+00
+START | 2020-01-01 00:00:00+00 | 2020-01-01 00:00:11+00
+   OK | 2020-01-01 00:00:11+00 | 2020-01-01 00:01:00+00
+ERROR | 2020-01-01 00:01:00+00 | 2020-01-01 00:01:03+00
+   OK | 2020-01-01 00:01:03+00 | 2020-01-01 00:02:00+00
+ STOP | 2020-01-01 00:02:00+00 | 2020-01-05 00:00:00+00
+```
+
+
+## interpolated_state_periods
+
+```SQL
+SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods(
+    'OK',
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    '2019-12-31', '1 days',
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3),
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3)
+)
+ORDER BY start_time;
+```
+```output
+start_time             | end_time
+-----------------------+-----------------------
+2020-01-01 00:00:11+00 | 2020-01-01 00:01:00+00
+2020-01-01 00:01:03+00 | 2020-01-01 00:02:00+00
+```
+
+```SQL
+SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods(
+    'START',
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    '2019-12-31', '5 days',
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3),
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3)
+)
+ORDER BY start_time;
+```
+```output
+start_time             | end_time
+-----------------------+-----------------------
+2019-12-31 00:00:00+00 | 2020-01-01 00:00:11+00
+```
+
+```SQL
+SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods(
+    'STOP',
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    '2019-12-31', '1 days',
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2),
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2)
+)
+ORDER BY start_time;
+```
+```output
+start_time             | end_time
+-----------------------+-----------------------
+2019-12-31 00:00:00+00 | 2020-01-01 00:00:00+00
+2020-01-01 00:02:00+00 | 2020-01-01 00:02:00+00
+```
+
+```SQL
+SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods(
+    'STOP',
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    '2019-12-31', '5 days',
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2),
+    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2)
+)
+ORDER BY start_time;
+```
+```output
+start_time             | end_time
+-----------------------+-----------------------
+2019-12-31 00:00:00+00 | 2020-01-01 00:00:00+00
+2020-01-01 00:02:00+00 | 2020-01-05 00:00:00+00
 ```

--- a/extension/src/state_aggregate.rs
+++ b/extension/src/state_aggregate.rs
@@ -778,7 +778,7 @@ pub fn interpolated_state_periods<'a>(
 #[derive(Clone, Debug, Deserialize, Eq, FlatSerializable, PartialEq, Serialize)]
 #[repr(C)]
 pub struct DurationInState {
-    duration: i64, // TODO BRIAN is i64 or u64 the right type
+    duration: i64,
     state_beg: u32,
     state_end: u32,
 }
@@ -786,8 +786,8 @@ pub struct DurationInState {
 #[derive(Clone, Debug, Deserialize, Eq, FlatSerializable, PartialEq, Serialize)]
 #[repr(C)]
 pub struct TimeInState {
-    start_time: i64, // TODO BRIAN is i64 or u64 the right type
-    end_time: i64,   // TODO BRIAN is i64 or u64 the right type
+    start_time: i64,
+    end_time: i64,
     state_beg: u32,
     state_end: u32,
 }


### PR DESCRIPTION
Adds a `timeline_agg` aggregate that can be used in the same ways as `state_agg` but also allows getting the entire state timeline with `state_timeline`.

Note that this PR returns start times and end times instead of `tstzrange`s. pgx 0.6.0 will add support for `tstzrange`s so when that release comes out I'll update the relevant functions to return ranges.

This partially addresses #619 (adding `rollup` and supporting integer values will be separate PRs to make them easier to review).