### PR TITLE
Ensure PostgreSQL 16 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
 
     - name: Run doc tests
       # depends on TSDB, which requires PG >=13
-      if: ${{ matrix.pgversion >= 13 && (matrix.pgversion >= 13 && (matrix.pgversion <= 16 || ((github.event_name == 'schedule' && github.event.schedule == '0 8 * * 1-4') || inputs.tsdb-commit != ''))) }}
+      if: ${{ matrix.pgversion >= 13 && (matrix.pgversion >= 13 && (matrix.pgversion <= 15 || ((github.event_name == 'schedule' && github.event.schedule == '0 8 * * 1-4') || inputs.tsdb-commit != ''))) }}
       run: su postgres -c 'sh tools/build -pg${{ matrix.pgversion }} test-doc 2>&1'
 
     - name: Run binary update tests (deb)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,43 +39,47 @@ jobs:
       fail-fast: false
       max-parallel: 12
       matrix:
-        pgversion: [12, 13, 14, 15]
-        container: "${{ \
-          ( \
-            inputs.all-platforms || \
-            ( \
-              github.event_name == 'schedule' && \
-              github.event.schedule == '0 6 * * 1-4' \
-            ) \
-          ) && \
-          fromJSON('[ \
-            { \"os\": \"debian\", \"version\": \"10\", \"image\": \"debian-10-amd64\" }, \
-            { \"os\": \"debian\", \"version\": \"11\", \"image\": \"debian-11-amd64\" }, \
-            { \"os\": \"rockylinux\", \"version\": \"8\", \"image\": \"rockylinux-8-x86_64\" }, \
-            { \"os\": \"rockylinux\", \"version\": \"9\", \"image\": \"rockylinux-9-x86_64\" }, \
-            { \"os\": \"centos\", \"version\": \"7\", \"image\": \"centos-7-x86_64\" }, \
-            { \"os\": \"ubuntu\", \"version\": \"20.04\", \"image\": \"ubuntu-20.04-amd64\" }, \
-            { \"os\": \"ubuntu\", \"version\": \"22.04\", \"image\": \"ubuntu-22.04-amd64\" } \
-          ]') \
-          || fromJSON('[ \
-            { \"os\": \"debian\", \"version\": \"11\", \"image\": \"debian-11-amd64\" }, \
-            { \"os\": \"rockylinux\", \"version\": \"9\", \"image\": \"rockylinux-9-x86_64\" }, \
-            { \"os\": \"centos\", \"version\": \"7\", \"image\": \"centos-7-x86_64\" } \
-          ]') \
-        }}"
-        # Building TSDB in CI is only supported on Debian/Ubuntu
-        exclude: "${{ \
-          ( \
-            (github.event_name == 'schedule' && github.event.schedule == '0 8 * * 1-4') \
-            || inputs.tsdb-commit != '' \
-          ) && \
-            fromJSON('[ \
-              {\"container\": {\"os\": \"centos\"}}, \
-              {\"container\": {\"os\": \"rockylinux\"}} \
-            ]') || \
-            fromJSON('[]') \
-        }}"
+        pgversion: [12, 13, 14, 15, 16]
+        container:
+        - os: rockylinux
+          version: "9"
+          image: rockylinux-9-x86_64
+          # Building TSDB in CI is only supported on Debian/Ubuntu
+          skip: ${{ inputs.tsdb-commit != '' }}
+          schedule: ${{ !(github.event_name == 'schedule' && github.event.schedule == '0 8 * * 1-4') }}
+        - os: centos
+          version: "7"
+          image: centos-7-x86_64
+          # Building TSDB in CI is only supported on Debian/Ubuntu
+          skip: ${{ inputs.tsdb-commit != '' }}
+          schedule: ${{ !(github.event_name == 'schedule' && github.event.schedule == '0 8 * * 1-4') }}
+        - os: debian
+          version: "11"
+          image: debian-11-amd64
+          schedule: true
+        - os: debian
+          version: "10"
+          image: debian-10-amd64
+          schedule: ${{ inputs.all-platforms || ( github.event_name == 'schedule' && github.event.schedule == '0 6 * * 1-4' ) }}
+        - os: ubuntu
+          version: "20.04"
+          image: ubuntu-20.04-amd64
+          schedule: ${{ inputs.all-platforms || ( github.event_name == 'schedule' && github.event.schedule == '0 6 * * 1-4' ) }}
+        - os: ubuntu
+          version: "22.04"
+          image: ubuntu-22.04-amd64
+          schedule: ${{ inputs.all-platforms || ( github.event_name == 'schedule' && github.event.schedule == '0 6 * * 1-4' ) }}
 
+        exclude:
+        - container:
+            skip: true
+        - container:
+            schedule: false
+        # CentOS 7 does not have PostgreSQL 16 packages
+        - container:
+            os: centos
+            version: "7"
+          pgversion: 16
     env:
       # TODO Why?  Cargo default is to pass `-C incremental` to rustc; why don't we want that?
       #   https://doc.rust-lang.org/rustc/codegen-options/index.html#incremental

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,14 +137,17 @@ jobs:
         su postgres -c 'sh tools/build -pg${{ matrix.pgversion }} test-extension 2>&1'
 
     - name: Run doc tests
+      # depends on TSDB, which requires PG >=13
+      if: ${{ matrix.pgversion >= 13 && (matrix.pgversion >= 13 && (matrix.pgversion <= 16 || ((github.event_name == 'schedule' && github.event.schedule == '0 8 * * 1-4') || inputs.tsdb-commit != ''))) }}
       run: su postgres -c 'sh tools/build -pg${{ matrix.pgversion }} test-doc 2>&1'
 
     - name: Run binary update tests (deb)
-      if: ${{ matrix.container.os == 'debian' || matrix.container.os == 'ubuntu' }}
+      # depends on TSDB, which requires PG >=13
+      if: ${{ (matrix.container.os == 'debian' || matrix.container.os == 'ubuntu') && (matrix.pgversion >= 13 && (matrix.pgversion <= 16 || ((github.event_name == 'schedule' && github.event.schedule == '0 8 * * 1-4') || inputs.tsdb-commit != ''))) }}
       run: |
         su postgres -c 'OS_NAME=${{ matrix.container.os }} OS_VERSION=${{ matrix.container.version }} tools/testbin -version no -bindir / -pgversions ${{ matrix.pgversion }} ci 2>&1'    
     - name: Run binary update tests (EL)
-      if: ${{ (matrix.container.os == 'rockylinux' || matrix.container.os == 'centos') && matrix.container.version != '9' }}
+      if: ${{ (matrix.container.os == 'rockylinux' || matrix.container.os == 'centos') && matrix.container.version != '9' && (matrix.pgversion >= 13 && (matrix.pgversion <= 16 || ((github.event_name == 'schedule' && github.event.schedule == '0 8 * * 1-4') || inputs.tsdb-commit != ''))) }}
       run: |
         su postgres -c 'OS_NAME=${{ matrix.container.os }} OS_VERSION=${{ matrix.container.version }} tools/testbin -version no -bindir / -pgversions ${{ matrix.pgversion }} rpm_ci 2>&1'
 

--- a/Readme.md
+++ b/Readme.md
@@ -96,7 +96,7 @@ hop on the [Discussions forum](https://github.com/timescale/timescaledb-toolkit/
 
 See above for prerequisites and installation instructions.
 
-You can run tests against a postgres version `pg12`, `pg13`, `pg14`, or `pg15` using
+You can run tests against a postgres version `pg12`, `pg13`, `pg14`, `pg15` or `pg16` using
 
 ```
 cargo pgrx test ${postgres_version}

--- a/docker/ci/setup.sh
+++ b/docker/ci/setup.sh
@@ -133,10 +133,13 @@ EOF
             for pg in $PG_VERSIONS; do
                 yum -q -y install \
                     postgresql$pg-devel \
-                    postgresql$pg-server \
-                    timescaledb-2-postgresql-$pg
+                    postgresql$pg-server
                 # We install as user postgres, so that needs write access to these.
                 chown $BUILDER_USERNAME $PG_BASE$pg/lib $PG_BASE$pg/share/extension
+            done;
+
+            for pg in $TSDB_PG_VERSIONS; do
+                yum -q -y install timescaledb-2-postgresql-$pg
             done
 
             gem install fpm -v $FPM_VERSION -N
@@ -198,10 +201,13 @@ EOF
             apt-get -qq install \
                     postgresql-$pg \
                     postgresql-server-dev-$pg
-            # timescaledb packages Recommend toolkit, which we don't want here.
-            apt-get -qq install --no-install-recommends timescaledb-2-postgresql-$pg
             # We install as user postgres, so that needs write access to these.
             chown $BUILDER_USERNAME $PG_BASE$pg/lib /usr/share/postgresql/$pg/extension
+        done
+
+        for pg in $TSDB_PG_VERSIONS; do
+            # timescaledb packages Recommend toolkit, which we don't want here.
+            apt-get -qq install --no-install-recommends timescaledb-2-postgresql-$pg
         done
 
         # Ubuntu is the only system we want an image for that sticks an extra
@@ -244,7 +250,7 @@ for pg in $PG_VERSIONS; do
 done
 cargo pgrx init $init_flags
 ## Initialize pgrx-managed databases so we can add the timescaledb load.
-for pg in $PG_VERSIONS; do
+for pg in $TSDB_PG_VERSIONS; do
     echo "shared_preload_libraries = 'timescaledb'" >> ~/.pgrx/data-$pg/postgresql.conf
 done
 

--- a/docs/counter_agg.md
+++ b/docs/counter_agg.md
@@ -79,7 +79,7 @@ Now we can make our continuous aggregate:
 
 ```SQL ,ignore
 CREATE MATERIALIZED VIEW foo_15
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT measure_id,
     time_bucket('15 min'::interval, ts) as bucket,
     counter_agg(ts, val, bounds => time_bucket_range('15 min'::interval, ts))

--- a/docs/percentile_approximation.md
+++ b/docs/percentile_approximation.md
@@ -200,7 +200,7 @@ Let's do this with our example, we can't use `percentile_disc` anymore as ordere
 
 ```SQL , non-transactional, ignore-output
 CREATE MATERIALIZED VIEW response_times_hourly
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT
     time_bucket('1 h'::interval, ts) as bucket,
     api_id,
@@ -379,7 +379,7 @@ They are often used to create [continuous aggregates]() after which we can use m
 
 ```SQL ,ignore
 CREATE MATERIALIZED VIEW foo_hourly
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT
     time_bucket('1 h'::interval, ts) as bucket,
     percentile_agg(value) as pct_agg

--- a/docs/state_agg.md
+++ b/docs/state_agg.md
@@ -749,7 +749,7 @@ VALUES
 
 ```SQL ,non-transactional,ignore-output
 CREATE MATERIALIZED VIEW sa
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1 minute'::interval, ts) AS bucket,
   id,
   state_agg(ts, status) AS agg

--- a/docs/tdigest.md
+++ b/docs/tdigest.md
@@ -108,7 +108,7 @@ Next a materialized view with the timescaledb.continuous property is added.  Thi
 including the tdigest in this case, up to date as data is added to the table.
 ```SQL ,non-transactional,ignore-output
 CREATE MATERIALIZED VIEW weekly_sketch
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT
     time_bucket('7 day'::interval, time) as week,
     tdigest(100, value) as digest

--- a/docs/test_caggs.md
+++ b/docs/test_caggs.md
@@ -17,7 +17,7 @@ SELECT create_hypertable('test', 'time');
 ## Setup continuous aggs
 ```SQL ,non-transactional,ignore-output
 CREATE MATERIALIZED VIEW weekly_aggs
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT
     time_bucket('7 day'::interval, time) as week,
     hyperloglog(64, value1) as hll,

--- a/docs/test_candlestick_agg.md
+++ b/docs/test_candlestick_agg.md
@@ -15,7 +15,7 @@ SELECT create_hypertable('stocks_real_time','time');
 ## Setup Continuous Aggs
 ```SQL,non-transactional,ignore-output
 CREATE MATERIALIZED VIEW cs
-WITH (timescaledb.continuous) AS
+WITH (timescaledb.continuous, timescaledb.materialized_only=false) AS
 SELECT time_bucket('1 minute'::interval, "time") AS ts,
   symbol,
   candlestick_agg("time", price, day_volume) AS candlestick

--- a/docs/time_weighted_average.md
+++ b/docs/time_weighted_average.md
@@ -102,7 +102,7 @@ Now we can make our continuous aggregate:
 
 ```SQL ,non-transactional, ignore-output
 CREATE MATERIALIZED VIEW foo_5
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT measure_id,
     time_bucket('5 min'::interval, ts) as bucket,
     time_weight('LOCF', ts, val)

--- a/docs/two-step_aggregation.md
+++ b/docs/two-step_aggregation.md
@@ -127,7 +127,7 @@ Two-step aggregates expose the internal, re-aggregateable form to the user so th
 
 ```SQL , ignore
 CREATE MATERIALIZED VIEW foo_15
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT id,
     time_bucket('15 min'::interval, ts) as bucket,
     sum(val),

--- a/docs/uddsketch.md
+++ b/docs/uddsketch.md
@@ -126,7 +126,7 @@ SELECT create_hypertable('test', 'time');
 Now we'll create a continuous aggregate which will group all the points for each week into a UddSketch:
 ```SQL ,non-transactional,ignore-output
 CREATE MATERIALIZED VIEW weekly_sketch
-WITH (timescaledb.continuous)
+WITH (timescaledb.continuous, timescaledb.materialized_only=false)
 AS SELECT
     time_bucket('7 day'::interval, time) as week,
     uddsketch(100, 0.005, value) as sketch

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [features]
-default = ["pg14"]
+default = ["pg15"]
 pg12 = ["pgrx/pg12", "pgrx-tests/pg12"]
 pg13 = ["pgrx/pg13", "pgrx-tests/pg13"]
 pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
 pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
 pg_test = ["approx"]
 
 [dependencies]

--- a/tools/build
+++ b/tools/build
@@ -20,7 +20,7 @@ usage() {
 }
 
 require_pg_version() {
-    [ -n "$pg_version" ] || die 'specify one of -pg12 | -pg13 | -pg14 | -pg15'
+    [ -n "$pg_version" ] || die 'specify one of -pg12 | -pg13 | -pg14 | -pg15 | -pg16'
 }
 
 find_pg_config() {

--- a/tools/build
+++ b/tools/build
@@ -116,7 +116,7 @@ while [ $# -gt 0 ]; do
         test-doc)
             find_profile
             require_pg_version
-            $nop cargo pgrx start --package timescaledb_toolkit $pg
+            $nop cargo pgrx start --package timescaledb_toolkit $pg || (cat /home/postgres/.pgrx/${pg_version}.log; false)
             $nop cargo run --profile $profile -p sql-doctester -- \
                  -h localhost \
                  -p $pg_port \
@@ -130,7 +130,7 @@ while [ $# -gt 0 ]; do
             find_pg_config
             require_cargo_pgrx
             require_cargo_pgrx_old
-            $nop cargo pgrx start --package timescaledb_toolkit $pg
+            $nop cargo pgrx start --package timescaledb_toolkit $pg || (cat /home/postgres/.pgrx/${pg_version}.log; false)
             $nop cargo run --profile $profile --manifest-path tools/update-tester/Cargo.toml -- full-update-test-source \
                  -h localhost \
                  -p $pg_port \

--- a/tools/dependencies.sh
+++ b/tools/dependencies.sh
@@ -7,9 +7,9 @@
 # All our automation scripts read this, so at least we're not duplicating this
 # information across all those.
 
-PG_VERSIONS='12 13 14 15'
-# TODO: remove this once TimescaleDB supports PostgreSQL 15: issue #648
-TSDB_PG_VERSIONS='12 13 14'
+PG_VERSIONS='12 13 14 15 16'
+# TODO: extend this with 16 this once TimescaleDB supports PostgreSQL 16: issue #5752
+TSDB_PG_VERSIONS='12 13 14 15'
 
 CARGO_EDIT=0.11.2
 

--- a/tools/testbin
+++ b/tools/testbin
@@ -103,8 +103,9 @@ skip_from_version() {
 # - FROM_VERSION
 # - PG_VERSION
 skip_from_version_pg_version() {
-    # skip versions without PG15 binaries
+    # skip versions without binaries for this PostgreSQL version
     [ $PG_VERSION -gt 14 ] && [ `cmp_version $FROM_VERSION` -lt 011301 ] && return
+    [ $PG_VERSION -gt 15 ] && [ `cmp_version $FROM_VERSION` -lt 011801 ] && return
 }
 
 # Requires:


### PR DESCRIPTION
DateTimeParseError: PostgreSQL source code documents that we can pass null pointers here:

 > extra can be NULL if not needed for the particular dterr value.
 > [...]
 > If escontext points to an ErrorSaveContext node, that is filled instead
 > of throwing an error

DecodeDateTime however does not allow us to pass a null pointer, reading the source code, it is expected that extra is not null. Therefore, in order for us to get this thing to compile, we create an empty DateTimeErrorExtra, which gets passed along.