### PR TITLE
expose sum for sketches as `total`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -12,7 +12,7 @@ This changelog should be updated as part of a PR if the work is worth noting (mo
 
 #### Other notable changes
 - [#847](https://github.com/timescale/timescaledb-toolkit/pull/847): Added `total` accessor for tdigest and uddsketch
-
+- [#853](https://github.com/timescale/timescaledb-toolkit/pull/853): Performance improvements for `UDDSketch`
 
 #### Shout-outs
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,8 @@ This changelog should be updated as part of a PR if the work is worth noting (mo
 #### Bug fixes
 
 #### Other notable changes
+- [#847](https://github.com/timescale/timescaledb-toolkit/pull/847): Added `total` accessor for tdigest and uddsketch
+
 
 #### Shout-outs
 

--- a/extension/src/stabilization_info.rs
+++ b/extension/src/stabilization_info.rs
@@ -11,6 +11,10 @@
 
 crate::functions_stabilized_at! {
     STABLE_FUNCTIONS
+    "1.20.0" => {
+        total(tdigest),
+        total(uddsketch),
+    }
     "1.16.0" => {
         approx_count_distinct(anyelement),
         approx_count_distinct_trans(internal,anyelement),

--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -416,6 +416,12 @@ pub fn tdigest_mean<'a>(digest: TDigest<'a>) -> f64 {
     }
 }
 
+/// Total sum of all the values entered in the digest.
+#[pg_extern(immutable, parallel_safe, name = "total")]
+pub fn tdigest_sum(digest: TDigest<'_>) -> f64 {
+    digest.sum
+}
+
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {

--- a/extension/src/uddsketch.rs
+++ b/extension/src/uddsketch.rs
@@ -671,6 +671,12 @@ pub fn uddsketch_mean<'a>(sketch: UddSketch<'a>) -> f64 {
     }
 }
 
+// Total sum of all the values entered in the sketch.
+#[pg_extern(immutable, parallel_safe, name = "total")]
+pub fn uddsketch_sum(sketch: UddSketch<'_>) -> f64 {
+    sketch.sum
+}
+
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
 pub fn arrow_uddsketch_error<'a>(sketch: UddSketch<'a>, _accessor: AccessorError<'a>) -> f64 {


### PR DESCRIPTION
We sometimes want to know the `sum` (or total) of a sketch.
We currently achieve that by :

```sql
mean(rollup(exec_times)) * num_vals(rollup(exec_times)
```

However, the following seems more natural:
```sql
sum(total(exec_times))
```