### PR TITLE
Support rollup and integer states state/timeline aggs

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -32,6 +32,9 @@ This changelog should be updated as part of a PR if the work is worth noting (mo
   
 - [#636](https://github.com/timescale/timescaledb-toolkit/pull/636): New `timeline_agg` aggregate, which is similar to `state_agg` but tracks the entire state timeline instead of just the duration in each state.
 
+- [#640](https://github.com/timescale/timescaledb-toolkit/pull/640): Support `rollup` for `state_agg` and `timeline_agg`.
+- [#640](https://github.com/timescale/timescaledb-toolkit/pull/640): Support integer states for `state_agg` and `timeline_agg`.
+
 - [#638](https://github.com/timescale/timescaledb-toolkit/pull/638): Introducing Time Vector Templates.
 
 #### Bug fixes

--- a/docs/state_agg.md
+++ b/docs/state_agg.md
@@ -398,3 +398,23 @@ FROM buckets;
    (OK,"2020-01-01 00:01:03+00","2020-01-01 00:02:00+00")
  (STOP,"2020-01-01 00:02:00+00","2020-01-01 00:02:00+00")
 ```
+
+```SQL
+WITH buckets AS (SELECT
+    date_trunc('minute', ts) as dt,
+    toolkit_experimental.timeline_agg(ts, state) AS sa
+FROM states_test
+GROUP BY date_trunc('minute', ts)
+HAVING date_trunc('minute', ts) != '2020-01-01 00:01:00+00'::timestamptz)
+SELECT toolkit_experimental.state_timeline(
+    toolkit_experimental.rollup(buckets.sa)
+)
+FROM buckets;
+```
+```output
+                      state_timeline
+-----------------------------------------------------------
+(START,"2020-01-01 00:00:00+00","2020-01-01 00:00:11+00")
+   (OK,"2020-01-01 00:00:11+00","2020-01-01 00:02:00+00")
+ (STOP,"2020-01-01 00:02:00+00","2020-01-01 00:02:00+00")
+```

--- a/docs/state_agg.md
+++ b/docs/state_agg.md
@@ -363,6 +363,24 @@ FROM buckets;
 ```SQL
 WITH buckets AS (SELECT
     date_trunc('minute', ts) as dt,
+    toolkit_experimental.state_agg(ts, state) AS sa
+FROM states_test
+GROUP BY date_trunc('minute', ts))
+SELECT toolkit_experimental.duration_in(
+    'OK',
+    toolkit_experimental.rollup(buckets.sa)
+)
+FROM buckets;
+```
+```output
+ interval
+----------
+ 00:01:46
+```
+
+```SQL
+WITH buckets AS (SELECT
+    date_trunc('minute', ts) as dt,
     toolkit_experimental.timeline_agg(ts, state) AS sa
 FROM states_test
 GROUP BY date_trunc('minute', ts))
@@ -375,8 +393,8 @@ FROM buckets;
                       state_timeline
 -----------------------------------------------------------
 (START,"2020-01-01 00:00:00+00","2020-01-01 00:00:11+00")
-   (OK,"2020-01-01 00:00:11+00","2020-01-01 00:00:11+00")
+   (OK,"2020-01-01 00:00:11+00","2020-01-01 00:01:00+00")
 (ERROR,"2020-01-01 00:01:00+00","2020-01-01 00:01:03+00")
-   (OK,"2020-01-01 00:01:03+00","2020-01-01 00:01:03+00")
+   (OK,"2020-01-01 00:01:03+00","2020-01-01 00:02:00+00")
  (STOP,"2020-01-01 00:02:00+00","2020-01-01 00:02:00+00")
 ```

--- a/extension/src/state_aggregate.rs
+++ b/extension/src/state_aggregate.rs
@@ -72,13 +72,13 @@ impl StateEntry {
     }
     fn from_str(states: &mut String, new_state: &str) -> Self {
         let (a, b) = if let Some(bounds) = states
-            .find(&new_state)
+            .find(new_state)
             .map(|idx| (idx as i64, (idx + new_state.len()) as i64))
         {
             bounds
         } else {
             let bounds = (states.len() as i64, (states.len() + new_state.len()) as i64);
-            states.push_str(&new_state);
+            states.push_str(new_state);
             bounds
         };
         Self { a, b }
@@ -91,17 +91,13 @@ impl StateEntry {
         }
     }
     fn try_from_existing_str(states: &str, state: &str) -> Option<Self> {
-        if let Some(bounds) = states
-            .find(&state)
+        states
+            .find(state)
             .map(|idx| (idx as i64, (idx + state.len()) as i64))
-        {
-            Some(Self {
+            .map(|bounds| Self {
                 a: bounds.0,
                 b: bounds.1,
             })
-        } else {
-            None
-        }
     }
 
     fn materialize(&self, states: &str) -> MaterializedState {
@@ -288,7 +284,7 @@ pub mod toolkit_experimental {
                         let start_interval = self.first_time - interval_start;
                         let start_state = &prev.durations.as_slice()[prev.last_state as usize]
                             .state
-                            .materialize(&prev.states_as_str());
+                            .materialize(prev.states_as_str());
 
                         // update durations
                         let state = match durations
@@ -772,7 +768,7 @@ pub fn duration_in<'a>(state: String, aggregate: Option<StateAgg<'a>>) -> crate:
     };
     duration_in_inner(
         aggregate.as_ref().and_then(|aggregate| {
-            StateEntry::try_from_existing_str(&aggregate.states_as_str(), &state)
+            StateEntry::try_from_existing_str(aggregate.states_as_str(), &state)
         }),
         aggregate,
     )

--- a/extension/src/state_aggregate.rs
+++ b/extension/src/state_aggregate.rs
@@ -2076,4 +2076,32 @@ SELECT toolkit_experimental.duration_in('one', toolkit_experimental.state_agg(ts
             assert_eq!(durations.next().unwrap()[1].value(), Some("12:00:00"));
         })
     }
+
+    #[pg_test]
+    #[should_panic = "can't merge overlapping aggregates"]
+    fn merge_range_full_overlap() {
+        let mut outer = StateAgg::empty(false);
+        outer.first_time = 10;
+        outer.last_time = 50;
+
+        let mut inner = StateAgg::empty(false);
+        inner.first_time = 20;
+        inner.last_time = 30;
+
+        inner.merge(&outer);
+    }
+
+    #[pg_test]
+    #[should_panic = "can't merge overlapping aggregates"]
+    fn merge_range_partial_overlap() {
+        let mut r1 = StateAgg::empty(false);
+        r1.first_time = 10;
+        r1.last_time = 50;
+
+        let mut r2 = StateAgg::empty(false);
+        r2.first_time = 20;
+        r2.last_time = 50;
+
+        r2.merge(&r1);
+    }
 }

--- a/extension/src/state_aggregate/rollup.rs
+++ b/extension/src/state_aggregate/rollup.rs
@@ -100,11 +100,10 @@ impl OwnedStateAgg {
             "later aggregate must be non-empty"
         );
 
-        let later_states = String::from_utf8(later.states.iter().map(|x| *x).collect::<Vec<u8>>())
-            .expect("invalid later UTF-8 states");
+        let later_states =
+            String::from_utf8(later.states.to_vec()).expect("invalid later UTF-8 states");
         let mut merged_states =
-            String::from_utf8(earlier.states.iter().map(|x| *x).collect::<Vec<u8>>())
-                .expect("invalid earlier UTF-8 states");
+            String::from_utf8(earlier.states.to_vec()).expect("invalid earlier UTF-8 states");
         let mut merged_durations = earlier.durations.into_iter().collect::<Vec<_>>();
 
         let earlier_len = earlier.combined_durations.len();
@@ -166,7 +165,7 @@ impl OwnedStateAgg {
         OwnedStateAgg {
             states: merged_states,
             durations: merged_durations,
-            combined_durations: combined_durations,
+            combined_durations,
 
             first_time: earlier.first_time,
             last_time: later.last_time,

--- a/extension/src/state_aggregate/rollup.rs
+++ b/extension/src/state_aggregate/rollup.rs
@@ -1,82 +1,408 @@
-use super::*;
-use crate::aggregate_utils::in_aggregate_context;
+use super::{toolkit_experimental::*, *};
+use crate::{
+    aggregate_utils::in_aggregate_context,
+    palloc::{InternalAsValue, ToInternal},
+};
+use serde::{Deserialize, Serialize};
 
 extension_sql!(
     "CREATE AGGREGATE toolkit_experimental.rollup(
         value toolkit_experimental.StateAgg
     ) (
         sfunc = toolkit_experimental.state_agg_rollup_trans,
-        stype = toolkit_experimental.StateAgg,
-        finalfunc = toolkit_experimental.state_agg_rollup_final
+        stype = internal,
+        finalfunc = toolkit_experimental.state_agg_rollup_final,
+        combinefunc = toolkit_experimental.state_agg_rollup_combine,
+        serialfunc = toolkit_experimental.state_agg_rollup_serialize,
+        deserialfunc = toolkit_experimental.state_agg_rollup_deserialize,
+        parallel = restricted
     );",
     name = "state_agg_rollup",
     requires = [
-        // TODO: depend on state_agg somehow?
         state_agg_rollup_trans,
         state_agg_rollup_final,
+        state_agg_rollup_combine,
+        state_agg_rollup_serialize,
+        state_agg_rollup_deserialize,
+        StateAgg,
     ],
 );
-
-#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
-pub fn state_agg_rollup_trans<'a>(
-    state: Option<toolkit_experimental::StateAgg<'a>>,
-    val: toolkit_experimental::StateAgg<'a>,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<toolkit_experimental::StateAgg<'a>> {
-    Some(unsafe {
-        in_aggregate_context(fcinfo, || match state {
-            None => val.into(),
-            Some(state) => state.merge(&val),
-        })
-    })
-}
-
-#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
-pub fn state_agg_rollup_final<'a>(
-    state: toolkit_experimental::StateAgg<'a>,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<StateAgg<'a>> {
-    unsafe { in_aggregate_context(fcinfo, || Some(state.in_current_context())) }
-}
-
 extension_sql!(
     "CREATE AGGREGATE toolkit_experimental.rollup(
         value toolkit_experimental.TimelineAgg
     ) (
         sfunc = toolkit_experimental.timeline_agg_rollup_trans,
-        stype = toolkit_experimental.StateAgg,
-        finalfunc = toolkit_experimental.timeline_agg_rollup_final
+        stype = internal,
+        finalfunc = toolkit_experimental.timeline_agg_rollup_final,
+        combinefunc = toolkit_experimental.state_agg_rollup_combine,
+        serialfunc = toolkit_experimental.state_agg_rollup_serialize,
+        deserialfunc = toolkit_experimental.state_agg_rollup_deserialize,
+        parallel = restricted
     );",
     name = "timeline_agg_rollup",
     requires = [
-        // TODO: depend on state_agg somehow?
         timeline_agg_rollup_trans,
         timeline_agg_rollup_final,
+        state_agg_rollup_combine,
+        state_agg_rollup_serialize,
+        state_agg_rollup_deserialize,
+        TimelineAgg,
     ],
 );
 
-#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
-pub fn timeline_agg_rollup_trans<'a>(
-    state: Option<toolkit_experimental::StateAgg<'a>>,
-    val: toolkit_experimental::TimelineAgg<'a>,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<toolkit_experimental::StateAgg<'a>> {
-    Some(unsafe {
-        in_aggregate_context(fcinfo, || match state {
-            None => val.as_state_agg().into(),
-            Some(state) => state.merge(&val.as_state_agg()),
-        })
-    })
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RollupTransState {
+    values: Vec<OwnedStateAgg>,
+    from_timeline_agg: bool,
 }
 
-#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
-pub fn timeline_agg_rollup_final<'a>(
-    state: toolkit_experimental::StateAgg<'a>,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct OwnedStateAgg {
+    durations: Vec<DurationInState>,
+    combined_durations: Vec<TimeInState>,
+    first_time: i64,
+    last_time: i64,
+    first_state: u32,
+    last_state: u32,
+    states: Vec<u8>,
+    from_timeline_agg: bool,
+    integer_states: bool,
+}
+
+impl OwnedStateAgg {
+    pub fn merge(self, other: Self) -> Self {
+        assert_eq!(
+            self.from_timeline_agg, other.from_timeline_agg,
+            "can't merge state_agg and timeline_agg"
+        );
+        assert_eq!(
+            self.integer_states, other.integer_states,
+            "can't merge aggs with different state types"
+        );
+
+        let (earlier, later) = match self.first_time.cmp(&other.first_time) {
+            Ordering::Less => (self, other),
+            Ordering::Greater => (other, self),
+            Ordering::Equal => panic!("can't merge overlapping aggregates (same start time)"),
+        };
+        assert!(
+            earlier.last_time <= later.first_time,
+            "can't merge overlapping aggregates"
+        );
+        assert_ne!(
+            later.durations.len(),
+            0,
+            "later aggregate must be non-empty"
+        );
+        assert_ne!(
+            earlier.durations.len(),
+            0,
+            "later aggregate must be non-empty"
+        );
+
+        let later_states = String::from_utf8(later.states.iter().map(|x| *x).collect::<Vec<u8>>())
+            .expect("invalid later UTF-8 states");
+        let mut merged_states =
+            String::from_utf8(earlier.states.iter().map(|x| *x).collect::<Vec<u8>>())
+                .expect("invalid earlier UTF-8 states");
+        let mut merged_durations = earlier.durations.into_iter().collect::<Vec<_>>();
+
+        let earlier_len = earlier.combined_durations.len();
+
+        let mut added_entries = 0;
+        for dis in later.durations.iter() {
+            let merged_duration_to_update = merged_durations.iter_mut().find(|merged_dis| {
+                merged_dis.state.materialize(&merged_states) == dis.state.materialize(&later_states)
+            });
+            if let Some(merged_duration_to_update) = merged_duration_to_update {
+                merged_duration_to_update.duration += dis.duration;
+            } else {
+                let state = dis
+                    .state
+                    .materialize(&later_states)
+                    .entry(&mut merged_states);
+                merged_durations.push(DurationInState {
+                    state,
+                    duration: dis.duration,
+                });
+                added_entries += 1;
+            };
+        }
+
+        let mut combined_durations = earlier
+            .combined_durations
+            .into_iter()
+            .chain(later.combined_durations.into_iter().map(|tis| {
+                let state = tis
+                    .state
+                    .materialize(&later_states)
+                    .existing_entry(&merged_states);
+                TimeInState { state, ..tis }
+            }))
+            .collect::<Vec<_>>();
+
+        let gap = later.first_time - earlier.last_time;
+        assert!(gap >= 0);
+        merged_durations[earlier.last_state as usize].duration += gap;
+
+        // ensure combined_durations covers the whole range of time
+        if earlier.from_timeline_agg {
+            if combined_durations[earlier_len - 1]
+                .state
+                .materialize(&merged_states)
+                == combined_durations[earlier_len]
+                    .state
+                    .materialize(&merged_states)
+            {
+                combined_durations[earlier_len - 1].end_time =
+                    combined_durations.remove(earlier_len).end_time;
+            } else {
+                combined_durations[earlier_len - 1].end_time =
+                    combined_durations[earlier_len].start_time;
+            }
+        }
+
+        let merged_states = merged_states.into_bytes();
+        OwnedStateAgg {
+            states: merged_states,
+            durations: merged_durations,
+            combined_durations: combined_durations,
+
+            first_time: earlier.first_time,
+            last_time: later.last_time,
+            first_state: earlier.first_state,
+            last_state: added_entries + later.last_state,
+
+            // these values are always the same for both
+            from_timeline_agg: earlier.from_timeline_agg,
+            integer_states: earlier.integer_states,
+        }
+    }
+}
+
+impl<'a> From<OwnedStateAgg> for StateAgg<'a> {
+    fn from(owned: OwnedStateAgg) -> StateAgg<'a> {
+        unsafe {
+            flatten!(StateAgg {
+                states_len: owned.states.len() as u64,
+                states: (&*owned.states).into(),
+                durations_len: owned.durations.len() as u64,
+                durations: (&*owned.durations).into(),
+                combined_durations: (&*owned.combined_durations).into(),
+                combined_durations_len: owned.combined_durations.len() as u64,
+                first_time: owned.first_time,
+                last_time: owned.last_time,
+                first_state: owned.first_state,
+                last_state: owned.last_state,
+                from_timeline_agg: owned.from_timeline_agg,
+                integer_states: owned.integer_states,
+            })
+        }
+    }
+}
+
+impl<'a> From<StateAgg<'a>> for OwnedStateAgg {
+    fn from(agg: StateAgg<'a>) -> OwnedStateAgg {
+        OwnedStateAgg {
+            states: agg.states.iter().collect::<Vec<_>>(),
+            durations: agg.durations.iter().collect::<Vec<_>>(),
+            combined_durations: agg.combined_durations.iter().collect::<Vec<_>>(),
+            first_time: agg.first_time,
+            last_time: agg.last_time,
+            first_state: agg.first_state,
+            last_state: agg.last_state,
+            from_timeline_agg: agg.from_timeline_agg,
+            integer_states: agg.integer_states,
+        }
+    }
+}
+
+impl RollupTransState {
+    fn merge(&mut self) {
+        self.values = self
+            .values
+            .drain(..)
+            .reduce(|a, b| a.merge(b))
+            .map(|val| vec![val])
+            .unwrap_or_else(Vec::new);
+    }
+}
+
+#[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
+pub fn state_agg_rollup_trans<'a>(
+    state: Internal,
+    next: Option<StateAgg<'a>>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    state_agg_rollup_trans_inner(unsafe { state.to_inner() }, next, fcinfo).internal()
+}
+
+pub fn state_agg_rollup_trans_inner<'a>(
+    state: Option<Inner<RollupTransState>>,
+    next: Option<StateAgg<'a>>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Inner<RollupTransState>> {
+    unsafe {
+        in_aggregate_context(fcinfo, || match (state, next) {
+            (None, None) => None,
+            (None, Some(next)) => Some(
+                RollupTransState {
+                    values: vec![next.into()],
+                    from_timeline_agg: false,
+                }
+                .into(),
+            ),
+            (Some(state), None) => Some(state),
+            (Some(mut state), Some(next)) => {
+                state.values.push(next.into());
+                Some(state)
+            }
+        })
+    }
+}
+
+#[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
+pub fn timeline_agg_rollup_trans<'a>(
+    state: Internal,
+    next: Option<TimelineAgg<'a>>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    state_agg_rollup_trans_inner(
+        unsafe { state.to_inner() },
+        next.map(TimelineAgg::as_state_agg),
+        fcinfo,
+    )
+    .internal()
+}
+
+#[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
+fn state_agg_rollup_final<'a>(
+    state: Internal,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<StateAgg<'a>> {
+    state_agg_rollup_final_inner(unsafe { state.to_inner() }, fcinfo)
+}
+
+fn state_agg_rollup_final_inner<'a>(
+    state: Option<Inner<RollupTransState>>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<StateAgg<'a>> {
+    unsafe {
+        in_aggregate_context(fcinfo, || {
+            let mut state = match state {
+                None => return None,
+                Some(state) => state.clone(),
+            };
+            state.merge();
+            assert!(state.values.len() == 1);
+            let agg: Option<OwnedStateAgg> = state.values.drain(..).next().unwrap().into();
+            agg.map(Into::into)
+        })
+    }
+}
+
+#[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
+fn timeline_agg_rollup_final<'a>(
+    state: Internal,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<TimelineAgg<'a>> {
+    timeline_agg_rollup_final_inner(unsafe { state.to_inner() }, fcinfo)
+}
+
+fn timeline_agg_rollup_final_inner<'a>(
+    state: Option<Inner<RollupTransState>>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<TimelineAgg<'a>> {
     unsafe {
         in_aggregate_context(fcinfo, || {
-            Some(TimelineAgg::new(state).in_current_context())
+            let mut state = match state {
+                None => return None,
+                Some(state) => state.clone(),
+            };
+            state.merge();
+            assert!(state.values.len() == 1);
+            let agg: Option<OwnedStateAgg> = state.values.drain(..).next().unwrap().into();
+            agg.map(Into::into).map(TimelineAgg::new)
         })
+    }
+}
+
+#[pg_extern(immutable, parallel_safe, strict, schema = "toolkit_experimental")]
+pub fn state_agg_rollup_serialize(state: Internal) -> bytea {
+    let mut state: Inner<RollupTransState> = unsafe { state.to_inner().unwrap() };
+    state.merge();
+    crate::do_serialize!(state)
+}
+
+#[pg_extern(strict, immutable, parallel_safe, schema = "toolkit_experimental")]
+pub fn state_agg_rollup_deserialize(bytes: bytea, _internal: Internal) -> Option<Internal> {
+    state_agg_rollup_deserialize_inner(bytes).internal()
+}
+pub fn state_agg_rollup_deserialize_inner(bytes: bytea) -> Inner<RollupTransState> {
+    let t: RollupTransState = crate::do_deserialize!(bytes, RollupTransState);
+    t.into()
+}
+
+#[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
+pub fn state_agg_rollup_combine(
+    state1: Internal,
+    state2: Internal,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Internal> {
+    unsafe {
+        state_agg_rollup_combine_inner(state1.to_inner(), state2.to_inner(), fcinfo).internal()
+    }
+}
+
+pub fn state_agg_rollup_combine_inner(
+    state1: Option<Inner<RollupTransState>>,
+    state2: Option<Inner<RollupTransState>>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<Inner<RollupTransState>> {
+    unsafe {
+        in_aggregate_context(fcinfo, || match (state1, state2) {
+            (None, None) => None,
+            (Some(x), None) => Some(x),
+            (None, Some(x)) => Some(x),
+            (Some(mut x), Some(mut y)) => {
+                x.values.append(&mut y.values);
+                Some(x.into())
+            }
+        })
+    }
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pg_schema]
+mod tests {
+    use super::*;
+    use pgx_macros::pg_test;
+
+    #[pg_test]
+    #[should_panic = "can't merge overlapping aggregates"]
+    fn merge_range_full_overlap() {
+        let mut outer: OwnedStateAgg = StateAgg::empty(false, false).into();
+        outer.first_time = 10;
+        outer.last_time = 50;
+
+        let mut inner: OwnedStateAgg = StateAgg::empty(false, false).into();
+        inner.first_time = 20;
+        inner.last_time = 30;
+
+        inner.merge(outer);
+    }
+
+    #[pg_test]
+    #[should_panic = "can't merge overlapping aggregates"]
+    fn merge_range_partial_overlap() {
+        let mut r1: OwnedStateAgg = StateAgg::empty(false, false).into();
+        r1.first_time = 10;
+        r1.last_time = 50;
+
+        let mut r2: OwnedStateAgg = StateAgg::empty(false, false).into();
+        r2.first_time = 20;
+        r2.last_time = 50;
+
+        r2.merge(r1);
     }
 }

--- a/extension/src/state_aggregate/rollup.rs
+++ b/extension/src/state_aggregate/rollup.rs
@@ -1,0 +1,82 @@
+use super::*;
+use crate::aggregate_utils::in_aggregate_context;
+
+extension_sql!(
+    "CREATE AGGREGATE toolkit_experimental.rollup(
+        value toolkit_experimental.StateAgg
+    ) (
+        sfunc = toolkit_experimental.state_agg_rollup_trans,
+        stype = toolkit_experimental.StateAgg,
+        finalfunc = toolkit_experimental.state_agg_rollup_final
+    );",
+    name = "state_agg_rollup",
+    requires = [
+        // TODO: depend on state_agg somehow?
+        state_agg_rollup_trans,
+        state_agg_rollup_final,
+    ],
+);
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn state_agg_rollup_trans<'a>(
+    state: Option<toolkit_experimental::StateAgg<'a>>,
+    val: toolkit_experimental::StateAgg<'a>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<toolkit_experimental::StateAgg<'a>> {
+    Some(unsafe {
+        in_aggregate_context(fcinfo, || match state {
+            None => val.into(),
+            Some(state) => state.merge(&val),
+        })
+    })
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn state_agg_rollup_final<'a>(
+    state: toolkit_experimental::StateAgg<'a>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<StateAgg<'a>> {
+    unsafe { in_aggregate_context(fcinfo, || Some(state.in_current_context())) }
+}
+
+extension_sql!(
+    "CREATE AGGREGATE toolkit_experimental.rollup(
+        value toolkit_experimental.TimelineAgg
+    ) (
+        sfunc = toolkit_experimental.timeline_agg_rollup_trans,
+        stype = toolkit_experimental.StateAgg,
+        finalfunc = toolkit_experimental.timeline_agg_rollup_final
+    );",
+    name = "timeline_agg_rollup",
+    requires = [
+        // TODO: depend on state_agg somehow?
+        timeline_agg_rollup_trans,
+        timeline_agg_rollup_final,
+    ],
+);
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn timeline_agg_rollup_trans<'a>(
+    state: Option<toolkit_experimental::StateAgg<'a>>,
+    val: toolkit_experimental::TimelineAgg<'a>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<toolkit_experimental::StateAgg<'a>> {
+    Some(unsafe {
+        in_aggregate_context(fcinfo, || match state {
+            None => val.as_state_agg().into(),
+            Some(state) => state.merge(&val.as_state_agg()),
+        })
+    })
+}
+
+#[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
+pub fn timeline_agg_rollup_final<'a>(
+    state: toolkit_experimental::StateAgg<'a>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<TimelineAgg<'a>> {
+    unsafe {
+        in_aggregate_context(fcinfo, || {
+            Some(TimelineAgg::new(state).in_current_context())
+        })
+    }
+}


### PR DESCRIPTION
- Adds `rollup` for `state_agg` and `timeline_agg`.
- Supports integer states for `state_agg` and `timeline_agg`. An aggregate can have integer states or string states, but not both. For a few functions this would mean having two functions with the same argument types but differing return types, so in that case I made a separate function for integer-valued aggregates (e.g. `state_int_timeline`).

Ideally this should have been two separate PRs, but my changes to `rollup` and the rest of the `state_agg` code have become intertwined.

(this should be merged after #636)