### PR TITLE
Use `main` branch for CI badge in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/timescale/timescaledb-toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/timescale/timescaledb-toolkit/actions/workflows/ci.yml)
+[![CI](https://github.com/timescale/timescaledb-toolkit/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/timescale/timescaledb-toolkit/actions/workflows/ci.yml)
 
 
 # TimescaleDB Toolkit #


### PR DESCRIPTION
Configures the CI badge on the README to reflect the status of the `main` branch, instead of whatever CI run happens to be the most recent.