### PR TITLE
Fix right boundary when interpolating 'locf' TWA

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@ This changelog should be updated as part of a PR if the work is worth noting (mo
 
 #### Bug fixes
 - [#733](https://github.com/timescale/timescaledb-toolkit/pull/733): Fix a bug when rolling up overlapping heartbeat_aggs
+- [#740](https://github.com/timescale/timescaledb-toolkit/pull/740): When interpolating an 'locf' time weighted average, extend last point to interpolation boundary
 
 #### Other notable changes
 

--- a/extension/src/time_weighted_average/accessors.rs
+++ b/extension/src/time_weighted_average/accessors.rs
@@ -26,8 +26,8 @@ ron_inout_funcs!(TimeWeightInterpolatedAverageAccessor);
 fn time_weight_interpolated_average_accessor<'a>(
     start: crate::raw::TimestampTz,
     duration: crate::raw::Interval,
-    prev: Option<TimeWeightSummary<'a>>,
-    next: Option<TimeWeightSummary<'a>>,
+    prev: default!(Option<TimeWeightSummary<'a>>, "NULL"),
+    next: default!(Option<TimeWeightSummary<'a>>, "NULL"),
 ) -> TimeWeightInterpolatedAverageAccessor<'static> {
     fn empty_summary<'b>() -> Option<TimeWeightSummary<'b>> {
         Some(unsafe {
@@ -75,8 +75,8 @@ ron_inout_funcs!(TimeWeightInterpolatedIntegralAccessor);
 fn time_weight_interpolated_integral_accessor<'a>(
     start: crate::raw::TimestampTz,
     interval: crate::raw::Interval,
-    prev: Option<TimeWeightSummary<'a>>,
-    next: Option<TimeWeightSummary<'a>>,
+    prev: default!(Option<TimeWeightSummary<'a>>, "NULL"),
+    next: default!(Option<TimeWeightSummary<'a>>, "NULL"),
     unit: default!(String, "'second'"),
 ) -> TimeWeightInterpolatedIntegralAccessor<'static> {
     fn empty_summary<'b>() -> Option<TimeWeightSummary<'b>> {


### PR DESCRIPTION
This change will make it so a time weighted average with the locf method will include the range between the last data point and the interpolation boundary, even when there is no next aggregate to interpolate.

Note that the behavior here might not be entirely intuitive, so we need to make sure we update our docs to describe our exact behavior.

Fixes #732 