### PR TITLE
Require Rust 1.64 to fix image build

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,7 @@ As for other platforms:  patches welcome!
 
 ### 🔧 Tools Setup ###
 
-Building the extension requires valid [rust](https://www.rust-lang.org/) (we build and test on 1.63), [rustfmt](https://github.com/rust-lang/rustfmt), and clang installs, along with the postgres headers for whichever version of postgres you are running, and pgx.
+Building the extension requires valid [rust](https://www.rust-lang.org/) (we build and test on 1.64), [rustfmt](https://github.com/rust-lang/rustfmt), and clang installs, along with the postgres headers for whichever version of postgres you are running, and pgx.
 We recommend installing rust using the [official instructions](https://www.rust-lang.org/tools/install):
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh

--- a/tools/dependencies.sh
+++ b/tools/dependencies.sh
@@ -16,7 +16,7 @@ CARGO_EDIT=0.11.2
 # Keep synchronized with extension/Cargo.toml and `cargo install --version N.N.N cargo-pgx` in Readme.md .
 PGX_VERSION=0.6.1
 
-RUST_TOOLCHAIN=1.63.0
+RUST_TOOLCHAIN=1.64.0
 RUST_PROFILE=minimal
 RUST_COMPONENTS=clippy,rustfmt
 


### PR DESCRIPTION
cargo-pgx doesn't seem to lock it's dependencies, and a dependency it has now requires a newer Rust version. Trying to build the CI image fails now because of that:
```
error: failed to compile `cargo-pgx v0.6.1`, intermediate artifacts can be found at `/tmp/cargo-install19HcGL`

Caused by:
package `clap_lex v0.3.1` cannot be built because it requires rustc 1.64.0 or newer, while the currently active rustc version is 1.63.0
```

This PR bumps our minimum Rust version to 1.64.