### PR TITLE
Stop installing curl on RHEL-derived systems.

### DIFF
--- a/docker/ci/setup.sh
+++ b/docker/ci/setup.sh
@@ -101,7 +101,6 @@ if $privileged; then
             # - make
             # - pkg-config
             yum -q -y install \
-                curl \
                 gcc \
                 git \
                 make \


### PR DESCRIPTION
It's already installed on the images we build on (centos:7,
rockylinux:8, rockylinux:9) and attempting to install 'curl' no longer
works on rockylinux:9 due to conflicting 'curl-minimal' package.