### PR TITLE
Prepare for 1.14 release cycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "timescaledb_toolkit"
-version = "1.13.0-dev"
+version = "1.14.0-dev"
 dependencies = [
  "aggregate_builder",
  "approx 0.4.0",

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timescaledb_toolkit"
-version = "1.13.0-dev"
+version = "1.14.0-dev"
 edition = "2021"
 
 [lib]

--- a/extension/timescaledb_toolkit.control
+++ b/extension/timescaledb_toolkit.control
@@ -5,4 +5,4 @@ superuser = false
 module_pathname = '$libdir/timescaledb_toolkit' # only for testing, will be removed for real installs
 # comma-separated list of previous versions this version can be upgraded from
 # directly. This is used to generate upgrade scripts.
-# upgradeable_from = '1.4, 1.5, 1.5.1, 1.5.2, 1.6.0, 1.7.0, 1.8.0, 1.10.0-dev, 1.10.1, 1.11.0, 1.12.0, 1.12.1'
+# upgradeable_from = '1.4, 1.5, 1.5.1, 1.5.2, 1.6.0, 1.7.0, 1.8.0, 1.10.0-dev, 1.10.1, 1.11.0, 1.12.0, 1.12.1, 1.13.0'


### PR DESCRIPTION
This would have been pushed to main automatically by the release script, but that failed due to a permissions error.