### PR TITLE
Fix rustc and clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,6 @@ jobs:
           # Building TSDB in CI is only supported on Debian/Ubuntu
           skip: ${{ inputs.tsdb-commit != '' }}
           schedule: ${{ !(github.event_name == 'schedule' && github.event.schedule == '0 8 * * 1-4') }}
-        - os: centos
-          version: "7"
-          image: centos-7-x86_64
-          # Building TSDB in CI is only supported on Debian/Ubuntu
-          skip: ${{ inputs.tsdb-commit != '' }}
-          schedule: ${{ !(github.event_name == 'schedule' && github.event.schedule == '0 8 * * 1-4') }}
         - os: debian
           version: "11"
           image: debian-11-amd64
@@ -74,11 +68,6 @@ jobs:
             skip: true
         - container:
             schedule: false
-        # CentOS 7 does not have PostgreSQL 16 packages
-        - container:
-            os: centos
-            version: "7"
-          pgversion: 16
         include:
         # TimescaleDB as of 2.12.0 no longer supports PostgreSQL 12.
         # To allow us to do run CI against PostgreSQL 12, we therefore explicitly
@@ -167,7 +156,7 @@ jobs:
       run: |
         su postgres -c 'OS_NAME=${{ matrix.container.os }} OS_VERSION=${{ matrix.container.version }} tools/testbin -version no -bindir / -pgversions ${{ matrix.pgversion }} ci 2>&1'    
     - name: Run binary update tests (EL)
-      if: ${{ (matrix.container.os == 'rockylinux' || matrix.container.os == 'centos') && matrix.container.version != '9' && (matrix.pgversion >= 13 && (matrix.pgversion <= 16 || ((github.event_name == 'schedule' && github.event.schedule == '0 8 * * 1-4') || inputs.tsdb-commit != ''))) }}
+      if: ${{ (matrix.container.os == 'rockylinux') && matrix.container.version != '9' && (matrix.pgversion >= 13 && (matrix.pgversion <= 16 || ((github.event_name == 'schedule' && github.event.schedule == '0 8 * * 1-4') || inputs.tsdb-commit != ''))) }}
       run: |
         su postgres -c 'OS_NAME=${{ matrix.container.os }} OS_VERSION=${{ matrix.container.version }} tools/testbin -version no -bindir / -pgversions ${{ matrix.pgversion }} rpm_ci 2>&1'
 

--- a/crates/aggregate_builder/Cargo.toml
+++ b/crates/aggregate_builder/Cargo.toml
@@ -10,3 +10,6 @@ proc-macro = true
 syn = {version="1.0", features=["extra-traits", "visit", "visit-mut", "full"]}
 quote = "1.0"
 proc-macro2 = "1.0"
+
+[features]
+print-generated = []

--- a/crates/hyperloglogplusplus/src/lib.rs
+++ b/crates/hyperloglogplusplus/src/lib.rs
@@ -5,7 +5,7 @@ extern crate quickcheck;
 extern crate quickcheck_macros;
 
 use std::{
-    hash::{BuildHasher, Hash, Hasher},
+    hash::{BuildHasher, Hash},
     marker::PhantomData,
 };
 
@@ -131,9 +131,7 @@ where
     pub fn add(&mut self, value: &T) {
         use HyperLogLogStorage::*;
 
-        let mut hasher = self.buildhasher.build_hasher();
-        value.hash(&mut hasher);
-        let hash = hasher.finish();
+        let hash = self.buildhasher.hash_one(value);
         match &mut self.storage {
             Sparse(s) => {
                 let overflowing = s.add_hash(hash);

--- a/crates/stats-agg/src/lib.rs
+++ b/crates/stats-agg/src/lib.rs
@@ -49,9 +49,9 @@ pub struct XYPair<T: FloatLike> {
 // but then the cost of recalculation is low, compared to when there are many values in a rolling calculation, so we
 // test early in the function for whether we need to recalculate and pass NULL quickly so that we don't affect those
 // cases too heavily.
-#[cfg(not(any(test, feature = "pg_test")))]
+#[cfg(not(test))]
 const INV_FLOATING_ERROR_THRESHOLD: f64 = 0.99;
-#[cfg(any(test, feature = "pg_test"))] // don't have a threshold for tests, to ensure the inverse function is better tested
+#[cfg(test)] // don't have a threshold for tests, to ensure the inverse function is better tested
 const INV_FLOATING_ERROR_THRESHOLD: f64 = f64::INFINITY;
 
 pub mod stats1d;

--- a/crates/t-digest/src/lib.rs
+++ b/crates/t-digest/src/lib.rs
@@ -123,8 +123,8 @@ impl TDigest {
             max_size,
             sum: OrderedFloat::from(0.0),
             count: 0,
-            max: OrderedFloat::from(std::f64::NAN),
-            min: OrderedFloat::from(std::f64::NAN),
+            max: OrderedFloat::from(f64::NAN),
+            min: OrderedFloat::from(f64::NAN),
         }
     }
 
@@ -243,8 +243,8 @@ impl Default for TDigest {
             max_size: 100,
             sum: OrderedFloat::from(0.0),
             count: 0,
-            max: OrderedFloat::from(std::f64::NAN),
-            min: OrderedFloat::from(std::f64::NAN),
+            max: OrderedFloat::from(f64::NAN),
+            min: OrderedFloat::from(f64::NAN),
         }
     }
 }
@@ -429,8 +429,8 @@ impl TDigest {
         let mut starts: Vec<usize> = Vec::with_capacity(digests.len());
 
         let mut count: u64 = 0;
-        let mut min = OrderedFloat::from(std::f64::INFINITY);
-        let mut max = OrderedFloat::from(std::f64::NEG_INFINITY);
+        let mut min = OrderedFloat::from(f64::INFINITY);
+        let mut max = OrderedFloat::from(f64::NEG_INFINITY);
 
         let mut start: usize = 0;
         for digest in digests.into_iter() {
@@ -1037,9 +1037,8 @@ mod tests {
 
         let digest = TDigest::merge_digests(vec![digest1, digest2]);
 
-        let quantile_tests = vec![0.01, 0.1, 0.25, 0.5, 0.6, 0.8, 0.95];
-        let tolerated_percentile_error =
-            vec![0.010001, 0.100001, 0.2, 0.30, 0.275, 0.1725, 0.050001]; // .000001 cases are to handle rounding errors on cases that might return infinities
+        let quantile_tests = [0.01, 0.1, 0.25, 0.5, 0.6, 0.8, 0.95];
+        let tolerated_percentile_error = [0.010001, 0.100001, 0.2, 0.30, 0.275, 0.1725, 0.050001]; // .000001 cases are to handle rounding errors on cases that might return infinities
 
         let mut master: Vec<f64> = batch1
             .iter()

--- a/crates/time-weighted-average/src/lib.rs
+++ b/crates/time-weighted-average/src/lib.rs
@@ -114,10 +114,10 @@ impl TimeWeightSummary {
     /// The initial aggregate will only have points within the time bucket, but outside of it, you will either have a point that you select
     /// or a TimeWeightSummary where the first or last point can be used depending on which bound you are extrapolating to.
     /// 1. The start_prev parameter is optional, but if a start is provided a previous point must be
-    /// provided (for both linear and locf weighting methods).
+    ///    provided (for both linear and locf weighting methods).
     /// 2. The end_next parameter is also optional, if an end is provided and the locf weighting
-    /// method is specified, a next parameter isn't needed, with the linear method, the next
-    /// point is needed and we will error if it is not provided.
+    ///    method is specified, a next parameter isn't needed, with the linear method, the next
+    ///    point is needed and we will error if it is not provided.
     pub fn with_bounds(
         &self,
         start_prev: Option<(i64, TSPoint)>,

--- a/crates/udd-sketch/src/lib.rs
+++ b/crates/udd-sketch/src/lib.rs
@@ -710,7 +710,7 @@ mod tests {
             sketch.add_value(*value);
         }
 
-        let quantile_tests = vec![0.01, 0.1, 0.25, 0.5, 0.6, 0.8, 0.95];
+        let quantile_tests = [0.01, 0.1, 0.25, 0.5, 0.6, 0.8, 0.95];
 
         master.sort_by(|a, b| a.partial_cmp(b).unwrap());
 

--- a/docker/ci/setup.sh
+++ b/docker/ci/setup.sh
@@ -32,7 +32,7 @@ BUILDER_HOME=$6
 
 # Phase 0 - set platform-specific parameters
 case $OS_NAME in
-    centos | rockylinux)
+    rockylinux)
         PG_BASE=/usr/pgsql-
         ;;
     debian | ubuntu)
@@ -51,34 +51,8 @@ if $privileged; then
     # Phase 2 - platform-specific package installation
     case $OS_NAME in
         # Red Hat Enterprise derivatives
-        centos | rockylinux)
+        rockylinux)
             case $OS_VERSION in
-                7)
-                    export PG_VERSIONS="13 14 15 16 17"
-                    export TSDB_PG_VERSIONS="13 14 15 16 17"
-                    # Postgresql packages require both
-                    # - llvm-toolset-7-clang from centos-release-scl-rh
-                    # - llvm5.0-devel from epel-release
-                    # ¯\_(ツ)_/¯
-                    yum -q -y install centos-release-scl-rh epel-release
-                    yum -q -y install devtoolset-7-gcc llvm-toolset-7-clang-devel llvm-toolset-7-clang-libs
-                    # devtoolset-7 includes a BROKEN sudo!  It even leads with a TODO about its brokenness!
-                    rm -f /opt/rh/devtoolset-7/root/usr/bin/sudo
-                    # for fpm
-                    yum -q -y install rh-ruby26-ruby-devel
-
-                    # TODO Would be nice to be able to resolve all system
-                    #  differences here rather than also in package-rpm.sh -
-                    #  maybe install wrappers in /usr/local/bin or setup ~/.profile .
-                    #  For now, most the knowledge is split.
-                    # Here, we only need `cc` for installing cargo-pgrx below.
-                    set +e      # scl_source has unchecked yet harmless errors?!  ¯\_(ツ)_/¯
-                    . scl_source enable devtoolset-7
-                    # And rh-ruby26 for gem install fpm below.
-                    . scl_source enable rh-ruby26
-                    set -e
-                    ;;
-
                 8)
                     yum -qy install dnf-plugins-core
                     dnf config-manager --enable powertools

--- a/extension/src/countminsketch.rs
+++ b/extension/src/countminsketch.rs
@@ -26,7 +26,7 @@ pub mod toolkit_experimental {
 
     impl CountMinSketch<'_> {
         fn new(width: u32, depth: u32, counters: Vec<i64>) -> Self {
-            let counters_arr = counters.try_into().unwrap();
+            let counters_arr = counters.into();
             unsafe {
                 flatten!(CountMinSketch {
                     width,

--- a/extension/src/datum_utils.rs
+++ b/extension/src/datum_utils.rs
@@ -330,8 +330,7 @@ impl<'a, 'de> Deserialize<'de> for DatumStore<'a> {
             where
                 A: SeqAccess<'de>,
             {
-                let oid =
-                    Oid::from(seq.next_element::<u32>().unwrap().unwrap()); // TODO: error handling
+                let oid = Oid::from(seq.next_element::<u32>().unwrap().unwrap()); // TODO: error handling
 
                 // TODO separate human-readable and binary forms
                 let mut reader = DatumFromSerializedTextReader::from_oid(oid);

--- a/extension/src/frequency.rs
+++ b/extension/src/frequency.rs
@@ -1276,12 +1276,9 @@ pub fn freq_iter<'a>(
         TableIterator::new(agg.datums.clone().into_iter().zip(counts).map_while(
             move |(value, (&count, &overcount))| {
                 let total = agg.values_seen as f64;
-                let value = AnyElement::from_polymorphic_datum(
-                    value,
-                    false,
-                    Oid::from(agg.type_oid),
-                )
-                .unwrap();
+                let value =
+                    AnyElement::from_polymorphic_datum(value, false, Oid::from(agg.type_oid))
+                        .unwrap();
                 let min_freq = (count - overcount) as f64 / total;
                 let max_freq = count as f64 / total;
                 Some((value, min_freq, max_freq))

--- a/extension/src/lttb.rs
+++ b/extension/src/lttb.rs
@@ -117,6 +117,7 @@ pub fn gp_lttb_trans(
 
     let mut trans = lttb_trans_inner(state, time, val, resolution, fcinfo);
     if needs_interval {
+        #[allow(clippy::manual_inspect)] // need to mutate s
         trans.as_mut().map(|s| {
             s.gap_interval = gap_val;
             s

--- a/extension/src/raw.rs
+++ b/extension/src/raw.rs
@@ -76,7 +76,10 @@ macro_rules! raw_type {
         unsafe impl<'fcx> callconv::ArgAbi<'fcx> for $name {
             unsafe fn unbox_arg_unchecked(arg: callconv::Arg<'_, 'fcx>) -> Self {
                 let index = arg.index();
-                unsafe { arg.unbox_arg_using_from_datum().unwrap_or_else(|| panic!("argument {index} must not be null")) }
+                unsafe {
+                    arg.unbox_arg_using_from_datum()
+                        .unwrap_or_else(|| panic!("argument {index} must not be null"))
+                }
             }
 
             unsafe fn unbox_nullable_arg(arg: callconv::Arg<'_, 'fcx>) -> nullable::Nullable<Self> {
@@ -92,9 +95,10 @@ pub struct bytea(pub pg_sys::Datum);
 raw_type!(bytea, pg_sys::BYTEAOID, pg_sys::BYTEAARRAYOID);
 
 unsafe impl pgrx::callconv::BoxRet for bytea {
-    unsafe fn box_into<'fcx>(self, fcinfo: &mut pgrx::callconv::FcInfo<'fcx>)
-        -> pgrx::datum::Datum<'fcx>
-    {
+    unsafe fn box_into<'fcx>(
+        self,
+        fcinfo: &mut pgrx::callconv::FcInfo<'fcx>,
+    ) -> pgrx::datum::Datum<'fcx> {
         unsafe { fcinfo.return_raw_datum(self.0) }
     }
 }
@@ -113,9 +117,10 @@ raw_type!(
 );
 
 unsafe impl pgrx::callconv::BoxRet for TimestampTz {
-    unsafe fn box_into<'fcx>(self, fcinfo: &mut pgrx::callconv::FcInfo<'fcx>)
-        -> pgrx::datum::Datum<'fcx>
-    {
+    unsafe fn box_into<'fcx>(
+        self,
+        fcinfo: &mut pgrx::callconv::FcInfo<'fcx>,
+    ) -> pgrx::datum::Datum<'fcx> {
         unsafe { fcinfo.return_raw_datum(self.0) }
     }
 }
@@ -145,9 +150,10 @@ pub struct Interval(pub pg_sys::Datum);
 raw_type!(Interval, pg_sys::INTERVALOID, pg_sys::INTERVALARRAYOID);
 
 unsafe impl pgrx::callconv::BoxRet for Interval {
-    unsafe fn box_into<'fcx>(self, fcinfo: &mut pgrx::callconv::FcInfo<'fcx>)
-        -> pgrx::datum::Datum<'fcx>
-    {
+    unsafe fn box_into<'fcx>(
+        self,
+        fcinfo: &mut pgrx::callconv::FcInfo<'fcx>,
+    ) -> pgrx::datum::Datum<'fcx> {
         unsafe { fcinfo.return_raw_datum(self.0) }
     }
 }

--- a/extension/src/serialization.rs
+++ b/extension/src/serialization.rs
@@ -6,8 +6,6 @@ use std::{
     os::raw::{c_char, c_int},
 };
 
-#[cfg(feature = "pg16")]
-use pgrx::pg_sys::DateTimeErrorExtra;
 use pgrx::pg_sys::{self};
 
 use std::ffi::CStr;
@@ -78,12 +76,7 @@ pub extern "C" fn _ts_toolkit_decode_timestamptz(text: &str) -> i64 {
             pg_sys::MAXDATEFIELDS as i32,
             &mut nf,
         );
-        #[cfg(any(
-            feature = "pg12",
-            feature = "pg13",
-            feature = "pg14",
-            feature = "pg15"
-        ))]
+        #[cfg(any(feature = "pg12", feature = "pg13", feature = "pg14", feature = "pg15"))]
         if dterr == 0 {
             dterr = pg_sys::DecodeDateTime(
                 field.as_mut_ptr(),
@@ -95,10 +88,7 @@ pub extern "C" fn _ts_toolkit_decode_timestamptz(text: &str) -> i64 {
                 &mut tz,
             )
         }
-        #[cfg(any(
-            feature = "pg16",
-            feature = "pg17"
-        ))]
+        #[cfg(any(feature = "pg16", feature = "pg17"))]
         if dterr == 0 {
             let mut extra = pgrx::pg_sys::DateTimeErrorExtra::default();
             dterr = pg_sys::DecodeDateTime(
@@ -113,12 +103,7 @@ pub extern "C" fn _ts_toolkit_decode_timestamptz(text: &str) -> i64 {
             )
         }
 
-        #[cfg(any(
-            feature = "pg12",
-            feature = "pg13",
-            feature = "pg14",
-            feature = "pg15"
-        ))]
+        #[cfg(any(feature = "pg12", feature = "pg13", feature = "pg14", feature = "pg15"))]
         if dterr != 0 {
             pg_sys::DateTimeParseError(
                 dterr,
@@ -126,10 +111,7 @@ pub extern "C" fn _ts_toolkit_decode_timestamptz(text: &str) -> i64 {
                 b"timestamptz\0".as_ptr().cast::<c_char>(),
             );
         }
-        #[cfg(any(
-            feature = "pg16",
-            feature = "pg17"
-        ))]
+        #[cfg(any(feature = "pg16", feature = "pg17"))]
         if dterr != 0 {
             pg_sys::DateTimeParseError(
                 dterr,

--- a/extension/src/serialization/types.rs
+++ b/extension/src/serialization/types.rs
@@ -276,8 +276,11 @@ impl<'de> Deserialize<'de> for PgTypId {
             );
             let namespace = CStr::from_ptr(namespace);
 
-            let name =
-                pg_sys::pg_any_to_server(name.as_ptr(), name_len as _, pg_sys::pg_enc::PG_UTF8 as _);
+            let name = pg_sys::pg_any_to_server(
+                name.as_ptr(),
+                name_len as _,
+                pg_sys::pg_enc::PG_UTF8 as _,
+            );
             let name = CStr::from_ptr(name);
 
             let namespace_id = pg_sys::LookupExplicitNamespace(namespace.as_ptr(), true);

--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -290,7 +290,7 @@ fn tdigest_compound_final(
     _fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<TDigest<'static>> {
     let state: Option<&InternalTDigest> = unsafe { state.get() };
-    state.map(|state| TDigest::from_internal_tdigest(state.deref()))
+    state.map(TDigest::from_internal_tdigest)
 }
 
 #[pg_extern(immutable, parallel_safe)]

--- a/extension/src/time_vector/pipeline/map.rs
+++ b/extension/src/time_vector/pipeline/map.rs
@@ -93,10 +93,9 @@ pub fn map_series_pipeline_element(
 }
 
 pub fn map_series_element<'a>(function: crate::raw::regproc) -> Element<'a> {
-    let function: pg_sys::regproc =
-        pg_sys::Oid::from(function.0.value() as u32)
-            .try_into()
-            .unwrap();
+    let function: pg_sys::regproc = pg_sys::Oid::from(function.0.value() as u32)
+        .try_into()
+        .unwrap();
     check_user_function_type(function);
     Element::MapSeries {
         function: PgProcId(function),

--- a/extension/src/type_builder.rs
+++ b/extension/src/type_builder.rs
@@ -37,7 +37,7 @@ macro_rules! pg_type {
     ) => {
         $crate::pg_type_impl!{
             'input
-            $(#[$attrs])* 
+            $(#[$attrs])*
             struct $name $(<$inlife>)?
             {
                 $($($vals)*)?
@@ -431,8 +431,8 @@ macro_rules! do_deserialize {
     ($bytes: expr, $t: ty) => {{
         use $crate::type_builder::SerializationType;
 
+        let input: $crate::raw::bytea = $bytes;
         let state: $t = unsafe {
-            let input: $crate::raw::bytea = $bytes;
             let input: pgrx::pg_sys::Datum = input.into();
             let detoasted = pg_sys::pg_detoast_datum_packed(input.cast_mut_ptr());
             let len = pgrx::varsize_any_exhdr(detoasted);

--- a/tools/sql-doctester/src/runner.rs
+++ b/tools/sql-doctester/src/runner.rs
@@ -276,8 +276,8 @@ fn stringify_delta(left: &[Vec<String>], right: &[Vec<String>]) -> String {
     let mut width = vec![
         0;
         max(
-            left.get(0).map(Vec::len).unwrap_or(0),
-            right.get(0).map(Vec::len).unwrap_or(0)
+            left.first().map(Vec::len).unwrap_or(0),
+            right.first().map(Vec::len).unwrap_or(0)
         )
     ];
     let num_rows = max(left.len(), right.len());

--- a/tools/testbin
+++ b/tools/testbin
@@ -96,7 +96,6 @@ skip_from_version() {
     [ $FROM_VERSION = 1.10.0-dev ] && return
     [ $OS_NAME = debian ] && [ $OS_VERSION = 10 ] && [ `cmp_version $FROM_VERSION` -lt 011100 ] && return
     [ $OS_NAME = ubuntu ] && [ $OS_VERSION = 22.04 ] && [ `cmp_version $FROM_VERSION` -lt 010600 ] && return
-    [ $OS_NAME = centos ] && [ $OS_VERSION = 7 ] && [ `cmp_version $FROM_VERSION` -ge 010800 ] && [ `cmp_version $FROM_VERSION` -le 011100 ] && return
 }
 
 # Requires:

--- a/tools/update-tester/src/testrunner.rs
+++ b/tools/update-tester/src/testrunner.rs
@@ -583,8 +583,8 @@ fn stringify_delta(left: &[Vec<String>], right: &[Vec<String>]) -> String {
     let mut width = vec![
         0;
         max(
-            left.get(0).map(Vec::len).unwrap_or(0),
-            right.get(0).map(Vec::len).unwrap_or(0)
+            left.first().map(Vec::len).unwrap_or(0),
+            right.first().map(Vec::len).unwrap_or(0)
         )
     ];
     let num_rows = max(left.len(), right.len());


### PR DESCRIPTION
This doesn't fix the CI (the alignment issue is still there), but it gets it closer to working.

Also drops CentOS 7 support, because the CI wasn't working on that and it's EOL anyways.