### PR TITLE
Tell bors about Postgres 15 tests

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -3,6 +3,7 @@ status = [
     "Test Postgres (12)",
     "Test Postgres (13)",
     "Test Postgres (14)",
+    "Test Postgres (15)",
 ]
 delete-merged-branches = true
 timeout_sec = 3600 # 60 min


### PR DESCRIPTION
Makes it so bors ensures PG15 tests pass before merging PRs.