### PR TITLE
Add rollup functionality to frequency aggregates

### DIFF
--- a/extension/src/aggregate_utils.rs
+++ b/extension/src/aggregate_utils.rs
@@ -11,6 +11,14 @@ pub unsafe fn get_collation(fcinfo: pg_sys::FunctionCallInfo) -> Option<pg_sys::
     }
 }
 
+pub fn get_collation_or_default(fcinfo: pg_sys::FunctionCallInfo) -> Option<pg_sys::Oid> {
+    if fcinfo.is_null() {
+        Some(100) // TODO: default OID, there should be a constant for this
+    } else {
+        unsafe { get_collation(fcinfo) }
+    }
+}
+
 pub unsafe fn in_aggregate_context<T, F: FnOnce() -> T>(
     fcinfo: pg_sys::FunctionCallInfo,
     f: F,

--- a/extension/src/datum_utils.rs
+++ b/extension/src/datum_utils.rs
@@ -170,11 +170,7 @@ impl DatumHashBuilder {
 
 impl Clone for DatumHashBuilder {
     fn clone(&self) -> Self {
-        Self {
-            info: self.info,
-            type_id: self.type_id,
-            collation: self.collation,
-        }
+        unsafe { DatumHashBuilder::from_type_id(self.type_id, Some(self.collation)) }
     }
 }
 


### PR DESCRIPTION
This change implements adds in rollup functions for frequency aggregates.

Note that while the rollup of a set of frequency aggregates will not necessarily be identical to computing a single aggregate over the underlying data (may not have the exact same upper and lower bounds on frequency), the rollup maintains the same invariants and will be able to identify most common elements as long as the frequency is different enough.

Fixes #685 