### PR TITLE
Allow spaces around equals sign in find_pg_config

### DIFF
--- a/tools/build
+++ b/tools/build
@@ -26,7 +26,7 @@ require_pg_version() {
 find_pg_config() {
     if [ -z "$pg_config" ]; then
         require_pg_version
-        pg_config=`sed -ne 's/"//g' -e s/^pg$pg_version=//p ~/.pgrx/config.toml`
+        pg_config=`sed -ne 's/"//g' -e "s/^pg$pg_version *= *//p" ~/.pgrx/config.toml`
     fi
     [ -x "$pg_config" ] || die "$pg_config not executable"
 }

--- a/tools/build
+++ b/tools/build
@@ -26,7 +26,7 @@ require_pg_version() {
 find_pg_config() {
     if [ -z "$pg_config" ]; then
         require_pg_version
-        pg_config=`sed -ne 's/"//g' -e "s/^pg$pg_version *= *//p" ~/.pgrx/config.toml`
+        pg_config=`which $(sed -ne 's/"//g' -e "s/^pg$pg_version *= *//p" ~/.pgrx/config.toml)`
     fi
     [ -x "$pg_config" ] || die "$pg_config not executable"
 }


### PR DESCRIPTION
Sometimes there are spaces in the `.pgrx/config.toml` file now; this updates the build script to be able to handle that.