### PR TITLE
Fix errors in state_agg rollup

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ This changelog should be updated as part of a PR if the work is worth noting (mo
 #### New experimental features
 
 #### Bug fixes
+- [#715](https://github.com/timescale/timescaledb-toolkit/pull/715): Fix out-of-bounds indexing error in `state_agg` rollup
 
 #### Other notable changes
 

--- a/extension/src/state_aggregate.rs
+++ b/extension/src/state_aggregate.rs
@@ -104,13 +104,20 @@ impl StateEntry {
         if self.a == i64::MAX {
             MaterializedState::Integer(self.b)
         } else {
-            MaterializedState::String(states[self.a as usize..self.b as usize].to_string())
+            MaterializedState::String(
+                states
+                    .get(self.a as usize..self.b as usize)
+                    .expect("tried to materialize out-of-bounds state")
+                    .to_string(),
+            )
         }
     }
 
     fn as_str(self, states: &str) -> &str {
         assert!(self.a != i64::MAX, "Tried to get non-string state");
-        &states[self.a as usize..self.b as usize]
+        states
+            .get(self.a as usize..self.b as usize)
+            .expect("tried to stringify out-of-bounds state")
     }
 
     fn as_integer(self) -> i64 {

--- a/extension/src/state_aggregate/rollup.rs
+++ b/extension/src/state_aggregate/rollup.rs
@@ -435,4 +435,72 @@ mod tests {
 
         r2.merge(r1);
     }
+
+    #[test]
+    fn merges_compact_aggs_correctly() {
+        let s1 = OwnedCompactStateAgg {
+            durations: vec![
+                DurationInState {
+                    duration: 500,
+                    state: StateEntry::from_integer(555_2),
+                },
+                DurationInState {
+                    duration: 400,
+                    state: StateEntry::from_integer(555_1),
+                },
+            ],
+            combined_durations: vec![],
+            first_time: 100,
+            last_time: 1000,
+            first_state: 1,
+            last_state: 0,
+            states: vec![],
+            compact: true,
+            integer_states: true,
+        };
+        let s2 = OwnedCompactStateAgg {
+            durations: vec![
+                DurationInState {
+                    duration: 500,
+                    state: StateEntry::from_integer(555_2),
+                },
+                DurationInState {
+                    duration: 400,
+                    state: StateEntry::from_integer(555_1),
+                },
+            ],
+            combined_durations: vec![],
+            first_time: 1000 + 12345,
+            last_time: 1900 + 12345,
+            first_state: 1,
+            last_state: 0,
+            states: vec![],
+            compact: true,
+            integer_states: true,
+        };
+        let expected = OwnedCompactStateAgg {
+            durations: vec![
+                DurationInState {
+                    duration: 500 * 2 + 12345,
+                    state: StateEntry::from_integer(555_2),
+                },
+                DurationInState {
+                    duration: 400 * 2,
+                    state: StateEntry::from_integer(555_1),
+                },
+            ],
+            combined_durations: vec![],
+            first_time: 100,
+            last_time: 1900 + 12345,
+            first_state: 1,
+            last_state: 0,
+            states: vec![],
+            compact: true,
+            integer_states: true,
+        };
+        let merged = s1.clone().merge(s2.clone());
+        assert_eq!(merged, expected);
+        let merged = s2.merge(s1);
+        assert_eq!(merged, expected);
+    }
 }

--- a/extension/src/state_aggregate/rollup.rs
+++ b/extension/src/state_aggregate/rollup.rs
@@ -91,7 +91,11 @@ impl OwnedCompactStateAgg {
 
         assert!(
             earlier.last_time <= later.first_time,
-            "can't merge overlapping aggregates (earlier={earlier:?}, later={later:?})"
+            "can't merge overlapping aggregates (earlier={}-{}, later={}-{})",
+            earlier.first_time,
+            earlier.last_time,
+            later.first_time,
+            later.last_time,
         );
         assert_ne!(
             later.durations.len(),


### PR DESCRIPTION
This PR should fix out-of-bounds indexing in `rollup`:
- before, `last_state` in the merged aggregate was computed incorrectly; it is now determined correctly
- merging aggregates now sorts them first

It also improves the various error messages that could arise when using rollup.