### PR TITLE
Build CI image on PRs modifying dependencies

### DIFF
--- a/.github/workflows/ci_image_build.yml
+++ b/.github/workflows/ci_image_build.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'docker/ci/**'
       - '.github/workflows/ci_image_build.yml'
+      - 'tools/dependencies.sh'
   workflow_dispatch:
     inputs:
       tag-base:


### PR DESCRIPTION
Runs the CI image building action on PRs that modify `tools/dependencies.sh`, since that file impacts the Docker image. We already do this for the files in `docker/ci` and the build action itself.