### PR TITLE
Bugfix: make space saving aggregate serialization strict

### DIFF
--- a/extension/src/frequency.rs
+++ b/extension/src/frequency.rs
@@ -956,7 +956,7 @@ fn space_saving_text_final(
     state.map(SpaceSavingTextAggregate::from)
 }
 
-#[pg_extern(immutable, parallel_safe)]
+#[pg_extern(immutable, parallel_safe, strict)]
 fn space_saving_serialize(state: Internal) -> bytea {
     let state: Inner<SpaceSavingTransState> = unsafe { state.to_inner().unwrap() };
     crate::do_serialize!(state)


### PR DESCRIPTION
This pull request follows in the footsteps of https://github.com/timescale/timescaledb-toolkit/pull/351 in making space saving aggregate serialization strict for frequency aggregates.

Motivation: I'm running into the following error when trying to refresh a continuous aggregate manually.

```
ERROR:  XX000: called `Option::unwrap()` on a `None` value
CONTEXT:  SQL statement “INSERT INTO _timescaledb_internal._materialized_hypertable_86 SELECT * FROM _timescaledb_internal._partial_view_86 AS I WHERE I.bucket >= $1 AND I.bucket < $2 ;”
LOCATION:  frequency.rs:961
```

This appears to be [a known problem](https://github.com/timescale/timescaledb-toolkit/issues/350) when the source table has empty partitions, and I would guess that there are other aggregates that still need to be made strict for serialization.