### PR TITLE
Skip PostgreSQL 12 by default for CICD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       max-parallel: 12
       matrix:
-        pgversion: [12, 13, 14, 15, 16]
+        pgversion: [13, 14, 15, 16]
         container:
         - os: rockylinux
           version: "9"
@@ -80,6 +80,17 @@ jobs:
             os: centos
             version: "7"
           pgversion: 16
+        # TimescaleDB as of 2.12.0 no longer supports PostgreSQL 12.
+        # To allow us to do run CI against PostgreSQL 12, we therefore explicitly
+        # remove all CI's, except if we are run against the latest supported TimescaleDB
+        # version for PostgreSQL 12, which is 2.11.2
+        include:
+        - pgversion: 12
+          container:
+            image: debian-11-amd64
+            os: debian
+            version: "11" 
+          tsdb_commit: 2.11.2
     env:
       # TODO Why?  Cargo default is to pass `-C incremental` to rustc; why don't we want that?
       #   https://doc.rust-lang.org/rustc/codegen-options/index.html#incremental
@@ -113,7 +124,7 @@ jobs:
 
     - name: Build and install TimescaleDB
       if: ${{ (github.event_name == 'schedule' && github.event.schedule == '0 8 * * 1-4') || inputs.tsdb-commit != '' }}
-      run: ./tools/install-timescaledb '${{ matrix.pgversion }}' '${{ inputs.tsdb-repo || 'https://github.com/timescale/timescaledb.git' }}' '${{ inputs.tsdb-commit == '' && 'main' || inputs.tsdb-commit }}'
+      run: ./tools/install-timescaledb '${{ matrix.pgversion }}' '${{ matrix.tsdb_commit || inputs.tsdb-repo || 'https://github.com/timescale/timescaledb.git' }}' '${{ inputs.tsdb-commit == '' && 'main' || matrix.tsdb_commit || inputs.tsdb-commit }}'
 
     # TODO After the container image contains a primed target dir, is this still worth it?
     #   Only possible advantage is this one is per-pg-version but what's the impact?

--- a/docker/ci/setup.sh
+++ b/docker/ci/setup.sh
@@ -54,6 +54,8 @@ if $privileged; then
         centos | rockylinux)
             case $OS_VERSION in
                 7)
+                    export PG_VERSIONS="13 14 15"
+                    export TSDB_PG_VERSIONS="13 14 15"
                     # Postgresql packages require both
                     # - llvm-toolset-7-clang from centos-release-scl-rh
                     # - llvm5.0-devel from epel-release

--- a/docker/ci/setup.sh
+++ b/docker/ci/setup.sh
@@ -147,6 +147,11 @@ EOF
 
         # Debian family
         debian | ubuntu)
+            # TimescaleDB does not have packages for Debian 12
+            if [[ $OS_VERSION -ge 12 ]]; then
+                export TSDB_PG_VERSIONS="13 14 15"
+            fi
+
             # Image comes in with no package lists so we have to start with this.
             apt-get -qq update
 


### PR DESCRIPTION
TimescaleDB 2.12.0 does not support PostgreSQL 12 anymore. This currently causes our CI to fail. To still be able to test PostgreSQL 12, we will run tests against TimescaleDB 2.11.2 for PostgreSQL 12, and for Debian only.

https://docs.timescale.com/about/latest/release-notes/#timescaledb-2120-on-2023-09-27