### PR TITLE
Upgrade CICD ubuntu image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   testpostgres:
     name: Test Postgres
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: ${{ inputs.container-image || 'timescaledev/toolkit-builder-test' }}:${{ matrix.container.image }}
     strategy:
@@ -56,8 +56,8 @@ jobs:
           image: debian-10-amd64
           schedule: ${{ inputs.all-platforms || ( github.event_name == 'schedule' && github.event.schedule == '0 6 * * 1-4' ) }}
         - os: ubuntu
-          version: "20.04"
-          image: ubuntu-20.04-amd64
+          version: "24.04"
+          image: ubuntu-24.04-amd64
           schedule: ${{ inputs.all-platforms || ( github.event_name == 'schedule' && github.event.schedule == '0 6 * * 1-4' ) }}
         - os: ubuntu
           version: "22.04"
@@ -162,7 +162,7 @@ jobs:
 
   testcrates:
     name: Test Crates
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: ${{ inputs.container-image || 'timescaledev/toolkit-builder' }}:debian-11-amd64
       env:

--- a/.github/workflows/ci_image_build.yml
+++ b/.github/workflows/ci_image_build.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     env:
       GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB_PACKAGE }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Run release-build-scripts job
         # Repeating the default here for 'pull_request'.  Keep in sync with above.

--- a/.github/workflows/clippy_rustfmt.yml
+++ b/.github/workflows/clippy_rustfmt.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   clippy:
     name: Clippy/rustfmt Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       # Duplicated from ci.yml
       image: ${{ inputs.container-image || 'timescaledev/toolkit-builder-test:debian-11-amd64' }}

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -10,7 +10,7 @@ jobs:
   package:
     env:
       GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB_PACKAGE }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Set env
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container:
       image: timescaledev/toolkit-builder-test:debian-11-amd64
 

--- a/.github/workflows/report_packaging_failures.yml
+++ b/.github/workflows/report_packaging_failures.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   on-failure:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     if: ${{ github.event.workflow_run.conclusion != 'success' && github.event.workflow_run.event != 'pull_request' }}
     steps:
       - name: slack-send

--- a/Readme.md
+++ b/Readme.md
@@ -27,8 +27,8 @@ All versions of the extension contain experimental features in the `toolkit_expe
 
 The engineering team regularly tests the extension on the following platforms:
 
-- x86_64-unknown-linux-gnu (Ubuntu Linux 20.04) (tested prior to every merge)
-- aarch64-unknown-linux-gnu (Ubuntu Linux 20.04) (tested at release time)
+- x86_64-unknown-linux-gnu (Ubuntu Linux 24.04) (tested prior to every merge)
+- aarch64-unknown-linux-gnu (Ubuntu Linux 24.04) (tested at release time)
 - x86_64-apple-darwin (MacOS 12) (tested frequently on eng workstation)
 - aarch64-apple-darwin (MacOS 12) (tested frequently on eng workstation)
 

--- a/tools/testbin
+++ b/tools/testbin
@@ -3,7 +3,7 @@
 # This script automates binary upgrade testing.
 
 # Sample run:
-# OS_NAME=ubuntu OS_VERSION=20.04 tools/testbin -version 1.11.0 -bindir .. -pgversions '13 14' deb
+# OS_NAME=ubuntu OS_VERSION=24.04 tools/testbin -version 1.11.0 -bindir .. -pgversions '13 14' deb
 
 # A released toolkit lists the versions it is upgradeable from in
 # extension/timescaledb_toolkit.control .  This script processes those entries


### PR DESCRIPTION
The old one is no longer working

> This is a scheduled Ubuntu 20.04 retirement.
> Ubuntu 20.04 LTS runner will be removed on 2025-04-15.
> For more details, see https://github.com/actions/runner-images/issues/11101