### PR TITLE
Fix a bug in the heartbeat agg rollup code

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@ This changelog should be updated as part of a PR if the work is worth noting (mo
 #### New experimental features
 
 #### Bug fixes
+- [#733](https://github.com/timescale/timescaledb-toolkit/pull/733): Fix a bug when rolling up overlapping heartbeat_aggs
 
 #### Other notable changes
 


### PR DESCRIPTION
This change prevents us from using the optimized path for rolling up adjacent heartbeat_aggs if the aggregates have overlapping points.

Fixes #731