### PR TITLE
Pre-stabilization changes for state_agg - part 1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,9 @@ This changelog should be updated as part of a PR if the work is worth noting (mo
 #### Bug fixes
 
 #### Other notable changes
+- [#692](https://github.com/timescale/timescaledb-toolkit/pull/692): Support specifying a range to `duration_in` to specify a time range to get states in for state aggregates
+- [#692](https://github.com/timescale/timescaledb-toolkit/pull/692): Removed `next` parameter from interpolated state aggregate functions
+- [#692](https://github.com/timescale/timescaledb-toolkit/pull/692): Renamed `state_agg` to `compressed_state_agg` and `timeline_agg` to `state_agg`
 
 #### Shout-outs
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,7 +13,7 @@ This changelog should be updated as part of a PR if the work is worth noting (mo
 #### Other notable changes
 - [#692](https://github.com/timescale/timescaledb-toolkit/pull/692): Support specifying a range to `duration_in` to specify a time range to get states in for state aggregates
 - [#692](https://github.com/timescale/timescaledb-toolkit/pull/692): Removed `next` parameter from interpolated state aggregate functions
-- [#692](https://github.com/timescale/timescaledb-toolkit/pull/692): Renamed `state_agg` to `compressed_state_agg` and `timeline_agg` to `state_agg`
+- [#692](https://github.com/timescale/timescaledb-toolkit/pull/692): Renamed `state_agg` to `compact_state_agg` and `timeline_agg` to `state_agg`
 
 #### Shout-outs
 

--- a/docs/state_agg.md
+++ b/docs/state_agg.md
@@ -46,7 +46,7 @@ INSERT INTO states_test_5 VALUES
 Compute the amount of time spent in a state as INTERVAL.
 
 ```SQL
-SELECT toolkit_experimental.duration_in('ERROR', toolkit_experimental.compressed_state_agg(ts, state)) FROM states_test;
+SELECT toolkit_experimental.duration_in('ERROR', toolkit_experimental.compact_state_agg(ts, state)) FROM states_test;
 ```
 ```output
  interval
@@ -54,7 +54,7 @@ SELECT toolkit_experimental.duration_in('ERROR', toolkit_experimental.compressed
  00:00:03
 ```
 ```SQL
-SELECT toolkit_experimental.duration_in(2, toolkit_experimental.compressed_state_agg(ts, state)) FROM states_test_4;
+SELECT toolkit_experimental.duration_in(2, toolkit_experimental.compact_state_agg(ts, state)) FROM states_test_4;
 ```
 ```output
  interval
@@ -67,7 +67,7 @@ Extract as number of seconds:
 ```SQL
 SELECT
   EXTRACT(epoch FROM
-    toolkit_experimental.duration_in('ERROR', toolkit_experimental.compressed_state_agg(ts, state))
+    toolkit_experimental.duration_in('ERROR', toolkit_experimental.compact_state_agg(ts, state))
   )::INTEGER
 FROM states_test;
 ```
@@ -133,7 +133,7 @@ SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts,
 
 ```SQL
 SELECT state, duration FROM toolkit_experimental.into_values(
-    (SELECT toolkit_experimental.compressed_state_agg(ts, state) FROM states_test))
+    (SELECT toolkit_experimental.compact_state_agg(ts, state) FROM states_test))
     ORDER BY state, duration;
 ```
 ```output
@@ -146,7 +146,7 @@ SELECT state, duration FROM toolkit_experimental.into_values(
 ```
 ```SQL
 SELECT state, duration FROM toolkit_experimental.into_int_values(
-    (SELECT toolkit_experimental.compressed_state_agg(ts, state) FROM states_test_4))
+    (SELECT toolkit_experimental.compact_state_agg(ts, state) FROM states_test_4))
     ORDER BY state, duration;
 ```
 ```output
@@ -396,7 +396,7 @@ start_time             | end_time
 ```SQL
 WITH buckets AS (SELECT
     date_trunc('minute', ts) as dt,
-    toolkit_experimental.compressed_state_agg(ts, state) AS sa
+    toolkit_experimental.compact_state_agg(ts, state) AS sa
 FROM states_test
 GROUP BY date_trunc('minute', ts))
 SELECT toolkit_experimental.duration_in(
@@ -414,7 +414,7 @@ FROM buckets;
 ```SQL
 WITH buckets AS (SELECT
     date_trunc('minute', ts) as dt,
-    toolkit_experimental.compressed_state_agg(ts, state) AS sa
+    toolkit_experimental.compact_state_agg(ts, state) AS sa
 FROM states_test
 GROUP BY date_trunc('minute', ts))
 SELECT toolkit_experimental.duration_in(

--- a/docs/state_agg.md
+++ b/docs/state_agg.md
@@ -237,7 +237,6 @@ start_time             | end_time
 SELECT state, start_time, end_time FROM toolkit_experimental.interpolated_state_timeline(
     (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
     '2019-12-31', '1 days',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3),
     (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3)
 )
 ORDER BY start_time;
@@ -256,7 +255,6 @@ ERROR | 2020-01-01 00:01:00+00 | 2020-01-01 00:01:03+00
 SELECT state, start_time, end_time FROM toolkit_experimental.interpolated_state_timeline(
     (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
     '2019-12-31', '5 days',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3),
     (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3)
 )
 ORDER BY start_time;
@@ -275,7 +273,6 @@ ERROR | 2020-01-01 00:01:00+00 | 2020-01-01 00:01:03+00
 SELECT state, start_time, end_time FROM toolkit_experimental.interpolated_state_timeline(
     (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
     '2019-12-31', '1 days',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2),
     (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2)
 )
 ORDER BY start_time;
@@ -295,7 +292,6 @@ ERROR | 2020-01-01 00:01:00+00 | 2020-01-01 00:01:03+00
 SELECT state, start_time, end_time FROM toolkit_experimental.interpolated_state_timeline(
     (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
     '2019-12-31', '5 days',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2),
     (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2)
 )
 ORDER BY start_time;
@@ -319,7 +315,6 @@ SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods
     'OK',
     (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
     '2019-12-31', '1 days',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3),
     (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3)
 )
 ORDER BY start_time;
@@ -336,7 +331,6 @@ SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods
     'START',
     (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
     '2019-12-31', '5 days',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3),
     (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3)
 )
 ORDER BY start_time;
@@ -352,7 +346,6 @@ SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods
     'STOP',
     (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
     '2019-12-31', '1 days',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2),
     (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2)
 )
 ORDER BY start_time;
@@ -369,7 +362,6 @@ SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods
     'STOP',
     (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
     '2019-12-31', '5 days',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2),
     (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2)
 )
 ORDER BY start_time;

--- a/docs/state_agg.md
+++ b/docs/state_agg.md
@@ -79,7 +79,7 @@ FROM states_test;
 
 #### duration_in for a range
 ```SQL
-SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00', '2020-01-03 00:01:00+00') FROM states_test;
+SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00', '2 days') FROM states_test;
 ```
 ```output
  duration_in
@@ -87,7 +87,7 @@ SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts,
  00:00:57
 ```
 ```SQL
-SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00') FROM states_test;
+SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00', NULL) FROM states_test;
 ```
 ```output
  duration_in
@@ -95,7 +95,7 @@ SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts,
  00:00:57
 ```
 ```SQL
-SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00', '2020-01-03 00:01:00+00') FROM states_test_4;
+SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00', '2 days') FROM states_test_4;
 ```
 ```output
  duration_in
@@ -103,12 +103,30 @@ SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.state_agg(ts
  00:00:57
 ```
 ```SQL
-SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00') FROM states_test_4;
+SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00', NULL) FROM states_test_4;
 ```
 ```output
  duration_in
 -------------
  00:00:57
+```
+
+```SQL
+SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts, state), '2020-01-01 00:00:15+00', '30 seconds') FROM states_test;
+```
+```output
+ duration_in
+-------------
+ 00:00:30
+```
+
+```SQL
+SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts, state), '2020-01-01 00:00:15+00', '1 minute 1 second') FROM states_test;
+```
+```output
+ duration_in
+-------------
+ 00:00:58
 ```
 
 ### into_values

--- a/docs/state_agg.md
+++ b/docs/state_agg.md
@@ -77,6 +77,40 @@ FROM states_test;
        3
 ```
 
+#### duration_in for a range
+```SQL
+SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.timeline_agg(ts, state), '2020-01-01 00:01:00+00', '2020-01-03 00:01:00+00') FROM states_test;
+```
+```output
+ duration_in
+-------------
+ 00:00:57
+```
+```SQL
+SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.timeline_agg(ts, state), '2020-01-01 00:01:00+00') FROM states_test;
+```
+```output
+ duration_in
+-------------
+ 00:00:57
+```
+```SQL
+SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.timeline_agg(ts, state), '2020-01-01 00:01:00+00', '2020-01-03 00:01:00+00') FROM states_test_4;
+```
+```output
+ duration_in
+-------------
+ 00:00:57
+```
+```SQL
+SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.timeline_agg(ts, state), '2020-01-01 00:01:00+00') FROM states_test_4;
+```
+```output
+ duration_in
+-------------
+ 00:00:57
+```
+
 ### into_values
 
 ```SQL

--- a/docs/state_agg.md
+++ b/docs/state_agg.md
@@ -46,7 +46,7 @@ INSERT INTO states_test_5 VALUES
 Compute the amount of time spent in a state as INTERVAL.
 
 ```SQL
-SELECT toolkit_experimental.duration_in('ERROR', toolkit_experimental.state_agg(ts, state)) FROM states_test;
+SELECT toolkit_experimental.duration_in('ERROR', toolkit_experimental.compressed_state_agg(ts, state)) FROM states_test;
 ```
 ```output
  interval
@@ -54,7 +54,7 @@ SELECT toolkit_experimental.duration_in('ERROR', toolkit_experimental.state_agg(
  00:00:03
 ```
 ```SQL
-SELECT toolkit_experimental.duration_in(2, toolkit_experimental.state_agg(ts, state)) FROM states_test_4;
+SELECT toolkit_experimental.duration_in(2, toolkit_experimental.compressed_state_agg(ts, state)) FROM states_test_4;
 ```
 ```output
  interval
@@ -67,7 +67,7 @@ Extract as number of seconds:
 ```SQL
 SELECT
   EXTRACT(epoch FROM
-    toolkit_experimental.duration_in('ERROR', toolkit_experimental.state_agg(ts, state))
+    toolkit_experimental.duration_in('ERROR', toolkit_experimental.compressed_state_agg(ts, state))
   )::INTEGER
 FROM states_test;
 ```
@@ -79,7 +79,7 @@ FROM states_test;
 
 #### duration_in for a range
 ```SQL
-SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.timeline_agg(ts, state), '2020-01-01 00:01:00+00', '2020-01-03 00:01:00+00') FROM states_test;
+SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00', '2020-01-03 00:01:00+00') FROM states_test;
 ```
 ```output
  duration_in
@@ -87,7 +87,7 @@ SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.timeline_agg(
  00:00:57
 ```
 ```SQL
-SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.timeline_agg(ts, state), '2020-01-01 00:01:00+00') FROM states_test;
+SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00') FROM states_test;
 ```
 ```output
  duration_in
@@ -95,7 +95,7 @@ SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.timeline_agg(
  00:00:57
 ```
 ```SQL
-SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.timeline_agg(ts, state), '2020-01-01 00:01:00+00', '2020-01-03 00:01:00+00') FROM states_test_4;
+SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00', '2020-01-03 00:01:00+00') FROM states_test_4;
 ```
 ```output
  duration_in
@@ -103,7 +103,7 @@ SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.timeline_agg
  00:00:57
 ```
 ```SQL
-SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.timeline_agg(ts, state), '2020-01-01 00:01:00+00') FROM states_test_4;
+SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00') FROM states_test_4;
 ```
 ```output
  duration_in
@@ -115,7 +115,7 @@ SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.timeline_agg
 
 ```SQL
 SELECT state, duration FROM toolkit_experimental.into_values(
-    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test))
+    (SELECT toolkit_experimental.compressed_state_agg(ts, state) FROM states_test))
     ORDER BY state, duration;
 ```
 ```output
@@ -128,7 +128,7 @@ SELECT state, duration FROM toolkit_experimental.into_values(
 ```
 ```SQL
 SELECT state, duration FROM toolkit_experimental.into_int_values(
-    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_4))
+    (SELECT toolkit_experimental.compressed_state_agg(ts, state) FROM states_test_4))
     ORDER BY state, duration;
 ```
 ```output
@@ -144,7 +144,7 @@ SELECT state, duration FROM toolkit_experimental.into_int_values(
 
 ```SQL
 SELECT state, start_time, end_time FROM toolkit_experimental.state_timeline(
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test))
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test))
     ORDER BY start_time;
 ```
 ```output
@@ -159,7 +159,7 @@ ERROR | 2020-01-01 00:01:00+00 | 2020-01-01 00:01:03+00
 
 ```SQL
 SELECT state, start_time, end_time FROM toolkit_experimental.state_int_timeline(
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_4))
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_4))
     ORDER BY start_time;
 ```
 ```output
@@ -175,7 +175,7 @@ state | start_time             | end_time
 
 ```SQL
 SELECT state, start_time, end_time FROM toolkit_experimental.state_timeline(
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2))
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_2))
     ORDER BY start_time;
 ```
 ```output
@@ -192,7 +192,7 @@ START | 2019-12-31 00:00:00+00 | 2019-12-31 00:00:11+00
 SELECT start_time, end_time
 FROM toolkit_experimental.state_periods(
     'OK',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test)
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test)
 )
 ORDER BY start_time;
 ```
@@ -207,7 +207,7 @@ start_time             | end_time
 SELECT start_time, end_time
 FROM toolkit_experimental.state_periods(
     51351,
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_4)
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_4)
 )
 ORDER BY start_time;
 ```
@@ -222,7 +222,7 @@ start_time             | end_time
 SELECT start_time, end_time
 FROM toolkit_experimental.state_periods(
     'ANYTHING',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test)
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test)
 )
 ORDER BY start_time;
 ```
@@ -235,9 +235,9 @@ start_time             | end_time
 
 ```SQL
 SELECT state, start_time, end_time FROM toolkit_experimental.interpolated_state_timeline(
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test),
     '2019-12-31', '1 days',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3)
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_3)
 )
 ORDER BY start_time;
 ```
@@ -253,9 +253,9 @@ ERROR | 2020-01-01 00:01:00+00 | 2020-01-01 00:01:03+00
 
 ```SQL
 SELECT state, start_time, end_time FROM toolkit_experimental.interpolated_state_timeline(
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test),
     '2019-12-31', '5 days',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3)
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_3)
 )
 ORDER BY start_time;
 ```
@@ -271,9 +271,9 @@ ERROR | 2020-01-01 00:01:00+00 | 2020-01-01 00:01:03+00
 
 ```SQL
 SELECT state, start_time, end_time FROM toolkit_experimental.interpolated_state_timeline(
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test),
     '2019-12-31', '1 days',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2)
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_2)
 )
 ORDER BY start_time;
 ```
@@ -290,9 +290,9 @@ ERROR | 2020-01-01 00:01:00+00 | 2020-01-01 00:01:03+00
 
 ```SQL
 SELECT state, start_time, end_time FROM toolkit_experimental.interpolated_state_timeline(
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test),
     '2019-12-31', '5 days',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2)
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_2)
 )
 ORDER BY start_time;
 ```
@@ -313,9 +313,9 @@ ERROR | 2020-01-01 00:01:00+00 | 2020-01-01 00:01:03+00
 ```SQL
 SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods(
     'OK',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test),
     '2019-12-31', '1 days',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3)
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_3)
 )
 ORDER BY start_time;
 ```
@@ -329,9 +329,9 @@ start_time             | end_time
 ```SQL
 SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods(
     'START',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test),
     '2019-12-31', '5 days',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_3)
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_3)
 )
 ORDER BY start_time;
 ```
@@ -344,9 +344,9 @@ start_time             | end_time
 ```SQL
 SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods(
     'STOP',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test),
     '2019-12-31', '1 days',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2)
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_2)
 )
 ORDER BY start_time;
 ```
@@ -360,9 +360,9 @@ start_time             | end_time
 ```SQL
 SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods(
     'STOP',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test),
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test),
     '2019-12-31', '5 days',
-    (SELECT toolkit_experimental.timeline_agg(ts, state) FROM states_test_2)
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_2)
 )
 ORDER BY start_time;
 ```
@@ -378,7 +378,7 @@ start_time             | end_time
 ```SQL
 WITH buckets AS (SELECT
     date_trunc('minute', ts) as dt,
-    toolkit_experimental.state_agg(ts, state) AS sa
+    toolkit_experimental.compressed_state_agg(ts, state) AS sa
 FROM states_test
 GROUP BY date_trunc('minute', ts))
 SELECT toolkit_experimental.duration_in(
@@ -396,7 +396,7 @@ FROM buckets;
 ```SQL
 WITH buckets AS (SELECT
     date_trunc('minute', ts) as dt,
-    toolkit_experimental.state_agg(ts, state) AS sa
+    toolkit_experimental.compressed_state_agg(ts, state) AS sa
 FROM states_test
 GROUP BY date_trunc('minute', ts))
 SELECT toolkit_experimental.duration_in(
@@ -414,7 +414,7 @@ FROM buckets;
 ```SQL
 WITH buckets AS (SELECT
     date_trunc('minute', ts) as dt,
-    toolkit_experimental.timeline_agg(ts, state) AS sa
+    toolkit_experimental.state_agg(ts, state) AS sa
 FROM states_test
 GROUP BY date_trunc('minute', ts))
 SELECT toolkit_experimental.state_timeline(
@@ -435,7 +435,7 @@ FROM buckets;
 ```SQL
 WITH buckets AS (SELECT
     date_trunc('minute', ts) as dt,
-    toolkit_experimental.timeline_agg(ts, state) AS sa
+    toolkit_experimental.state_agg(ts, state) AS sa
 FROM states_test
 GROUP BY date_trunc('minute', ts)
 HAVING date_trunc('minute', ts) != '2020-01-01 00:01:00+00'::timestamptz)
@@ -455,7 +455,7 @@ FROM buckets;
 ```SQL
 WITH buckets AS (SELECT
     date_trunc('minute', ts) as dt,
-    toolkit_experimental.timeline_agg(ts, state) AS sa
+    toolkit_experimental.state_agg(ts, state) AS sa
 FROM states_test_5
 GROUP BY date_trunc('minute', ts)
 HAVING date_trunc('minute', ts) != '2020-01-01 00:01:00+00'::timestamptz)

--- a/docs/state_agg.md
+++ b/docs/state_agg.md
@@ -95,6 +95,14 @@ SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts,
  00:00:57
 ```
 ```SQL
+SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00') FROM states_test;
+```
+```output
+ duration_in
+-------------
+ 00:00:57
+```
+```SQL
 SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00', '2 days') FROM states_test_4;
 ```
 ```output

--- a/extension/src/state_aggregate.rs
+++ b/extension/src/state_aggregate.rs
@@ -345,7 +345,7 @@ pub mod toolkit_experimental {
                 let last_interval = interval_start + interval_len - self.last_time;
                 match durations.get_mut(self.last_state as usize) {
                     None => {
-                        pgx::error!("poorly formed CompressedStateAgg, last_state out of starts")
+                        pgx::error!("poorly formed state aggregate, last_state out of starts")
                     }
                     Some(dis) => {
                         dis.duration += last_interval;
@@ -353,7 +353,7 @@ pub mod toolkit_experimental {
                             // extend last duration
                             combined_durations
                                 .last_mut()
-                                .expect("poorly formed StateAgg, length mismatch")
+                                .expect("poorly formed state aggregate, length mismatch")
                                 .end_time += last_interval;
                         };
                         Record {

--- a/extension/src/state_aggregate.rs
+++ b/extension/src/state_aggregate.rs
@@ -875,7 +875,7 @@ pub fn duration_in_range<'a>(
     state: String,
     aggregate: Option<StateAgg<'a>>,
     start: TimestampTz,
-    interval: Option<crate::raw::Interval>,
+    interval: default!(Option<crate::raw::Interval>, "NULL"),
 ) -> crate::raw::Interval {
     if let Some(ref aggregate) = aggregate {
         aggregate.assert_str()
@@ -902,7 +902,7 @@ pub fn duration_in_range_int<'a>(
     state: i64,
     aggregate: Option<StateAgg<'a>>,
     start: TimestampTz,
-    interval: Option<crate::raw::Interval>,
+    interval: default!(Option<crate::raw::Interval>, "NULL"),
 ) -> crate::raw::Interval {
     if let Some(ref aggregate) = aggregate {
         aggregate.assert_int()

--- a/extension/src/state_aggregate.rs
+++ b/extension/src/state_aggregate.rs
@@ -337,7 +337,7 @@ pub mod toolkit_experimental {
                     state: self.durations.as_slice()[self.first_state as usize]
                         .state
                         .materialize(&states),
-                    time: interval_start,
+                    time: self.first_time,
                 },
             };
 
@@ -752,12 +752,6 @@ fn duration_in_inner<'a>(
             assert!(
                 !agg.0.compact,
                 "unreachable: interval specified for compact aggregate"
-            );
-            assert!(
-                start >= agg.0.first_time,
-                "Start time ({}) cannot be before first state ({})",
-                start,
-                agg.0.first_time,
             );
 
             let state = state.materialize(agg.states_as_str());

--- a/extension/src/state_aggregate.rs
+++ b/extension/src/state_aggregate.rs
@@ -757,14 +757,16 @@ fn duration_in_inner<'a>(
             let state = state.materialize(agg.states_as_str());
             let mut total = 0;
             for tis in agg.combined_durations.iter() {
-                if tis.state.materialize(agg.states_as_str()) == state {
-                    let tis_start_time = i64::max(tis.start_time, start);
-                    let tis_end_time = i64::min(tis.end_time, end);
-                    if tis_end_time >= start && tis_start_time <= end {
-                        let amount = tis_end_time - tis_start_time;
-                        assert!(amount >= 0, "incorrectly ordered times");
-                        total += amount;
-                    }
+                let tis_start_time = i64::max(tis.start_time, start);
+                let tis_end_time = i64::min(tis.end_time, end);
+                if tis_start_time > end {
+                    // combined_durations is sorted, so after this point there can't be any more
+                    break;
+                };
+                if tis_end_time >= start && tis.state.materialize(agg.states_as_str()) == state {
+                    let amount = tis_end_time - tis_start_time;
+                    assert!(amount >= 0, "incorrectly ordered times");
+                    total += amount;
                 }
             }
             total

--- a/extension/src/state_aggregate/rollup.rs
+++ b/extension/src/state_aggregate/rollup.rs
@@ -7,57 +7,57 @@ use serde::{Deserialize, Serialize};
 
 extension_sql!(
     "CREATE AGGREGATE toolkit_experimental.rollup(
+        value toolkit_experimental.CompressedStateAgg
+    ) (
+        sfunc = toolkit_experimental.compressed_state_agg_rollup_trans,
+        stype = internal,
+        finalfunc = toolkit_experimental.compressed_state_agg_rollup_final,
+        combinefunc = toolkit_experimental.compressed_state_agg_rollup_combine,
+        serialfunc = toolkit_experimental.compressed_state_agg_rollup_serialize,
+        deserialfunc = toolkit_experimental.compressed_state_agg_rollup_deserialize,
+        parallel = restricted
+    );",
+    name = "compressed_state_agg_rollup",
+    requires = [
+        compressed_state_agg_rollup_trans,
+        compressed_state_agg_rollup_final,
+        compressed_state_agg_rollup_combine,
+        compressed_state_agg_rollup_serialize,
+        compressed_state_agg_rollup_deserialize,
+        CompressedStateAgg,
+    ],
+);
+extension_sql!(
+    "CREATE AGGREGATE toolkit_experimental.rollup(
         value toolkit_experimental.StateAgg
     ) (
         sfunc = toolkit_experimental.state_agg_rollup_trans,
         stype = internal,
         finalfunc = toolkit_experimental.state_agg_rollup_final,
-        combinefunc = toolkit_experimental.state_agg_rollup_combine,
-        serialfunc = toolkit_experimental.state_agg_rollup_serialize,
-        deserialfunc = toolkit_experimental.state_agg_rollup_deserialize,
+        combinefunc = toolkit_experimental.compressed_state_agg_rollup_combine,
+        serialfunc = toolkit_experimental.compressed_state_agg_rollup_serialize,
+        deserialfunc = toolkit_experimental.compressed_state_agg_rollup_deserialize,
         parallel = restricted
     );",
     name = "state_agg_rollup",
     requires = [
         state_agg_rollup_trans,
         state_agg_rollup_final,
-        state_agg_rollup_combine,
-        state_agg_rollup_serialize,
-        state_agg_rollup_deserialize,
+        compressed_state_agg_rollup_combine,
+        compressed_state_agg_rollup_serialize,
+        compressed_state_agg_rollup_deserialize,
         StateAgg,
-    ],
-);
-extension_sql!(
-    "CREATE AGGREGATE toolkit_experimental.rollup(
-        value toolkit_experimental.TimelineAgg
-    ) (
-        sfunc = toolkit_experimental.timeline_agg_rollup_trans,
-        stype = internal,
-        finalfunc = toolkit_experimental.timeline_agg_rollup_final,
-        combinefunc = toolkit_experimental.state_agg_rollup_combine,
-        serialfunc = toolkit_experimental.state_agg_rollup_serialize,
-        deserialfunc = toolkit_experimental.state_agg_rollup_deserialize,
-        parallel = restricted
-    );",
-    name = "timeline_agg_rollup",
-    requires = [
-        timeline_agg_rollup_trans,
-        timeline_agg_rollup_final,
-        state_agg_rollup_combine,
-        state_agg_rollup_serialize,
-        state_agg_rollup_deserialize,
-        TimelineAgg,
     ],
 );
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RollupTransState {
-    values: Vec<OwnedStateAgg>,
-    from_timeline_agg: bool,
+    values: Vec<OwnedCompressedStateAgg>,
+    compressed: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct OwnedStateAgg {
+struct OwnedCompressedStateAgg {
     durations: Vec<DurationInState>,
     combined_durations: Vec<TimeInState>,
     first_time: i64,
@@ -65,15 +65,15 @@ struct OwnedStateAgg {
     first_state: u32,
     last_state: u32,
     states: Vec<u8>,
-    from_timeline_agg: bool,
+    compressed: bool,
     integer_states: bool,
 }
 
-impl OwnedStateAgg {
+impl OwnedCompressedStateAgg {
     pub fn merge(self, other: Self) -> Self {
         assert_eq!(
-            self.from_timeline_agg, other.from_timeline_agg,
-            "can't merge state_agg and timeline_agg"
+            self.compressed, other.compressed,
+            "can't merge compressed_state_agg and state_agg"
         );
         assert_eq!(
             self.integer_states, other.integer_states,
@@ -145,7 +145,7 @@ impl OwnedStateAgg {
         merged_durations[earlier.last_state as usize].duration += gap;
 
         // ensure combined_durations covers the whole range of time
-        if earlier.from_timeline_agg {
+        if !earlier.compressed {
             if combined_durations[earlier_len - 1]
                 .state
                 .materialize(&merged_states)
@@ -162,7 +162,7 @@ impl OwnedStateAgg {
         }
 
         let merged_states = merged_states.into_bytes();
-        OwnedStateAgg {
+        OwnedCompressedStateAgg {
             states: merged_states,
             durations: merged_durations,
             combined_durations,
@@ -173,16 +173,16 @@ impl OwnedStateAgg {
             last_state: added_entries + later.last_state,
 
             // these values are always the same for both
-            from_timeline_agg: earlier.from_timeline_agg,
+            compressed: earlier.compressed,
             integer_states: earlier.integer_states,
         }
     }
 }
 
-impl<'a> From<OwnedStateAgg> for StateAgg<'a> {
-    fn from(owned: OwnedStateAgg) -> StateAgg<'a> {
+impl<'a> From<OwnedCompressedStateAgg> for CompressedStateAgg<'a> {
+    fn from(owned: OwnedCompressedStateAgg) -> CompressedStateAgg<'a> {
         unsafe {
-            flatten!(StateAgg {
+            flatten!(CompressedStateAgg {
                 states_len: owned.states.len() as u64,
                 states: (&*owned.states).into(),
                 durations_len: owned.durations.len() as u64,
@@ -193,16 +193,16 @@ impl<'a> From<OwnedStateAgg> for StateAgg<'a> {
                 last_time: owned.last_time,
                 first_state: owned.first_state,
                 last_state: owned.last_state,
-                from_timeline_agg: owned.from_timeline_agg,
+                compressed: owned.compressed,
                 integer_states: owned.integer_states,
             })
         }
     }
 }
 
-impl<'a> From<StateAgg<'a>> for OwnedStateAgg {
-    fn from(agg: StateAgg<'a>) -> OwnedStateAgg {
-        OwnedStateAgg {
+impl<'a> From<CompressedStateAgg<'a>> for OwnedCompressedStateAgg {
+    fn from(agg: CompressedStateAgg<'a>) -> OwnedCompressedStateAgg {
+        OwnedCompressedStateAgg {
             states: agg.states.iter().collect::<Vec<_>>(),
             durations: agg.durations.iter().collect::<Vec<_>>(),
             combined_durations: agg.combined_durations.iter().collect::<Vec<_>>(),
@@ -210,7 +210,7 @@ impl<'a> From<StateAgg<'a>> for OwnedStateAgg {
             last_time: agg.last_time,
             first_state: agg.first_state,
             last_state: agg.last_state,
-            from_timeline_agg: agg.from_timeline_agg,
+            compressed: agg.compressed,
             integer_states: agg.integer_states,
         }
     }
@@ -228,17 +228,17 @@ impl RollupTransState {
 }
 
 #[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
-pub fn state_agg_rollup_trans<'a>(
+pub fn compressed_state_agg_rollup_trans<'a>(
     state: Internal,
-    next: Option<StateAgg<'a>>,
+    next: Option<CompressedStateAgg<'a>>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Internal> {
-    state_agg_rollup_trans_inner(unsafe { state.to_inner() }, next, fcinfo).internal()
+    compressed_state_agg_rollup_trans_inner(unsafe { state.to_inner() }, next, fcinfo).internal()
 }
 
-pub fn state_agg_rollup_trans_inner<'a>(
+pub fn compressed_state_agg_rollup_trans_inner<'a>(
     state: Option<Inner<RollupTransState>>,
-    next: Option<StateAgg<'a>>,
+    next: Option<CompressedStateAgg<'a>>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Inner<RollupTransState>> {
     unsafe {
@@ -247,7 +247,7 @@ pub fn state_agg_rollup_trans_inner<'a>(
             (None, Some(next)) => Some(
                 RollupTransState {
                     values: vec![next.into()],
-                    from_timeline_agg: false,
+                    compressed: false,
                 }
                 .into(),
             ),
@@ -261,17 +261,44 @@ pub fn state_agg_rollup_trans_inner<'a>(
 }
 
 #[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
-pub fn timeline_agg_rollup_trans<'a>(
+pub fn state_agg_rollup_trans<'a>(
     state: Internal,
-    next: Option<TimelineAgg<'a>>,
+    next: Option<StateAgg<'a>>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Internal> {
-    state_agg_rollup_trans_inner(
+    compressed_state_agg_rollup_trans_inner(
         unsafe { state.to_inner() },
-        next.map(TimelineAgg::as_state_agg),
+        next.map(StateAgg::as_compressed_state_agg),
         fcinfo,
     )
     .internal()
+}
+
+#[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
+fn compressed_state_agg_rollup_final<'a>(
+    state: Internal,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<CompressedStateAgg<'a>> {
+    compressed_state_agg_rollup_final_inner(unsafe { state.to_inner() }, fcinfo)
+}
+
+fn compressed_state_agg_rollup_final_inner<'a>(
+    state: Option<Inner<RollupTransState>>,
+    fcinfo: pg_sys::FunctionCallInfo,
+) -> Option<CompressedStateAgg<'a>> {
+    unsafe {
+        in_aggregate_context(fcinfo, || {
+            let mut state = match state {
+                None => return None,
+                Some(state) => state.clone(),
+            };
+            state.merge();
+            assert!(state.values.len() == 1);
+            let agg: Option<OwnedCompressedStateAgg> =
+                state.values.drain(..).next().unwrap().into();
+            agg.map(Into::into)
+        })
+    }
 }
 
 #[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
@@ -294,67 +321,46 @@ fn state_agg_rollup_final_inner<'a>(
             };
             state.merge();
             assert!(state.values.len() == 1);
-            let agg: Option<OwnedStateAgg> = state.values.drain(..).next().unwrap().into();
-            agg.map(Into::into)
-        })
-    }
-}
-
-#[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
-fn timeline_agg_rollup_final<'a>(
-    state: Internal,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<TimelineAgg<'a>> {
-    timeline_agg_rollup_final_inner(unsafe { state.to_inner() }, fcinfo)
-}
-
-fn timeline_agg_rollup_final_inner<'a>(
-    state: Option<Inner<RollupTransState>>,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<TimelineAgg<'a>> {
-    unsafe {
-        in_aggregate_context(fcinfo, || {
-            let mut state = match state {
-                None => return None,
-                Some(state) => state.clone(),
-            };
-            state.merge();
-            assert!(state.values.len() == 1);
-            let agg: Option<OwnedStateAgg> = state.values.drain(..).next().unwrap().into();
-            agg.map(Into::into).map(TimelineAgg::new)
+            let agg: Option<OwnedCompressedStateAgg> =
+                state.values.drain(..).next().unwrap().into();
+            agg.map(Into::into).map(StateAgg::new)
         })
     }
 }
 
 #[pg_extern(immutable, parallel_safe, strict, schema = "toolkit_experimental")]
-pub fn state_agg_rollup_serialize(state: Internal) -> bytea {
+pub fn compressed_state_agg_rollup_serialize(state: Internal) -> bytea {
     let mut state: Inner<RollupTransState> = unsafe { state.to_inner().unwrap() };
     state.merge();
     crate::do_serialize!(state)
 }
 
 #[pg_extern(strict, immutable, parallel_safe, schema = "toolkit_experimental")]
-pub fn state_agg_rollup_deserialize(bytes: bytea, _internal: Internal) -> Option<Internal> {
-    state_agg_rollup_deserialize_inner(bytes).internal()
+pub fn compressed_state_agg_rollup_deserialize(
+    bytes: bytea,
+    _internal: Internal,
+) -> Option<Internal> {
+    compressed_state_agg_rollup_deserialize_inner(bytes).internal()
 }
-pub fn state_agg_rollup_deserialize_inner(bytes: bytea) -> Inner<RollupTransState> {
+pub fn compressed_state_agg_rollup_deserialize_inner(bytes: bytea) -> Inner<RollupTransState> {
     let t: RollupTransState = crate::do_deserialize!(bytes, RollupTransState);
     t.into()
 }
 
 #[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
-pub fn state_agg_rollup_combine(
+pub fn compressed_state_agg_rollup_combine(
     state1: Internal,
     state2: Internal,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Internal> {
     unsafe {
-        state_agg_rollup_combine_inner(state1.to_inner(), state2.to_inner(), fcinfo).internal()
+        compressed_state_agg_rollup_combine_inner(state1.to_inner(), state2.to_inner(), fcinfo)
+            .internal()
     }
 }
 
 #[allow(clippy::redundant_clone)] // clone is needed so we don't mutate shared memory
-pub fn state_agg_rollup_combine_inner(
+pub fn compressed_state_agg_rollup_combine_inner(
     state1: Option<Inner<RollupTransState>>,
     state2: Option<Inner<RollupTransState>>,
     fcinfo: pg_sys::FunctionCallInfo,
@@ -365,10 +371,10 @@ pub fn state_agg_rollup_combine_inner(
             (Some(x), None) => Some(x.clone().into()),
             (None, Some(x)) => Some(x.clone().into()),
             (Some(x), Some(y)) => {
-                let from_timeline_agg = x.from_timeline_agg;
+                let compressed = x.compressed;
                 assert_eq!(
-                    from_timeline_agg, y.from_timeline_agg,
-                    "trying to merge state and timeline aggs, this should be unreachable"
+                    compressed, y.compressed,
+                    "trying to merge compressed and uncompressed state aggs, this should be unreachable"
                 );
                 let values = x
                     .values
@@ -376,10 +382,7 @@ pub fn state_agg_rollup_combine_inner(
                     .chain(y.values.iter())
                     .map(Clone::clone)
                     .collect::<Vec<_>>();
-                let trans_state = RollupTransState {
-                    values,
-                    from_timeline_agg,
-                };
+                let trans_state = RollupTransState { values, compressed };
                 Some(trans_state.clone().into())
             }
         })
@@ -395,11 +398,11 @@ mod tests {
     #[pg_test]
     #[should_panic = "can't merge overlapping aggregates"]
     fn merge_range_full_overlap() {
-        let mut outer: OwnedStateAgg = StateAgg::empty(false, false).into();
+        let mut outer: OwnedCompressedStateAgg = CompressedStateAgg::empty(false, false).into();
         outer.first_time = 10;
         outer.last_time = 50;
 
-        let mut inner: OwnedStateAgg = StateAgg::empty(false, false).into();
+        let mut inner: OwnedCompressedStateAgg = CompressedStateAgg::empty(false, false).into();
         inner.first_time = 20;
         inner.last_time = 30;
 
@@ -409,11 +412,11 @@ mod tests {
     #[pg_test]
     #[should_panic = "can't merge overlapping aggregates"]
     fn merge_range_partial_overlap() {
-        let mut r1: OwnedStateAgg = StateAgg::empty(false, false).into();
+        let mut r1: OwnedCompressedStateAgg = CompressedStateAgg::empty(false, false).into();
         r1.first_time = 10;
         r1.last_time = 50;
 
-        let mut r2: OwnedStateAgg = StateAgg::empty(false, false).into();
+        let mut r2: OwnedCompressedStateAgg = CompressedStateAgg::empty(false, false).into();
         r2.first_time = 20;
         r2.last_time = 50;
 


### PR DESCRIPTION
- Adds optional `start` and `end` parameters to `duration_in` to only get the duration in the specified range. If `end` is omitted all states after `start` are included. `interpolated_duration_in` now uses these ones as well.
- Renames `state_agg` -> `compressed_state_agg` (final name TBD), `timeline_agg` -> `state_agg`
- Removes mostly unused `next` parameters from interpolated state aggregate functions

Closes #687. Related to #691.