### PR TITLE
state_agg API tweaks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,8 @@ This changelog should be updated as part of a PR if the work is worth noting (mo
 - [#692](https://github.com/timescale/timescaledb-toolkit/pull/692): Support specifying a range to `duration_in` to specify a time range to get states in for state aggregates
 - [#692](https://github.com/timescale/timescaledb-toolkit/pull/692): Removed `next` parameter from interpolated state aggregate functions
 - [#692](https://github.com/timescale/timescaledb-toolkit/pull/692): Renamed `state_agg` to `compact_state_agg` and `timeline_agg` to `state_agg`
+- [#699](https://github.com/timescale/timescaledb-toolkit/pull/699): `interpolated_duration_in`/`duration_in`/`interpolated_state_periods`/`state_periods` have the first two arguments swapped: now the aggregate is first and the state is second
+- [#699](https://github.com/timescale/timescaledb-toolkit/pull/699): `into_values`/`into_int_values` now returns a table with intervals instead of microseconds
 
 #### Shout-outs
 

--- a/docs/state_agg.md
+++ b/docs/state_agg.md
@@ -217,8 +217,8 @@ START | 2019-12-31 00:00:00+00 | 2019-12-31 00:00:11+00
 ```SQL
 SELECT start_time, end_time
 FROM toolkit_experimental.state_periods(
-    'OK',
-    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test)
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test),
+    'OK'
 )
 ORDER BY start_time;
 ```
@@ -232,8 +232,8 @@ start_time             | end_time
 ```SQL
 SELECT start_time, end_time
 FROM toolkit_experimental.state_periods(
-    51351,
-    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_4)
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_4),
+    51351
 )
 ORDER BY start_time;
 ```
@@ -247,8 +247,8 @@ start_time             | end_time
 ```SQL
 SELECT start_time, end_time
 FROM toolkit_experimental.state_periods(
-    'ANYTHING',
-    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test)
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test),
+    'ANYTHING'
 )
 ORDER BY start_time;
 ```
@@ -338,8 +338,8 @@ ERROR | 2020-01-01 00:01:00+00 | 2020-01-01 00:01:03+00
 
 ```SQL
 SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods(
-    'OK',
     (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test),
+    'OK',
     '2019-12-31', '1 days',
     (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_3)
 )
@@ -354,8 +354,8 @@ start_time             | end_time
 
 ```SQL
 SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods(
-    'START',
     (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test),
+    'START',
     '2019-12-31', '5 days',
     (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_3)
 )
@@ -369,8 +369,8 @@ start_time             | end_time
 
 ```SQL
 SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods(
-    'STOP',
     (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test),
+    'STOP',
     '2019-12-31', '1 days',
     (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_2)
 )
@@ -385,8 +385,8 @@ start_time             | end_time
 
 ```SQL
 SELECT start_time, end_time FROM toolkit_experimental.interpolated_state_periods(
-    'STOP',
     (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test),
+    'STOP',
     '2019-12-31', '5 days',
     (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_2)
 )

--- a/docs/state_agg.md
+++ b/docs/state_agg.md
@@ -46,7 +46,7 @@ INSERT INTO states_test_5 VALUES
 Compute the amount of time spent in a state as INTERVAL.
 
 ```SQL
-SELECT toolkit_experimental.duration_in('ERROR', toolkit_experimental.compact_state_agg(ts, state)) FROM states_test;
+SELECT toolkit_experimental.duration_in(toolkit_experimental.compact_state_agg(ts, state), 'ERROR') FROM states_test;
 ```
 ```output
  interval
@@ -54,7 +54,7 @@ SELECT toolkit_experimental.duration_in('ERROR', toolkit_experimental.compact_st
  00:00:03
 ```
 ```SQL
-SELECT toolkit_experimental.duration_in(2, toolkit_experimental.compact_state_agg(ts, state)) FROM states_test_4;
+SELECT toolkit_experimental.duration_in(toolkit_experimental.compact_state_agg(ts, state), 2) FROM states_test_4;
 ```
 ```output
  interval
@@ -67,7 +67,7 @@ Extract as number of seconds:
 ```SQL
 SELECT
   EXTRACT(epoch FROM
-    toolkit_experimental.duration_in('ERROR', toolkit_experimental.compact_state_agg(ts, state))
+    toolkit_experimental.duration_in(toolkit_experimental.compact_state_agg(ts, state), 'ERROR')
   )::INTEGER
 FROM states_test;
 ```
@@ -79,7 +79,7 @@ FROM states_test;
 
 #### duration_in for a range
 ```SQL
-SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00', '2 days') FROM states_test;
+SELECT toolkit_experimental.duration_in(toolkit_experimental.state_agg(ts, state), 'OK', '2020-01-01 00:01:00+00', '2 days') FROM states_test;
 ```
 ```output
  duration_in
@@ -87,7 +87,7 @@ SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts,
  00:00:57
 ```
 ```SQL
-SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00', NULL) FROM states_test;
+SELECT toolkit_experimental.duration_in(toolkit_experimental.state_agg(ts, state), 'OK', '2020-01-01 00:01:00+00', NULL) FROM states_test;
 ```
 ```output
  duration_in
@@ -95,7 +95,7 @@ SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts,
  00:00:57
 ```
 ```SQL
-SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00') FROM states_test;
+SELECT toolkit_experimental.duration_in(toolkit_experimental.state_agg(ts, state), 'OK', '2020-01-01 00:01:00+00') FROM states_test;
 ```
 ```output
  duration_in
@@ -103,7 +103,7 @@ SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts,
  00:00:57
 ```
 ```SQL
-SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00', '2 days') FROM states_test_4;
+SELECT toolkit_experimental.duration_in(toolkit_experimental.state_agg(ts, state), 51351, '2020-01-01 00:01:00+00', '2 days') FROM states_test_4;
 ```
 ```output
  duration_in
@@ -111,7 +111,7 @@ SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.state_agg(ts
  00:00:57
 ```
 ```SQL
-SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.state_agg(ts, state), '2020-01-01 00:01:00+00', NULL) FROM states_test_4;
+SELECT toolkit_experimental.duration_in(toolkit_experimental.state_agg(ts, state), 51351, '2020-01-01 00:01:00+00', NULL) FROM states_test_4;
 ```
 ```output
  duration_in
@@ -120,7 +120,7 @@ SELECT toolkit_experimental.duration_in(51351, toolkit_experimental.state_agg(ts
 ```
 
 ```SQL
-SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts, state), '2020-01-01 00:00:15+00', '30 seconds') FROM states_test;
+SELECT toolkit_experimental.duration_in(toolkit_experimental.state_agg(ts, state), 'OK', '2020-01-01 00:00:15+00', '30 seconds') FROM states_test;
 ```
 ```output
  duration_in
@@ -129,7 +129,7 @@ SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts,
 ```
 
 ```SQL
-SELECT toolkit_experimental.duration_in('OK', toolkit_experimental.state_agg(ts, state), '2020-01-01 00:00:15+00', '1 minute 1 second') FROM states_test;
+SELECT toolkit_experimental.duration_in(toolkit_experimental.state_agg(ts, state), 'OK', '2020-01-01 00:00:15+00', '1 minute 1 second') FROM states_test;
 ```
 ```output
  duration_in
@@ -408,8 +408,8 @@ WITH buckets AS (SELECT
 FROM states_test
 GROUP BY date_trunc('minute', ts))
 SELECT toolkit_experimental.duration_in(
-    'START',
-    toolkit_experimental.rollup(buckets.sa)
+    toolkit_experimental.rollup(buckets.sa),
+    'START'
 )
 FROM buckets;
 ```
@@ -426,8 +426,8 @@ WITH buckets AS (SELECT
 FROM states_test
 GROUP BY date_trunc('minute', ts))
 SELECT toolkit_experimental.duration_in(
-    'OK',
-    toolkit_experimental.rollup(buckets.sa)
+    toolkit_experimental.rollup(buckets.sa),
+    'OK'
 )
 FROM buckets;
 ```

--- a/docs/state_agg.md
+++ b/docs/state_agg.md
@@ -147,23 +147,23 @@ SELECT state, duration FROM toolkit_experimental.into_values(
 ```output
  state | duration
 -------+-----------
- ERROR |   3000000
- OK    | 106000000
- START |  11000000
- STOP  |         0
+ ERROR |  00:00:03
+ OK    |  00:01:46
+ START |  00:00:11
+ STOP  |  00:00:00
 ```
 ```SQL
 SELECT state, duration FROM toolkit_experimental.into_int_values(
-    (SELECT toolkit_experimental.compact_state_agg(ts, state) FROM states_test_4))
+    (SELECT toolkit_experimental.state_agg(ts, state) FROM states_test_4))
     ORDER BY state, duration;
 ```
 ```output
  state | duration
 -------+-----------
-   -9 |         0
-    2 |   3000000
-    4 |  11000000
-51351 | 106000000
+   -9 |  00:00:00
+    2 |  00:00:03
+    4 |  00:00:11
+51351 |  00:01:46
 ```
 
 ### state_timeline

--- a/extension/src/state_aggregate.rs
+++ b/extension/src/state_aggregate.rs
@@ -1346,8 +1346,8 @@ fn state_periods_inner<'a>(
 
 #[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
 pub fn state_periods<'a>(
-    state: String,
     agg: StateAgg<'a>,
+    state: String,
 ) -> TableIterator<
     'a,
     (
@@ -1366,8 +1366,8 @@ pub fn state_periods<'a>(
     name = "state_periods"
 )]
 pub fn state_int_periods<'a>(
-    state: i64,
     agg: StateAgg<'a>,
+    state: i64,
 ) -> TableIterator<
     'a,
     (
@@ -1383,8 +1383,8 @@ pub fn state_int_periods<'a>(
 }
 
 fn interpolated_state_periods_inner<'a>(
-    state: MaterializedState,
     aggregate: Option<StateAgg<'a>>,
+    state: MaterializedState,
     start: TimestampTz,
     interval: crate::raw::Interval,
     prev: Option<StateAgg<'a>>,
@@ -1418,8 +1418,8 @@ fn interpolated_state_periods_inner<'a>(
 }
 #[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
 pub fn interpolated_state_periods<'a>(
-    state: String,
     aggregate: Option<StateAgg<'a>>,
+    state: String,
     start: TimestampTz,
     interval: crate::raw::Interval,
     prev: Option<StateAgg<'a>>,
@@ -1434,8 +1434,8 @@ pub fn interpolated_state_periods<'a>(
         aggregate.assert_str()
     };
     interpolated_state_periods_inner(
-        MaterializedState::String(state),
         aggregate,
+        MaterializedState::String(state),
         start,
         interval,
         prev,
@@ -1448,8 +1448,8 @@ pub fn interpolated_state_periods<'a>(
     name = "interpolated_state_periods"
 )]
 pub fn interpolated_state_periods_int<'a>(
-    state: i64,
     aggregate: Option<StateAgg<'a>>,
+    state: i64,
     start: TimestampTz,
     interval: crate::raw::Interval,
     prev: Option<StateAgg<'a>>,
@@ -1464,8 +1464,8 @@ pub fn interpolated_state_periods_int<'a>(
         aggregate.assert_int()
     };
     interpolated_state_periods_inner(
-        MaterializedState::Integer(state),
         aggregate,
+        MaterializedState::Integer(state),
         start,
         interval,
         prev,

--- a/extension/src/state_aggregate.rs
+++ b/extension/src/state_aggregate.rs
@@ -804,17 +804,14 @@ fn duration_in_inner<'a>(
 }
 
 #[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
-pub fn duration_in<'a>(
-    aggregate: Option<CompactStateAgg<'a>>,
-    state: String,
-) -> crate::raw::Interval {
-    if let Some(ref aggregate) = aggregate {
-        aggregate.assert_str()
+pub fn duration_in<'a>(agg: Option<CompactStateAgg<'a>>, state: String) -> crate::raw::Interval {
+    if let Some(ref agg) = agg {
+        agg.assert_str()
     };
-    let state = aggregate
+    let state = agg
         .as_ref()
-        .and_then(|aggregate| StateEntry::try_from_existing_str(aggregate.states_as_str(), &state));
-    duration_in_inner(aggregate, state, None)
+        .and_then(|agg| StateEntry::try_from_existing_str(agg.states_as_str(), &state));
+    duration_in_inner(agg, state, None)
 }
 
 #[pg_extern(
@@ -823,14 +820,11 @@ pub fn duration_in<'a>(
     name = "duration_in",
     schema = "toolkit_experimental"
 )]
-pub fn duration_in_int<'a>(
-    aggregate: Option<CompactStateAgg<'a>>,
-    state: i64,
-) -> crate::raw::Interval {
-    if let Some(ref aggregate) = aggregate {
-        aggregate.assert_int()
+pub fn duration_in_int<'a>(agg: Option<CompactStateAgg<'a>>, state: i64) -> crate::raw::Interval {
+    if let Some(ref agg) = agg {
+        agg.assert_int()
     };
-    duration_in_inner(aggregate, Some(StateEntry::from_integer(state)), None)
+    duration_in_inner(agg, Some(StateEntry::from_integer(state)), None)
 }
 
 #[pg_extern(
@@ -839,11 +833,11 @@ pub fn duration_in_int<'a>(
     name = "duration_in",
     schema = "toolkit_experimental"
 )]
-pub fn duration_in_tl<'a>(aggregate: Option<StateAgg<'a>>, state: String) -> crate::raw::Interval {
-    if let Some(ref aggregate) = aggregate {
-        aggregate.assert_str()
+pub fn duration_in_tl<'a>(agg: Option<StateAgg<'a>>, state: String) -> crate::raw::Interval {
+    if let Some(ref agg) = agg {
+        agg.assert_str()
     };
-    duration_in(aggregate.map(StateAgg::as_compact_state_agg), state)
+    duration_in(agg.map(StateAgg::as_compact_state_agg), state)
 }
 
 #[pg_extern(
@@ -852,12 +846,12 @@ pub fn duration_in_tl<'a>(aggregate: Option<StateAgg<'a>>, state: String) -> cra
     name = "duration_in",
     schema = "toolkit_experimental"
 )]
-pub fn duration_in_tl_int<'a>(aggregate: Option<StateAgg<'a>>, state: i64) -> crate::raw::Interval {
-    if let Some(ref aggregate) = aggregate {
-        aggregate.assert_int()
+pub fn duration_in_tl_int<'a>(agg: Option<StateAgg<'a>>, state: i64) -> crate::raw::Interval {
+    if let Some(ref agg) = agg {
+        agg.assert_int()
     };
     duration_in_inner(
-        aggregate.map(StateAgg::as_compact_state_agg),
+        agg.map(StateAgg::as_compact_state_agg),
         Some(StateEntry::from_integer(state)),
         None,
     )
@@ -870,21 +864,21 @@ pub fn duration_in_tl_int<'a>(aggregate: Option<StateAgg<'a>>, state: i64) -> cr
     schema = "toolkit_experimental"
 )]
 pub fn duration_in_range<'a>(
-    aggregate: Option<StateAgg<'a>>,
+    agg: Option<StateAgg<'a>>,
     state: String,
     start: TimestampTz,
     interval: default!(Option<crate::raw::Interval>, "NULL"),
 ) -> crate::raw::Interval {
-    if let Some(ref aggregate) = aggregate {
-        aggregate.assert_str()
+    if let Some(ref agg) = agg {
+        agg.assert_str()
     };
-    let aggregate = aggregate.map(StateAgg::as_compact_state_agg);
+    let agg = agg.map(StateAgg::as_compact_state_agg);
     let interval = interval.map(|interval| crate::datum_utils::interval_to_ms(&start, &interval));
     let start = start.into();
-    let state = aggregate
+    let state = agg
         .as_ref()
-        .and_then(|aggregate| StateEntry::try_from_existing_str(aggregate.states_as_str(), &state));
-    duration_in_inner(aggregate, state, Some((start, interval)))
+        .and_then(|agg| StateEntry::try_from_existing_str(agg.states_as_str(), &state));
+    duration_in_inner(agg, state, Some((start, interval)))
 }
 
 #[pg_extern(
@@ -894,18 +888,18 @@ pub fn duration_in_range<'a>(
     schema = "toolkit_experimental"
 )]
 pub fn duration_in_range_int<'a>(
-    aggregate: Option<StateAgg<'a>>,
+    agg: Option<StateAgg<'a>>,
     state: i64,
     start: TimestampTz,
     interval: default!(Option<crate::raw::Interval>, "NULL"),
 ) -> crate::raw::Interval {
-    if let Some(ref aggregate) = aggregate {
-        aggregate.assert_int()
+    if let Some(ref agg) = agg {
+        agg.assert_int()
     };
     let interval = interval.map(|interval| crate::datum_utils::interval_to_ms(&start, &interval));
     let start = start.into();
     duration_in_inner(
-        aggregate.map(StateAgg::as_compact_state_agg),
+        agg.map(StateAgg::as_compact_state_agg),
         Some(StateEntry::from_integer(state)),
         Some((start, interval)),
     )
@@ -953,17 +947,17 @@ fn interpolated_duration_in_inner<'a>(
 }
 #[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
 pub fn interpolated_duration_in<'a>(
-    aggregate: Option<CompactStateAgg<'a>>,
+    agg: Option<CompactStateAgg<'a>>,
     state: String,
     start: TimestampTz,
     interval: crate::raw::Interval,
     prev: Option<CompactStateAgg<'a>>,
 ) -> crate::raw::Interval {
-    if let Some(ref aggregate) = aggregate {
-        aggregate.assert_str()
+    if let Some(ref agg) = agg {
+        agg.assert_str()
     };
     interpolated_duration_in_inner(
-        aggregate,
+        agg,
         Some(MaterializedState::String(state)),
         start,
         interval,
@@ -978,17 +972,17 @@ pub fn interpolated_duration_in<'a>(
     schema = "toolkit_experimental"
 )]
 pub fn interpolated_duration_in_tl<'a>(
-    aggregate: Option<StateAgg<'a>>,
+    agg: Option<StateAgg<'a>>,
     state: String,
     start: TimestampTz,
     interval: crate::raw::Interval,
     prev: Option<StateAgg<'a>>,
 ) -> crate::raw::Interval {
-    if let Some(ref aggregate) = aggregate {
-        aggregate.assert_str()
+    if let Some(ref agg) = agg {
+        agg.assert_str()
     };
     interpolated_duration_in(
-        aggregate.map(StateAgg::as_compact_state_agg),
+        agg.map(StateAgg::as_compact_state_agg),
         state,
         start,
         interval,
@@ -1003,17 +997,17 @@ pub fn interpolated_duration_in_tl<'a>(
     name = "interpolated_duration_in"
 )]
 pub fn interpolated_duration_in_int<'a>(
-    aggregate: Option<CompactStateAgg<'a>>,
+    agg: Option<CompactStateAgg<'a>>,
     state: i64,
     start: TimestampTz,
     interval: crate::raw::Interval,
     prev: Option<CompactStateAgg<'a>>,
 ) -> crate::raw::Interval {
-    if let Some(ref aggregate) = aggregate {
-        aggregate.assert_int()
+    if let Some(ref agg) = agg {
+        agg.assert_int()
     };
     interpolated_duration_in_inner(
-        aggregate,
+        agg,
         Some(MaterializedState::Integer(state)),
         start,
         interval,
@@ -1028,17 +1022,17 @@ pub fn interpolated_duration_in_int<'a>(
     schema = "toolkit_experimental"
 )]
 pub fn interpolated_duration_in_tl_int<'a>(
-    aggregate: Option<StateAgg<'a>>,
+    agg: Option<StateAgg<'a>>,
     state: i64,
     start: TimestampTz,
     interval: crate::raw::Interval,
     prev: Option<StateAgg<'a>>,
 ) -> crate::raw::Interval {
-    if let Some(ref aggregate) = aggregate {
-        aggregate.assert_int()
+    if let Some(ref agg) = agg {
+        agg.assert_int()
     };
     interpolated_duration_in_int(
-        aggregate.map(StateAgg::as_compact_state_agg),
+        agg.map(StateAgg::as_compact_state_agg),
         state,
         start,
         interval,
@@ -1049,6 +1043,8 @@ pub fn interpolated_duration_in_tl_int<'a>(
 fn duration_in_bad_args_inner() -> ! {
     panic!("The start and interval parameters cannot be used for duration_in with a compact state aggregate")
 }
+
+#[allow(unused_variables)] // can't underscore-prefix since argument names are used by pgx
 #[pg_extern(
     immutable,
     parallel_safe,
@@ -1056,13 +1052,14 @@ fn duration_in_bad_args_inner() -> ! {
     schema = "toolkit_experimental"
 )]
 pub fn duration_in_bad_args<'a>(
-    _aggregate: Option<CompactStateAgg<'a>>,
-    _state: String,
-    _start: TimestampTz,
-    _interval: crate::raw::Interval,
+    agg: Option<CompactStateAgg<'a>>,
+    state: String,
+    start: TimestampTz,
+    interval: crate::raw::Interval,
 ) -> crate::raw::Interval {
     duration_in_bad_args_inner()
 }
+#[allow(unused_variables)] // can't underscore-prefix since argument names are used by pgx
 #[pg_extern(
     immutable,
     parallel_safe,
@@ -1070,10 +1067,10 @@ pub fn duration_in_bad_args<'a>(
     schema = "toolkit_experimental"
 )]
 pub fn duration_in_int_bad_args<'a>(
-    _aggregate: Option<CompactStateAgg<'a>>,
-    _state: i64,
-    _start: TimestampTz,
-    _interval: crate::raw::Interval,
+    agg: Option<CompactStateAgg<'a>>,
+    state: i64,
+    start: TimestampTz,
+    interval: crate::raw::Interval,
 ) -> crate::raw::Interval {
     duration_in_bad_args_inner()
 }
@@ -1124,7 +1121,7 @@ pub fn into_int_values<'a>(
     schema = "toolkit_experimental"
 )]
 pub fn into_values_tl<'a>(
-    aggregate: StateAgg<'a>,
+    agg: StateAgg<'a>,
 ) -> TableIterator<
     'a,
     (
@@ -1132,8 +1129,8 @@ pub fn into_values_tl<'a>(
         pgx::name!(duration, crate::raw::Interval),
     ),
 > {
-    aggregate.assert_str();
-    into_values(aggregate.as_compact_state_agg())
+    agg.assert_str();
+    into_values(agg.as_compact_state_agg())
 }
 #[pg_extern(
     immutable,
@@ -1142,7 +1139,7 @@ pub fn into_values_tl<'a>(
     schema = "toolkit_experimental"
 )]
 pub fn into_values_tl_int<'a>(
-    aggregate: StateAgg<'a>,
+    agg: StateAgg<'a>,
 ) -> TableIterator<
     'a,
     (
@@ -1150,8 +1147,8 @@ pub fn into_values_tl_int<'a>(
         pgx::name!(duration, crate::raw::Interval),
     ),
 > {
-    aggregate.assert_int();
-    into_int_values(aggregate.as_compact_state_agg())
+    agg.assert_int();
+    into_int_values(agg.as_compact_state_agg())
 }
 
 fn state_timeline_inner<'a>(
@@ -1243,7 +1240,7 @@ pub fn state_int_timeline<'a>(
 
 #[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
 pub fn interpolated_state_timeline<'a>(
-    aggregate: Option<StateAgg<'a>>,
+    agg: Option<StateAgg<'a>>,
     start: TimestampTz,
     interval: crate::raw::Interval,
     prev: Option<StateAgg<'a>>,
@@ -1255,17 +1252,17 @@ pub fn interpolated_state_timeline<'a>(
         pgx::name!(end_time, TimestampTz),
     ),
 > {
-    if let Some(ref aggregate) = aggregate {
-        aggregate.assert_str()
+    if let Some(ref agg) = agg {
+        agg.assert_str()
     };
-    match aggregate {
+    match agg {
         None => pgx::error!(
             "when interpolating data between grouped data, all groups must contain some data"
         ),
-        Some(aggregate) => {
+        Some(agg) => {
             let interval = crate::datum_utils::interval_to_ms(&start, &interval);
             TableIterator::new(
-                state_timeline_inner(aggregate.as_compact_state_agg().interpolate(
+                state_timeline_inner(agg.as_compact_state_agg().interpolate(
                     start.into(),
                     interval,
                     prev.map(StateAgg::as_compact_state_agg),
@@ -1278,7 +1275,7 @@ pub fn interpolated_state_timeline<'a>(
 }
 #[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
 pub fn interpolated_int_state_timeline<'a>(
-    aggregate: Option<StateAgg<'a>>,
+    agg: Option<StateAgg<'a>>,
     start: TimestampTz,
     interval: crate::raw::Interval,
     prev: Option<StateAgg<'a>>,
@@ -1290,17 +1287,17 @@ pub fn interpolated_int_state_timeline<'a>(
         pgx::name!(end_time, TimestampTz),
     ),
 > {
-    if let Some(ref aggregate) = aggregate {
-        aggregate.assert_int()
+    if let Some(ref agg) = agg {
+        agg.assert_int()
     };
-    match aggregate {
+    match agg {
         None => pgx::error!(
             "when interpolating data between grouped data, all groups must contain some data"
         ),
-        Some(aggregate) => {
+        Some(agg) => {
             let interval = crate::datum_utils::interval_to_ms(&start, &interval);
             TableIterator::new(
-                state_int_timeline_inner(aggregate.as_compact_state_agg().interpolate(
+                state_int_timeline_inner(agg.as_compact_state_agg().interpolate(
                     start.into(),
                     interval,
                     prev.map(StateAgg::as_compact_state_agg),
@@ -1418,7 +1415,7 @@ fn interpolated_state_periods_inner<'a>(
 }
 #[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
 pub fn interpolated_state_periods<'a>(
-    aggregate: Option<StateAgg<'a>>,
+    agg: Option<StateAgg<'a>>,
     state: String,
     start: TimestampTz,
     interval: crate::raw::Interval,
@@ -1430,16 +1427,10 @@ pub fn interpolated_state_periods<'a>(
         pgx::name!(end_time, TimestampTz),
     ),
 > {
-    if let Some(ref aggregate) = aggregate {
-        aggregate.assert_str()
+    if let Some(ref agg) = agg {
+        agg.assert_str()
     };
-    interpolated_state_periods_inner(
-        aggregate,
-        MaterializedState::String(state),
-        start,
-        interval,
-        prev,
-    )
+    interpolated_state_periods_inner(agg, MaterializedState::String(state), start, interval, prev)
 }
 #[pg_extern(
     immutable,
@@ -1448,7 +1439,7 @@ pub fn interpolated_state_periods<'a>(
     name = "interpolated_state_periods"
 )]
 pub fn interpolated_state_periods_int<'a>(
-    aggregate: Option<StateAgg<'a>>,
+    agg: Option<StateAgg<'a>>,
     state: i64,
     start: TimestampTz,
     interval: crate::raw::Interval,
@@ -1460,11 +1451,11 @@ pub fn interpolated_state_periods_int<'a>(
         pgx::name!(end_time, TimestampTz),
     ),
 > {
-    if let Some(ref aggregate) = aggregate {
-        aggregate.assert_int()
+    if let Some(ref agg) = agg {
+        agg.assert_int()
     };
     interpolated_state_periods_inner(
-        aggregate,
+        agg,
         MaterializedState::Integer(state),
         start,
         interval,


### PR DESCRIPTION
- `interpolated_duration_in`/`duration_in`/`interpolated_state_periods`/`state_periods` have the first two arguments swapped: now the aggregate is first and the state is second
- `into_values`/`into_int_values` now returns a table with intervals instead of microseconds