### PR TITLE
Fix image build failures on Rocky Linux

### DIFF
--- a/docker/ci/setup.sh
+++ b/docker/ci/setup.sh
@@ -78,6 +78,8 @@ if $privileged; then
                     ;;
 
                 8)
+                    yum -qy install dnf-plugins-core
+                    dnf config-manager --enable powertools
                     dnf -qy module disable postgresql
                     # fpm suddenly requires newer public_suffix that requires newer ruby
                     # https://github.com/jordansissel/fpm/issues/1923 ¯\_(ツ)_/¯
@@ -86,6 +88,8 @@ if $privileged; then
                     ;;
 
                 9)
+                    yum -qy install dnf-plugins-core
+                    dnf config-manager --enable crb
                     dnf -qy install ruby-devel rubygems
                     ;;
 


### PR DESCRIPTION
Adds the `powertools`/`crb` repository to the Enterprise Linux images so that PostgreSQL can be installed again.

It seems that the official PostgreSQL RPMs have dependencies in the CRB (PowerTools before RL9) repository. This PR enables that repository before trying to install anything. With this PR, the CI image for RL8/9 [now builds successfully again](https://github.com/timescale/release-build-scripts/actions/runs/4185934031).

Fixes #711.