### PR TITLE
Use github-actions[bot] for automated issues and PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,4 +39,5 @@ jobs:
     - name: Run tools/release
       env:
         GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB_PACKAGE }}
+        ACTIONS_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: su postgres -c 'tools/release ${{ inputs.dry-run }} -version ${{ inputs.version }} ${{ inputs.commit }}' 2>&1

--- a/tools/release
+++ b/tools/release
@@ -325,6 +325,10 @@ set +e
 if $push; then
     # 7d. Push to $POST_REL_BRANCH branch.
     $nop git push origin HEAD:$POST_REL_BRANCH
+
+    # Run these next steps as github-actions[bot]
+    GITHUB_TOKEN="$ACTIONS_GITHUB_TOKEN"
+
     $nop gh pr create -R timescale/timescaledb-toolkit -B $MAIN_BRANCH --fill -H $POST_REL_BRANCH
 
     # 8. File issue for release tasks that are not yet automated.


### PR DESCRIPTION
Makes it so automated issues and PRs from the release script come from github-actions[bot] instead of an actual user account, to make it clear that those issues and PRs were not made by a human.