### PR TITLE
Push the post-release changes to main to a branch.

### DIFF
--- a/tools/release
+++ b/tools/release
@@ -12,7 +12,7 @@
 # 7a. Update upgradeable_form in control file.
 # 7b. Set toolkit version to released version with '-dev' appended.
 # 7c. Update Changelog.md .
-# 7d. Push to main (if -push).
+# 7d. Push to post-$VERSION branch (if -push).
 # 8. File issue for release tasks that are not yet automated (if -push).
 
 # [1] We need a self-hosted runner for arm64 build, which we can only get with
@@ -302,9 +302,9 @@ fi
 $nop git show
 
 if $push; then
-    # 7d. Push to main.
-    # TODO Create a pull request instead?
-    $nop git push origin main
+    # 7d. Push to post-$VERSION branch.
+    $nop git push origin post-$VERSION
+    # TODO Create a pull request for it.
 
     # 8. File issue for release tasks that are not yet automated.
     $nop gh issue create -R timescale/timescaledb-toolkit -F- -t "Release $VERSION" <<EOF


### PR DESCRIPTION
main is protected so we can't push directly to it.  We were considering a pull request for this anyway, and have now decided to do it.

We'll figure out how to create the pull request later.  For now we can do it manually.  At least we can stop making these edits manually.