### PR TITLE
Update pgrx version to 0.16.0

### DIFF
--- a/.github/workflows/ci_image_build.yml
+++ b/.github/workflows/ci_image_build.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Run release-build-scripts job
         # Repeating the default here for 'pull_request'.  Keep in sync with above.
         run: |
+          echo "toolkit-commit: ${{ inputs.toolkit-commit || github.event.pull_request.head.sha }}"
+          echo "builder: ${{ inputs.builder-commit || 'main' }}"
+          echo "tag-base: ${{ inputs.tag-base || 'timescaledev/toolkit-builder-test' }}"
           gh workflow run toolkit-image.yml \
                 -R timescale/release-build-scripts \
                 -r ${{ inputs.builder-commit || 'main' }} \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,13 +36,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "annotate-snippets"
-version = "0.9.2"
+name = "allocator-api2"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "annotate-snippets"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
 dependencies = [
- "unicode-width",
- "yansi-term",
+ "anstyle",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
@@ -87,17 +93,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "atomic-traits"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b29ec3788e96fb4fdb275ccb9d62811f2fa903d76c5eb4dd6fe7d09a7ed5871f"
-dependencies = [
- "cfg-if",
- "rustc_version",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -155,12 +151,12 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.70.1"
+version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
  "annotate-snippets",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -169,7 +165,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -195,9 +191,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bitvec"
@@ -280,20 +276,20 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.23",
+ "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.67",
 ]
 
 [[package]]
 name = "cargo_toml"
-version = "0.19.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98356df42a2eb1bd8f1793ae4ee4de48e384dd974ce5eac8eee802edb7492be"
+checksum = "374b7c592d9c00c1f4972ea58390ac6b18cbb6ab79011f3bdc90a0b82ca06b77"
 dependencies = [
  "serde",
- "toml",
+ "toml 0.9.5",
 ]
 
 [[package]]
@@ -304,15 +300,15 @@ checksum = "9ff11ddd2af3b5e80dd0297fee6e56ac038d9bdc549573cdb51bd6d2efe7f05e"
 dependencies = [
  "num-complex",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
 [[package]]
 name = "cc"
-version = "1.1.34"
+version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b9470d453346108f93a59222a9a1a5724db32d0a4727b7ab7ace4b4d822dc9"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
 dependencies = [
  "shlex",
 ]
@@ -409,7 +405,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -426,6 +422,15 @@ name = "clap_lex"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
+]
 
 [[package]]
 name = "colored"
@@ -453,24 +458,18 @@ version = "0.1.0"
 
 [[package]]
 name = "convert_case"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
 name = "counter-agg"
 version = "0.1.0"
 dependencies = [
- "approx 0.4.0",
+ "approx 0.5.1",
  "flat_serialize",
  "flat_serialize_macro",
  "serde",
@@ -482,7 +481,7 @@ dependencies = [
 name = "countminsketch"
 version = "0.1.0"
 dependencies = [
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -549,7 +548,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -557,6 +556,15 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "encodings"
@@ -583,7 +591,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -604,12 +612,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -636,9 +644,9 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flat_serialize"
@@ -663,6 +671,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -703,7 +717,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -749,7 +763,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -760,7 +774,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -806,15 +832,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,15 +842,10 @@ name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
-
-[[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
- "hash32",
- "stable_deref_trait",
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -890,11 +902,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1023,7 +1035,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1143,10 +1155,11 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1158,9 +1171,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -1186,9 +1199,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1261,7 +1274,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -1277,7 +1290,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "simba",
  "typenum",
@@ -1320,7 +1333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -1354,6 +1367,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
 name = "object"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "ordered-float"
@@ -1386,9 +1408,9 @@ checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "owo-colors"
-version = "4.1.0"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb37767f6569cd834a413442455e0f066d0d522de8630436e2a1761d9726ba56"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 dependencies = [
  "supports-color 2.1.0",
  "supports-color 3.0.1",
@@ -1445,7 +1467,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.67",
  "ucd-trie",
 ]
 
@@ -1485,25 +1507,25 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.6.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
 dependencies = [
  "fixedbitset",
+ "hashbrown 0.15.0",
  "indexmap 2.6.0",
+ "serde",
 ]
 
 [[package]]
 name = "pgrx"
-version = "0.12.9"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227bf7e162ce710994306a97bc56bb3fe305f21120ab6692e2151c48416f5c0d"
+checksum = "2c898b37587b29f8fa7ca20bfaaf57103e10fa81e6caed2cc7b742f96088d851"
 dependencies = [
- "atomic-traits",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "bitvec",
  "enum-map",
- "heapless",
  "libc",
  "once_cell",
  "pgrx-macros",
@@ -1513,15 +1535,15 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
- "thiserror",
- "uuid 1.11.0",
+ "thiserror 2.0.12",
+ "uuid 1.18.0",
 ]
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.12.9"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cbcd956c2da35baaf0a116e6f6a49a6c2fbc8f6b332f66d6fd060bfd00615f"
+checksum = "35439a65a6c0cc17e9758005da0557cff583a3e4da0f92a4a744494ac21c190e"
 dependencies = [
  "bindgen",
  "cc",
@@ -1530,46 +1552,50 @@ dependencies = [
  "pgrx-pg-config",
  "proc-macro2",
  "quote",
+ "regex",
  "shlex",
- "syn 2.0.87",
+ "syn 2.0.106",
  "walkdir",
 ]
 
 [[package]]
 name = "pgrx-macros"
-version = "0.12.9"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f4291450d65e4deb770ce57ea93e22353d97950566222429cd166ebdf6f938"
+checksum = "3586274c7d7237e68bebb871cf9244444f1ad78bb395679ad4ef1015db302454"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.12.9"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86a64a4c6e4e43e73cf8d3379d9533df98ded45c920e1ba8131c979633d74132"
+checksum = "0cc24f6663377dca8797ff3561d9ecdaef47e518ca2e2438fd85ef3c20f421ea"
 dependencies = [
  "cargo_toml",
+ "codepage",
+ "encoding_rs",
  "eyre",
  "home",
  "owo-colors",
  "pathsearch",
  "serde",
  "serde_json",
- "thiserror",
- "toml",
+ "thiserror 2.0.12",
+ "toml 0.8.19",
  "url",
+ "winapi",
 ]
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.12.9"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63a5dc64f2a8226434118aa2c4700450fa42b04f29488ad98268848b21c1a4ec"
+checksum = "b44a35477c0752c00cab38c2d8b7ea2d2d3554e3385870d7ad43e3ae5ade66a9"
 dependencies = [
  "cee-scape",
  "libc",
@@ -1582,25 +1608,25 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.12.9"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81cc2e851c7e36b2f47c03e22d64d56c1d0e762fbde0039ba2cd490cfef3615"
+checksum = "59036a5849c5b0bca0f33df1fdd72206ceb74712959756b3fecba56a8e19d52a"
 dependencies = [
  "convert_case",
  "eyre",
  "petgraph",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
- "thiserror",
+ "syn 2.0.106",
+ "thiserror 2.0.12",
  "unescape",
 ]
 
 [[package]]
 name = "pgrx-tests"
-version = "0.12.9"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2dd5d674cb7d92024709543da06d26723a2f7450c02083116b232587160929"
+checksum = "1455045c6345fcb1f1f441205735719290cb1cd71975e0a37693adb807b1b8a3"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -1612,12 +1638,15 @@ dependencies = [
  "pgrx-pg-config",
  "postgres",
  "proptest",
- "rand",
+ "rand 0.9.2",
  "regex",
  "serde",
  "serde_json",
+ "shlex",
  "sysinfo",
- "thiserror",
+ "tempfile",
+ "thiserror 2.0.12",
+ "winapi",
 ]
 
 [[package]]
@@ -1660,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "postgres"
-version = "0.19.7"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7915b33ed60abc46040cbcaa25ffa1c7ec240668e0477c4f3070786f5916d451"
+checksum = "363e6dfbdd780d3aa3597b6eb430db76bb315fa9bad7fae595bb8def808b8470"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -1674,9 +1703,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acda0ebdebc28befa84bee35e651e4c5f09073d668c7aed4cf7e23c3cda84b23"
+checksum = "76ff0abab4a9b844b93ef7b81f1efc0a366062aaef2cd702c76256b5dc075c54"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -1685,16 +1714,16 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.9.2",
  "sha2",
  "stringprep",
 ]
 
 [[package]]
 name = "postgres-types"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66ea23a2d0e5734297357705193335e0a957696f34bed2f2faefacb2fec336f"
+checksum = "613283563cd90e1dfc3518d548caee47e0e725455ed619881f5cf21f36de4b48"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -1716,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "beef09f85ae72cea1ef96ba6870c51e6382ebfa4f0e85b643459331f3daa5be0"
 dependencies = [
  "unicode-ident",
 ]
@@ -1731,11 +1760,11 @@ checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -1769,7 +1798,7 @@ checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger",
  "log",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1785,12 +1814,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -1805,8 +1840,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1816,7 +1861,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1825,7 +1880,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -1835,7 +1899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1844,7 +1908,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1879,7 +1943,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -1930,18 +1994,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -1959,16 +2014,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.38"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys 0.4.14",
- "windows-sys 0.52.0",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-fork"
@@ -2011,15 +2072,6 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
@@ -2028,19 +2080,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
-
-[[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -2057,13 +2100,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2083,6 +2126,15 @@ name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -2206,19 +2258,19 @@ dependencies = [
  "lazy_static",
  "nalgebra",
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
 name = "stats_agg"
 version = "0.1.0"
 dependencies = [
- "approx 0.4.0",
+ "approx 0.5.1",
  "flat_serialize",
  "flat_serialize_macro",
  "num-traits",
  "serde",
- "twofloat",
+ "twofloat 0.8.4",
 ]
 
 [[package]]
@@ -2276,9 +2328,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2293,21 +2345,19 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "sysinfo"
-version = "0.30.13"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+checksum = "a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2"
 dependencies = [
- "cfg-if",
- "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
- "rayon",
+ "objc2-core-foundation",
  "windows",
 ]
 
@@ -2340,14 +2390,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.3.3",
  "once_cell",
- "rustix 0.38.38",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -2401,7 +2451,16 @@ version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3c6efbfc763e64eb85c11c25320f0737cb7364c4b6336db90aa9ebe27a0bbd"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.67",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -2412,7 +2471,18 @@ checksum = "b607164372e89797d78b8e23a6d67d5d1038c1c65efd52e1389ef8b77caba2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2449,8 +2519,8 @@ dependencies = [
  "pgrx-macros",
  "pgrx-sql-entity-graph",
  "pgrx-tests",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_distr",
  "ron",
  "serde",
@@ -2461,7 +2531,7 @@ dependencies = [
  "tera",
  "time_weighted_average",
  "tspoint",
- "twofloat",
+ "twofloat 0.6.1",
  "uddsketch",
 ]
 
@@ -2507,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.10"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d340244b32d920260ae7448cb72b6e238bddc3d4f7603394e7dd46ed8e48f5b8"
+checksum = "6c95d533c83082bb6490e0189acaa0bbeef9084e60471b696ca6988cd0541fb0"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -2524,7 +2594,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand",
+ "rand 0.9.2",
  "socket2",
  "tokio",
  "tokio-util",
@@ -2551,9 +2621,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.8",
+ "toml_datetime 0.6.8",
  "toml_edit 0.22.22",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+dependencies = [
+ "indexmap 2.6.0",
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.12",
 ]
 
 [[package]]
@@ -2561,6 +2646,15 @@ name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
 dependencies = [
  "serde",
 ]
@@ -2584,10 +2678,25 @@ checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap 2.6.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
- "winnow",
+ "serde_spanned 0.6.8",
+ "toml_datetime 0.6.8",
+ "winnow 0.6.20",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+dependencies = [
+ "winnow 0.7.12",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tspoint"
@@ -2603,6 +2712,18 @@ name = "twofloat"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bd3efad063a313d3a552efa9350126fa4c00b11f18e3fd87ddeaac20b27f70d"
+dependencies = [
+ "hexf",
+ "libm",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "twofloat"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f25f7bfd28a043cba51ea618ad2d29c5fa991a1237a4c0b592b466fbbb60c5c"
 dependencies = [
  "hexf",
  "libm",
@@ -2629,7 +2750,7 @@ dependencies = [
  "ordered-float",
  "quickcheck",
  "quickcheck_macros",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -2741,6 +2862,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
 name = "update-tester"
 version = "0.3.0"
 dependencies = [
@@ -2751,7 +2878,7 @@ dependencies = [
  "postgres",
  "postgres_connection_configuration",
  "pulldown-cmark",
- "semver 1.0.23",
+ "semver",
  "toml_edit 0.14.4",
  "walkdir",
  "xshell",
@@ -2759,9 +2886,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2786,16 +2913,18 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2830,6 +2959,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,35 +2975,35 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2873,22 +3011,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
@@ -2944,9 +3085,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.52.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core",
  "windows-targets 0.52.6",
@@ -2954,9 +3095,43 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3119,6 +3294,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,15 +3345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4916a4a3cad759e499a3620523bf9545cc162d7a06163727dde97ce9aaa4cf39"
 
 [[package]]
-name = "yansi-term"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "yoke"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3183,7 +3364,7 @@ checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -3205,7 +3386,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3225,7 +3406,7 @@ checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -3248,5 +3429,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.106",
 ]

--- a/Readme.md
+++ b/Readme.md
@@ -53,7 +53,7 @@ sudo apt-get install make gcc pkg-config clang postgresql-server-dev-14 libssl-d
 Next you need [cargo-pgrx](https://github.com/tcdi/pgrx), which can be installed with
 
 ```bash
-cargo install --version '=0.12.9' --force cargo-pgrx
+cargo install --version '=0.16.0' --force cargo-pgrx
 ```
 
 You must reinstall cargo-pgrx whenever you update your Rust compiler, since cargo-pgrx needs to be built with the same compiler as Toolkit.

--- a/crates/aggregate_builder/src/lib.rs
+++ b/crates/aggregate_builder/src/lib.rs
@@ -21,7 +21,7 @@ pub fn aggregate(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as Aggregate);
     let expanded = expand(input);
     if cfg!(feature = "print-generated") {
-        println!("{}", expanded);
+        println!("{expanded}");
     }
     expanded.into()
 }
@@ -423,29 +423,27 @@ fn expand(agg: Aggregate) -> TokenStream2 {
     ];
 
     let schema_qualifier = match &schema {
-        Some(schema) => format!("{}.", schema),
+        Some(schema) => format!("{schema}."),
         None => String::new(),
     };
-    let mut create = format!("\nCREATE AGGREGATE {}{} (", schema_qualifier, name);
+    let mut create = format!("\nCREATE AGGREGATE {schema_qualifier}{name} (");
     for (i, (name, arg)) in transition_fn.sql_args().enumerate() {
         if i != 0 {
             let _ = write!(&mut create, ", ");
         }
         if let Some(name) = name {
-            let _ = write!(&mut create, "{} ", name);
+            let _ = write!(&mut create, "{name} ");
         }
-        let _ = write!(&mut create, "{}", arg);
+        let _ = write!(&mut create, "{arg}");
     }
+    let transition_fn_ident = transition_fn.outer_ident(&name);
+    let final_fn_ident = final_fn.outer_ident(&name);
     let _ = write!(
         &mut create,
         ") (\n    \
             stype = internal,\n    \
-            sfunc = {}{},\n    \
-            finalfunc = {}{}",
-        schema_qualifier,
-        transition_fn.outer_ident(&name),
-        schema_qualifier,
-        final_fn.outer_ident(&name),
+            sfunc = {schema_qualifier}{transition_fn_ident},\n    \
+            finalfunc = {schema_qualifier}{final_fn_ident}"
     );
 
     let parallel_safe = parallel_safe.map(|p| {
@@ -558,7 +556,7 @@ fn expand(agg: Aggregate) -> TokenStream2 {
 
     let _ = write!(&mut create, "\n);\n");
 
-    let extension_sql_name = format!("{}_extension_sql", name);
+    let extension_sql_name = format!("{name}_extension_sql");
 
     quote! {
         pub mod #name {
@@ -607,7 +605,7 @@ impl AggregateFn {
         } = self;
 
         let schema = schema.as_ref().map(|s| {
-            let s = format!("{}", s);
+            let s = format!("{s}");
             quote!(, schema = #s)
         });
 
@@ -719,7 +717,7 @@ impl AggregateFn {
         } = self;
 
         let schema = schema.as_ref().map(|s| {
-            let s = format!("{}", s);
+            let s = format!("{s}");
             quote!(, schema = #s)
         });
 
@@ -776,7 +774,7 @@ impl AggregateFn {
         } = self;
 
         let schema = schema.as_ref().map(|s| {
-            let s = format!("{}", s);
+            let s = format!("{s}");
             quote!(, schema = #s)
         });
 
@@ -835,7 +833,7 @@ impl AggregateFn {
         } = self;
 
         let schema = schema.as_ref().map(|s| {
-            let s = format!("{}", s);
+            let s = format!("{s}");
             quote!(, schema = #s)
         });
 
@@ -893,7 +891,7 @@ impl AggregateFn {
         } = self;
 
         let schema = schema.as_ref().map(|s| {
-            let s = format!("{}", s);
+            let s = format!("{s}");
             quote!(, schema = #s)
         });
 

--- a/crates/count-min-sketch/src/lib.rs
+++ b/crates/count-min-sketch/src/lib.rs
@@ -229,7 +229,7 @@ impl fmt::Display for CountMinSketch {
 
         write!(f, "|      ||")?;
         for b in 0..self.width {
-            write!(f, "    {:>3} |", b)?;
+            write!(f, "    {b:>3} |")?;
         }
         writeln!(f)?;
 
@@ -240,9 +240,9 @@ impl fmt::Display for CountMinSketch {
         writeln!(f)?;
 
         for n in 0..self.depth {
-            write!(f, "|  {:>3} ||", n)?;
+            write!(f, "|  {n:>3} ||")?;
             for x in &self.counters[n] {
-                write!(f, " {:>6} |", x)?;
+                write!(f, " {x:>6} |")?;
             }
             writeln!(f)?;
         }

--- a/crates/counter-agg/Cargo.toml
+++ b/crates/counter-agg/Cargo.toml
@@ -13,4 +13,4 @@ stats_agg = {path="../stats-agg"}
 tspoint = {path="../tspoint"}
 
 [dev-dependencies]
-approx = "0.4.0"
+approx = "0.5.1"

--- a/crates/flat_serialize/flat_serialize/src/lib.rs
+++ b/crates/flat_serialize/flat_serialize/src/lib.rs
@@ -658,7 +658,7 @@ unsafe fn fill_slice_from_iter<
         filled += 1;
     }
     if filled < count {
-        panic!("Not enough elements. Expected {} found {}", count, filled)
+        panic!("Not enough elements. Expected {count} found {filled}")
     }
     input
 }
@@ -678,7 +678,7 @@ fn len_of_iterable<'i, T: FlatSerializable<'i>, V: ValOrRef<T>, I: Iterator<Item
         }
     }
     if filled < count {
-        panic!("Not enough elements. Expected {} found {}", count, filled)
+        panic!("Not enough elements. Expected {count} found {filled}")
     }
     len
 }

--- a/crates/flat_serialize/flat_serialize_macro/src/lib.rs
+++ b/crates/flat_serialize/flat_serialize_macro/src/lib.rs
@@ -20,7 +20,7 @@ pub fn flat_serialize(input: TokenStream) -> TokenStream {
         FlatSerialize::Enum(input) => flat_serialize_enum(input),
     };
     if cfg!(feature = "print-generated") {
-        println!("{}", expanded);
+        println!("{expanded}");
     }
     expanded.into()
 }
@@ -614,7 +614,7 @@ impl FlatSerializeEnum {
             let variant = &v.body.ident;
 
             let break_label =
-                syn::Lifetime::new(&format!("'tryref_{}", i), proc_macro2::Span::call_site());
+                syn::Lifetime::new(&format!("'tryref_{i}"), proc_macro2::Span::call_site());
 
             let TryRefBody {
                 vars,

--- a/crates/hyperloglogplusplus/src/dense.rs
+++ b/crates/hyperloglogplusplus/src/dense.rs
@@ -19,8 +19,7 @@ impl<'s> Storage<'s> {
         // TODO what is max precision
         assert!(
             (4..=18).contains(&precision),
-            "invalid value for precision: {}; must be within [4, 18]",
-            precision,
+            "invalid value for precision: {precision}; must be within [4, 18]",
         );
         let non_index_bits = 64 - precision;
         Self {

--- a/crates/hyperloglogplusplus/src/sparse.rs
+++ b/crates/hyperloglogplusplus/src/sparse.rs
@@ -33,8 +33,7 @@ impl<'s> Storage<'s> {
         // TODO what is max precision
         assert!(
             (4..=18).contains(&precision),
-            "invalid value for precision: {}; must be within [4, 18]",
-            precision,
+            "invalid value for precision: {precision}; must be within [4, 18]",
         );
         Self {
             to_merge: Default::default(),
@@ -48,8 +47,7 @@ impl<'s> Storage<'s> {
         // TODO what is max precision
         assert!(
             (4..=18).contains(&precision),
-            "invalid value for precision: {}; must be within [4, 18]",
-            precision,
+            "invalid value for precision: {precision}; must be within [4, 18]",
         );
         Self {
             to_merge: Default::default(),

--- a/crates/scripting-utilities/control_file_reader/src/lib.rs
+++ b/crates/scripting-utilities/control_file_reader/src/lib.rs
@@ -23,9 +23,7 @@ pub fn get_upgradeable_from(control_file: &str) -> Result<Vec<String>> {
 /// find a `<field name> = '<field value>'` in `file` and extract `<field value>`
 pub fn get_field_val<'a>(file: &'a str, field_name: &str) -> Result<&'a str> {
     file.lines()
-        .filter(|line| {
-            line.starts_with(field_name) || line.starts_with(&format!("# {}", field_name))
-        })
+        .filter(|line| line.starts_with(field_name) || line.starts_with(&format!("# {field_name}")))
         .map(get_quoted_field)
         .next()
         .ok_or(Error::FieldNotFound)

--- a/crates/scripting-utilities/postgres_connection_configuration/src/lib.rs
+++ b/crates/scripting-utilities/postgres_connection_configuration/src/lib.rs
@@ -36,20 +36,20 @@ impl<'s> ConnectionConfig<'s> {
 
         let mut config = String::new();
         if let Some(host) = host {
-            let _ = write!(&mut config, "host={} ", host);
+            let _ = write!(&mut config, "host={host} ");
         }
         if let Some(port) = port {
-            let _ = write!(&mut config, "port={} ", port);
+            let _ = write!(&mut config, "port={port} ");
         }
         let _ = match user {
-            Some(user) => write!(&mut config, "user={} ", user),
+            Some(user) => write!(&mut config, "user={user} "),
             None => write!(&mut config, "user=postgres "),
         };
         if let Some(password) = password {
-            let _ = write!(&mut config, "password={} ", password);
+            let _ = write!(&mut config, "password={password} ");
         }
         if let Some(database) = database {
-            let _ = write!(&mut config, "dbname={} ", database);
+            let _ = write!(&mut config, "dbname={database} ");
         }
         config
     }

--- a/crates/stats-agg/Cargo.toml
+++ b/crates/stats-agg/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 flat_serialize = {path="../flat_serialize/flat_serialize"}
 flat_serialize_macro = {path="../flat_serialize/flat_serialize_macro"}
 serde = { version = "1.0", features = ["derive"] }
-twofloat = { version = "0.6.0", features = ["serde"] }
+twofloat = { version = "0.8.4", features = ["serde"] }
 num-traits = "0.2.15"
 
 [dev-dependencies]
-approx = "0.4.0"
+approx = "0.5.1"

--- a/crates/stats-agg/src/lib.rs
+++ b/crates/stats-agg/src/lib.rs
@@ -5,6 +5,8 @@
 // https://github.com/postgres/postgres/blob/472e518a44eacd9caac7d618f1b6451672ca4481/src/backend/utils/adt/float.c#L3260
 //
 
+pub use twofloat::TwoFloat;
+
 pub trait FloatLike:
     num_traits::NumOps + num_traits::NumAssignOps + num_traits::Float + From<f64>
 {
@@ -19,7 +21,7 @@ impl FloatLike for f64 {
         n as f64
     }
 }
-impl FloatLike for twofloat::TwoFloat {
+impl FloatLike for TwoFloat {
     fn from_u64(n: u64) -> Self {
         (n as f64).into()
     }

--- a/crates/stats-agg/src/stats1d.rs
+++ b/crates/stats-agg/src/stats1d.rs
@@ -1,6 +1,5 @@
-use crate::{m3, m4, FloatLike, StatsError, INV_FLOATING_ERROR_THRESHOLD};
+use crate::{m3, m4, FloatLike, StatsError, TwoFloat, INV_FLOATING_ERROR_THRESHOLD};
 use serde::{Deserialize, Serialize};
-use twofloat::TwoFloat;
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
 #[repr(C)]

--- a/crates/t-digest-lib/src/lib.rs
+++ b/crates/t-digest-lib/src/lib.rs
@@ -1,14 +1,14 @@
 // There is no safety here:  it's all in the hands of the caller, bless their heart.
 #![allow(clippy::missing_safety_doc)]
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn timescaledb_toolkit_tdigest_builder_with_size(
     size: usize,
 ) -> Box<tdigest::Builder> {
     Box::new(tdigest::Builder::with_size(size))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn timescaledb_toolkit_tdigest_push(
     builder: *mut tdigest::Builder,
     value: f64,
@@ -17,7 +17,7 @@ pub unsafe extern "C" fn timescaledb_toolkit_tdigest_push(
 }
 
 // TODO Don't abort the process if `builder` and `other` weren't created with the same size.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn timescaledb_toolkit_tdigest_merge(
     builder: *mut tdigest::Builder,
     other: Box<tdigest::Builder>,
@@ -26,24 +26,24 @@ pub unsafe extern "C" fn timescaledb_toolkit_tdigest_merge(
     (*builder).merge(other)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn timescaledb_toolkit_tdigest_builder_free(_: Box<tdigest::Builder>) {}
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn timescaledb_toolkit_tdigest_build(
     mut builder: Box<tdigest::Builder>,
 ) -> Box<tdigest::TDigest> {
     Box::new(builder.build())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn timescaledb_toolkit_tdigest_free(_: Box<tdigest::TDigest>) {}
 
 // TODO Messy, but good enough to experiment with.  We might want to
 // into_raw_parts the String and offer a transparent struct containing pointer
 // to and size of the buffer, with a ts_tk_tdigest_string_free taking it back
 // and releasing it.  That also avoids one copy.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn timescaledb_toolkit_tdigest_format_for_postgres(
     td: *const tdigest::TDigest,
 ) -> *mut libc::c_char {

--- a/crates/tspoint/src/lib.rs
+++ b/crates/tspoint/src/lib.rs
@@ -35,7 +35,7 @@ impl Serialize for TSPoint {
     {
         if serializer.is_human_readable() {
             // FIXME ugly hack to use postgres functions in an non-postgres library
-            extern "C" {
+            unsafe extern "C" {
                 fn _ts_toolkit_encode_timestamptz(dt: i64, buf: &mut [u8; 128]);
             }
             let mut ts = [0; 128];
@@ -70,7 +70,7 @@ impl<'de> Deserialize<'de> for TSPoint {
         }
 
         // FIXME ugly hack to use postgres functions in an non-postgres library
-        extern "C" {
+        unsafe extern "C" {
             // this is only going to be used to communicate with a rust lib we compile with this one
             #[allow(improper_ctypes)]
             fn _ts_toolkit_decode_timestamptz(text: &str) -> i64;

--- a/crates/udd-sketch/src/lib.rs
+++ b/crates/udd-sketch/src/lib.rs
@@ -856,7 +856,7 @@ mod tests {
     #[test]
     fn random_stress() {
         let mut sketch = UDDSketch::new(1000, 0.01);
-        let seed = rand::thread_rng().gen();
+        let seed = rand::thread_rng().gen_range(0..u64::MAX);
         let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
         let mut bounds = Vec::new();
         for _ in 0..100 {

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -20,9 +20,9 @@ pg_test = ["approx"]
 [dependencies]
 # Keep synchronized with `cargo install --version N.N.N cargo-pgrx` in Readme.md and docker/ci/Dockerfile
 # Also `pgrx-tests` down below in `dev-dependencies`.
-pgrx = "=0.12.9"
-pgrx-macros = "=0.12.9"
-pgrx-sql-entity-graph = "=0.12.9"
+pgrx = "=0.16.0"
+pgrx-macros = "=0.16.0"
+pgrx-sql-entity-graph = "=0.16.0"
 encodings = {path="../crates/encodings"}
 flat_serialize = {path="../crates/flat_serialize/flat_serialize"}
 flat_serialize_macro = {path="../crates/flat_serialize/flat_serialize_macro"}
@@ -59,5 +59,5 @@ spfunc = "0.1.0"
 statrs = "0.15.0"
 
 [dev-dependencies]
-pgrx-tests = "=0.12.9"
+pgrx-tests = "=0.16.0"
 approx = "0.4.0"

--- a/extension/src/accessors.rs
+++ b/extension/src/accessors.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto as _;
-
 use pgrx::*;
 
 use counter_agg::range::I64Range;
@@ -14,7 +12,6 @@ macro_rules! accessor {
     ) => {
         ::paste::paste! {
             $crate::pg_type!{
-                // TODO Move into pg_type as we don't care to vary it.
                 #[derive(Debug)]
                 struct [<Accessor $name:camel>] {
                 $($field: $typ,)*
@@ -37,7 +34,7 @@ macro_rules! accessor_fn_impl {
             #[pg_extern(immutable, parallel_safe, name = "" $name "")]
             fn [<accessor_ $name >](
                 $( $field: $typ ),*
-            ) -> [<Accessor $name:camel>]<'static> {
+            ) -> [<Accessor $name:camel>] {
                 $crate::build! {
                     [<Accessor $name:camel>] {
                         $( $field ),*
@@ -121,7 +118,7 @@ pg_type! {
 ron_inout_funcs!(AccessorLiveAt);
 
 #[pg_extern(immutable, parallel_safe, name = "live_at")]
-pub fn accessor_live_at(ts: crate::raw::TimestampTz) -> AccessorLiveAt<'static> {
+pub fn accessor_live_at(ts: crate::raw::TimestampTz) -> AccessorLiveAt {
     unsafe {
         flatten! {
             AccessorLiveAt {
@@ -133,9 +130,8 @@ pub fn accessor_live_at(ts: crate::raw::TimestampTz) -> AccessorLiveAt<'static> 
 
 pg_type! {
     #[derive(Debug)]
-    struct AccessorStdDev<'input> {
-        len: u32,
-        bytes: [u8; self.len],
+    struct AccessorStdDev {
+        method: crate::stats_agg::Method,
     }
 }
 
@@ -143,13 +139,12 @@ pg_type! {
 ron_inout_funcs!(AccessorStdDev);
 
 #[pg_extern(immutable, parallel_safe, name = "stddev")]
-pub fn accessor_stddev(method: default!(&str, "'sample'")) -> AccessorStdDev<'static> {
-    let _ = crate::stats_agg::method_kind(method);
+pub fn accessor_stddev(method: default!(&str, "'sample'")) -> AccessorStdDev {
+    let method_enum = crate::stats_agg::method_kind(method);
     unsafe {
         flatten! {
             AccessorStdDev {
-                len: method.len().try_into().unwrap(),
-                bytes: method.as_bytes().into(),
+                method: method_enum,
             }
         }
     }
@@ -157,9 +152,8 @@ pub fn accessor_stddev(method: default!(&str, "'sample'")) -> AccessorStdDev<'st
 
 pg_type! {
     #[derive(Debug)]
-    struct AccessorStdDevX<'input> {
-        len: u32,
-        bytes: [u8; self.len],
+    struct AccessorStdDevX {
+        method: crate::stats_agg::Method,
     }
 }
 
@@ -167,13 +161,12 @@ pg_type! {
 ron_inout_funcs!(AccessorStdDevX);
 
 #[pg_extern(immutable, parallel_safe, name = "stddev_x")]
-pub fn accessor_stddev_x(method: default!(&str, "'sample'")) -> AccessorStdDevX<'static> {
-    let _ = crate::stats_agg::method_kind(method);
+pub fn accessor_stddev_x(method: default!(&str, "'sample'")) -> AccessorStdDevX {
+    let method_enum = crate::stats_agg::method_kind(method);
     unsafe {
         flatten! {
             AccessorStdDevX {
-                len: method.len().try_into().unwrap(),
-                bytes: method.as_bytes().into(),
+                method: method_enum,
             }
         }
     }
@@ -181,9 +174,8 @@ pub fn accessor_stddev_x(method: default!(&str, "'sample'")) -> AccessorStdDevX<
 
 pg_type! {
     #[derive(Debug)]
-    struct AccessorStdDevY<'input> {
-        len: u32,
-        bytes: [u8; self.len],
+    struct AccessorStdDevY {
+        method: crate::stats_agg::Method,
     }
 }
 
@@ -191,13 +183,12 @@ pg_type! {
 ron_inout_funcs!(AccessorStdDevY);
 
 #[pg_extern(immutable, parallel_safe, name = "stddev_y")]
-pub fn accessor_stddev_y(method: default!(&str, "'sample'")) -> AccessorStdDevY<'static> {
-    let _ = crate::stats_agg::method_kind(method);
+pub fn accessor_stddev_y(method: default!(&str, "'sample'")) -> AccessorStdDevY {
+    let method_enum = crate::stats_agg::method_kind(method);
     unsafe {
         flatten! {
             AccessorStdDevY {
-                len: method.len().try_into().unwrap(),
-                bytes: method.as_bytes().into(),
+                method: method_enum,
             }
         }
     }
@@ -205,9 +196,8 @@ pub fn accessor_stddev_y(method: default!(&str, "'sample'")) -> AccessorStdDevY<
 
 pg_type! {
     #[derive(Debug)]
-    struct AccessorVariance<'input> {
-        len: u32,
-        bytes: [u8; self.len],
+    struct AccessorVariance {
+        method: crate::stats_agg::Method,
     }
 }
 
@@ -215,13 +205,12 @@ pg_type! {
 ron_inout_funcs!(AccessorVariance);
 
 #[pg_extern(immutable, parallel_safe, name = "variance")]
-pub fn accessor_variance(method: default!(&str, "'sample'")) -> AccessorVariance<'static> {
-    let _ = crate::stats_agg::method_kind(method);
+pub fn accessor_variance(method: default!(&str, "'sample'")) -> AccessorVariance {
+    let method_enum = crate::stats_agg::method_kind(method);
     unsafe {
         flatten! {
             AccessorVariance {
-                len: method.len().try_into().unwrap(),
-                bytes: method.as_bytes().into(),
+                method: method_enum,
             }
         }
     }
@@ -229,9 +218,8 @@ pub fn accessor_variance(method: default!(&str, "'sample'")) -> AccessorVariance
 
 pg_type! {
     #[derive(Debug)]
-    struct AccessorVarianceX<'input> {
-        len: u32,
-        bytes: [u8; self.len],
+    struct AccessorVarianceX {
+        method: crate::stats_agg::Method,
     }
 }
 
@@ -239,13 +227,12 @@ pg_type! {
 ron_inout_funcs!(AccessorVarianceX);
 
 #[pg_extern(immutable, parallel_safe, name = "variance_x")]
-pub fn accessor_variance_x(method: default!(&str, "'sample'")) -> AccessorVarianceX<'static> {
-    let _ = crate::stats_agg::method_kind(method);
+pub fn accessor_variance_x(method: default!(&str, "'sample'")) -> AccessorVarianceX {
+    let method_enum = crate::stats_agg::method_kind(method);
     unsafe {
         flatten! {
             AccessorVarianceX {
-                len: method.len().try_into().unwrap(),
-                bytes: method.as_bytes().into(),
+                method: method_enum,
             }
         }
     }
@@ -253,9 +240,8 @@ pub fn accessor_variance_x(method: default!(&str, "'sample'")) -> AccessorVarian
 
 pg_type! {
     #[derive(Debug)]
-    struct AccessorVarianceY<'input> {
-        len: u32,
-        bytes: [u8; self.len],
+    struct AccessorVarianceY {
+        method: crate::stats_agg::Method,
     }
 }
 
@@ -263,13 +249,12 @@ pg_type! {
 ron_inout_funcs!(AccessorVarianceY);
 
 #[pg_extern(immutable, parallel_safe, name = "variance_y")]
-pub fn accessor_variance_y(method: default!(&str, "'sample'")) -> AccessorVarianceY<'static> {
-    let _ = crate::stats_agg::method_kind(method);
+pub fn accessor_variance_y(method: default!(&str, "'sample'")) -> AccessorVarianceY {
+    let method_enum = crate::stats_agg::method_kind(method);
     unsafe {
         flatten! {
             AccessorVarianceY {
-                len: method.len().try_into().unwrap(),
-                bytes: method.as_bytes().into(),
+                method: method_enum,
             }
         }
     }
@@ -277,22 +262,21 @@ pub fn accessor_variance_y(method: default!(&str, "'sample'")) -> AccessorVarian
 
 pg_type! {
     #[derive(Debug)]
-    struct AccessorSkewness<'input>  {
-        len: u32,
-        bytes: [u8; self.len],
+    struct AccessorSkewness {
+        method: crate::stats_agg::Method,
     }
 }
 
+//FIXME string IO
 ron_inout_funcs!(AccessorSkewness);
 
 #[pg_extern(immutable, parallel_safe, name = "skewness")]
-pub fn accessor_skewness(method: default!(&str, "'sample'")) -> AccessorSkewness<'static> {
-    let _ = crate::stats_agg::method_kind(method);
+pub fn accessor_skewness(method: default!(&str, "'sample'")) -> AccessorSkewness {
+    let method_enum = crate::stats_agg::method_kind(method);
     unsafe {
         flatten! {
             AccessorSkewness {
-                len: method.len().try_into().unwrap(),
-                bytes: method.as_bytes().into(),
+                method: method_enum,
             }
         }
     }
@@ -300,22 +284,21 @@ pub fn accessor_skewness(method: default!(&str, "'sample'")) -> AccessorSkewness
 
 pg_type! {
     #[derive(Debug)]
-    struct AccessorSkewnessX<'input>  {
-        len: u32,
-        bytes: [u8; self.len],
+    struct AccessorSkewnessX {
+        method: crate::stats_agg::Method,
     }
 }
 
+//FIXME string IO
 ron_inout_funcs!(AccessorSkewnessX);
 
 #[pg_extern(immutable, parallel_safe, name = "skewness_x")]
-pub fn accessor_skewness_x(method: default!(&str, "'sample'")) -> AccessorSkewnessX<'static> {
-    let _ = crate::stats_agg::method_kind(method);
+pub fn accessor_skewness_x(method: default!(&str, "'sample'")) -> AccessorSkewnessX {
+    let method_enum = crate::stats_agg::method_kind(method);
     unsafe {
         flatten! {
             AccessorSkewnessX {
-                len: method.len().try_into().unwrap(),
-                bytes: method.as_bytes().into(),
+                method: method_enum,
             }
         }
     }
@@ -323,22 +306,21 @@ pub fn accessor_skewness_x(method: default!(&str, "'sample'")) -> AccessorSkewne
 
 pg_type! {
     #[derive(Debug)]
-    struct AccessorSkewnessY<'input>  {
-        len: u32,
-        bytes: [u8; self.len],
+    struct AccessorSkewnessY {
+        method: crate::stats_agg::Method,
     }
 }
 
+//FIXME string IO
 ron_inout_funcs!(AccessorSkewnessY);
 
 #[pg_extern(immutable, parallel_safe, name = "skewness_y")]
-pub fn accessor_skewness_y(method: default!(&str, "'sample'")) -> AccessorSkewnessY<'static> {
-    let _ = crate::stats_agg::method_kind(method);
+pub fn accessor_skewness_y(method: default!(&str, "'sample'")) -> AccessorSkewnessY {
+    let method_enum = crate::stats_agg::method_kind(method);
     unsafe {
         flatten! {
             AccessorSkewnessY {
-                len: method.len().try_into().unwrap(),
-                bytes: method.as_bytes().into(),
+                method: method_enum,
             }
         }
     }
@@ -346,22 +328,21 @@ pub fn accessor_skewness_y(method: default!(&str, "'sample'")) -> AccessorSkewne
 
 pg_type! {
     #[derive(Debug)]
-    struct AccessorKurtosis<'input>  {
-        len: u32,
-        bytes: [u8; self.len],
+    struct AccessorKurtosis {
+        method: crate::stats_agg::Method,
     }
 }
 
+//FIXME string IO
 ron_inout_funcs!(AccessorKurtosis);
 
 #[pg_extern(immutable, parallel_safe, name = "kurtosis")]
-pub fn accessor_kurtosis(method: default!(&str, "'sample'")) -> AccessorKurtosis<'static> {
-    let _ = crate::stats_agg::method_kind(method);
+pub fn accessor_kurtosis(method: default!(&str, "'sample'")) -> AccessorKurtosis {
+    let method_enum = crate::stats_agg::method_kind(method);
     unsafe {
         flatten! {
             AccessorKurtosis {
-                len: method.len().try_into().unwrap(),
-                bytes: method.as_bytes().into(),
+                method: method_enum,
             }
         }
     }
@@ -369,22 +350,21 @@ pub fn accessor_kurtosis(method: default!(&str, "'sample'")) -> AccessorKurtosis
 
 pg_type! {
     #[derive(Debug)]
-    struct AccessorKurtosisX<'input>  {
-        len: u32,
-        bytes: [u8; self.len],
+    struct AccessorKurtosisX {
+        method: crate::stats_agg::Method,
     }
 }
 
+//FIXME string IO
 ron_inout_funcs!(AccessorKurtosisX);
 
 #[pg_extern(immutable, parallel_safe, name = "kurtosis_x")]
-pub fn accessor_kurtosis_x(method: default!(&str, "'sample'")) -> AccessorKurtosisX<'static> {
-    let _ = crate::stats_agg::method_kind(method);
+pub fn accessor_kurtosis_x(method: default!(&str, "'sample'")) -> AccessorKurtosisX {
+    let method_enum = crate::stats_agg::method_kind(method);
     unsafe {
         flatten! {
             AccessorKurtosisX {
-                len: method.len().try_into().unwrap(),
-                bytes: method.as_bytes().into(),
+                method: method_enum,
             }
         }
     }
@@ -392,22 +372,21 @@ pub fn accessor_kurtosis_x(method: default!(&str, "'sample'")) -> AccessorKurtos
 
 pg_type! {
     #[derive(Debug)]
-    struct AccessorKurtosisY<'input>  {
-        len: u32,
-        bytes: [u8; self.len],
+    struct AccessorKurtosisY {
+        method: crate::stats_agg::Method,
     }
 }
 
+//FIXME string IO
 ron_inout_funcs!(AccessorKurtosisY);
 
 #[pg_extern(immutable, parallel_safe, name = "kurtosis_y")]
-pub fn accessor_kurtosis_y(method: default!(&str, "'sample'")) -> AccessorKurtosisY<'static> {
-    let _ = crate::stats_agg::method_kind(method);
+pub fn accessor_kurtosis_y(method: default!(&str, "'sample'")) -> AccessorKurtosisY {
+    let method_enum = crate::stats_agg::method_kind(method);
     unsafe {
         flatten! {
             AccessorKurtosisY {
-                len: method.len().try_into().unwrap(),
-                bytes: method.as_bytes().into(),
+                method: method_enum,
             }
         }
     }
@@ -415,23 +394,21 @@ pub fn accessor_kurtosis_y(method: default!(&str, "'sample'")) -> AccessorKurtos
 
 pg_type! {
     #[derive(Debug)]
-    struct AccessorCovar<'input> {
-        len: u32,
-        bytes: [u8; self.len],
+    struct AccessorCovar {
+        method: crate::stats_agg::Method,
     }
 }
 
-// FIXME string IO
+//FIXME string IO
 ron_inout_funcs!(AccessorCovar);
 
 #[pg_extern(immutable, parallel_safe, name = "covariance")]
-pub fn accessor_covar(method: default!(&str, "'sample'")) -> AccessorCovar<'static> {
-    let _ = crate::stats_agg::method_kind(method);
+pub fn accessor_covar(method: default!(&str, "'sample'")) -> AccessorCovar {
+    let method_enum = crate::stats_agg::method_kind(method);
     unsafe {
         flatten! {
             AccessorCovar {
-                len: method.len().try_into().unwrap(),
-                bytes: method.as_bytes().into(),
+                method: method_enum,
             }
         }
     }
@@ -439,9 +416,8 @@ pub fn accessor_covar(method: default!(&str, "'sample'")) -> AccessorCovar<'stat
 
 pg_type! {
     #[derive(Debug)]
-    struct AccessorExtrapolatedDelta<'input> {
-        len: u32,
-        bytes: [u8; self.len],
+    struct AccessorExtrapolatedDelta {
+        method: crate::counter_agg::Method,
     }
 }
 
@@ -449,13 +425,12 @@ pg_type! {
 ron_inout_funcs!(AccessorExtrapolatedDelta);
 
 #[pg_extern(immutable, parallel_safe, name = "extrapolated_delta")]
-pub fn accessor_extrapolated_delta(method: &str) -> AccessorExtrapolatedDelta<'static> {
-    let _ = crate::counter_agg::method_kind(method);
+pub fn accessor_extrapolated_delta(method: &str) -> AccessorExtrapolatedDelta {
+    let method_enum = crate::counter_agg::method_kind(method);
     unsafe {
         flatten! {
             AccessorExtrapolatedDelta {
-                len: method.len().try_into().unwrap(),
-                bytes: method.as_bytes().into(),
+                method: method_enum,
             }
         }
     }
@@ -463,9 +438,8 @@ pub fn accessor_extrapolated_delta(method: &str) -> AccessorExtrapolatedDelta<'s
 
 pg_type! {
     #[derive(Debug)]
-    struct AccessorExtrapolatedRate<'input> {
-        len: u32,
-        bytes: [u8; self.len],
+    struct AccessorExtrapolatedRate {
+        method: crate::counter_agg::Method,
     }
 }
 
@@ -473,13 +447,12 @@ pg_type! {
 ron_inout_funcs!(AccessorExtrapolatedRate);
 
 #[pg_extern(immutable, parallel_safe, name = "extrapolated_rate")]
-pub fn accessor_extrapolated_rate(method: &str) -> AccessorExtrapolatedRate<'static> {
-    let _ = crate::counter_agg::method_kind(method);
+pub fn accessor_extrapolated_rate(method: &str) -> AccessorExtrapolatedRate {
+    let method_enum = crate::counter_agg::method_kind(method);
     unsafe {
         flatten! {
             AccessorExtrapolatedRate {
-                len: method.len().try_into().unwrap(),
-                bytes: method.as_bytes().into(),
+                method: method_enum,
             }
         }
     }
@@ -499,7 +472,7 @@ pg_type! {
 ron_inout_funcs!(AccessorWithBounds);
 
 #[pg_extern(immutable, parallel_safe, name = "with_bounds")]
-pub fn accessor_with_bounds(bounds: crate::raw::tstzrange) -> AccessorWithBounds<'static> {
+pub fn accessor_with_bounds(bounds: crate::raw::tstzrange) -> AccessorWithBounds {
     let range = unsafe { crate::range::get_range(bounds.0.cast_mut_ptr()) };
     let mut accessor = build! {
         AccessorWithBounds {
@@ -526,7 +499,7 @@ pub fn accessor_with_bounds(bounds: crate::raw::tstzrange) -> AccessorWithBounds
     accessor
 }
 
-impl AccessorWithBounds<'_> {
+impl AccessorWithBounds {
     pub fn bounds(&self) -> Option<I64Range> {
         if self.range_null != 0 {
             return None;
@@ -551,7 +524,7 @@ ron_inout_funcs!(AccessorUnnest);
 // Note that this should be able to replace the timescale_experimental.unnest function
 // and related object in src/timevector/pipeline/expansion.rs
 #[pg_extern(immutable, parallel_safe, name = "unnest")]
-pub fn accessor_unnest() -> AccessorUnnest<'static> {
+pub fn accessor_unnest() -> AccessorUnnest {
     build! {
         AccessorUnnest {
         }
@@ -560,9 +533,9 @@ pub fn accessor_unnest() -> AccessorUnnest<'static> {
 
 pg_type! {
     #[derive(Debug)]
-    struct AccessorIntegral<'input> {
-        len: u32,
-        bytes: [u8; self.len],
+    struct AccessorIntegral {
+        len: u8,
+        bytes: [u8; 16],
     }
 }
 
@@ -570,12 +543,23 @@ pg_type! {
 ron_inout_funcs!(AccessorIntegral);
 
 #[pg_extern(immutable, parallel_safe, name = "integral")]
-pub fn accessor_integral(unit: default!(&str, "'second'")) -> AccessorIntegral<'static> {
+pub fn accessor_integral(unit: default!(&str, "'second'")) -> AccessorIntegral {
+    if unit.len() > 16 {
+        pgrx::error!(
+            "Time unit string too long: {} characters (max 16)",
+            unit.len()
+        );
+    }
+
+    let mut bytes = [0u8; 16];
+    let unit_bytes = unit.as_bytes();
+    bytes[..unit_bytes.len()].copy_from_slice(unit_bytes);
+
     unsafe {
         flatten! {
             AccessorIntegral {
-                len: unit.len().try_into().unwrap(),
-                bytes: unit.as_bytes().into(),
+                len: unit.len() as u8,
+                bytes,
             }
         }
     }
@@ -592,7 +576,7 @@ pg_type! {
 ron_inout_funcs!(AccessorTopNCount);
 
 #[pg_extern(immutable, parallel_safe, name = "topn")]
-pub fn accessor_topn_count(count: i64) -> AccessorTopNCount<'static> {
+pub fn accessor_topn_count(count: i64) -> AccessorTopNCount {
     unsafe {
         flatten! {
             AccessorTopNCount {
@@ -612,7 +596,7 @@ pg_type! {
 ron_inout_funcs!(AccessorMaxFrequencyInt);
 
 #[pg_extern(immutable, parallel_safe, name = "max_frequency")]
-pub fn accessor_max_frequency_int(value: i64) -> AccessorMaxFrequencyInt<'static> {
+pub fn accessor_max_frequency_int(value: i64) -> AccessorMaxFrequencyInt {
     unsafe {
         flatten! {
             AccessorMaxFrequencyInt {
@@ -632,7 +616,7 @@ pg_type! {
 ron_inout_funcs!(AccessorMinFrequencyInt);
 
 #[pg_extern(immutable, parallel_safe, name = "min_frequency")]
-pub fn accessor_min_frequency_int(value: i64) -> AccessorMinFrequencyInt<'static> {
+pub fn accessor_min_frequency_int(value: i64) -> AccessorMinFrequencyInt {
     unsafe {
         flatten! {
             AccessorMinFrequencyInt {
@@ -643,21 +627,31 @@ pub fn accessor_min_frequency_int(value: i64) -> AccessorMinFrequencyInt<'static
 }
 
 pg_type! {
-    struct AccessorPercentileArray<'input> {
+    #[derive(Debug)]
+    struct AccessorPercentileArray {
         len: u64,
-        percentile: [f64; self.len],
+        percentile: [f64; 32],
     }
 }
 
 ron_inout_funcs!(AccessorPercentileArray);
 
 #[pg_extern(immutable, name = "approx_percentiles")]
-pub fn accessor_percentiles(unit: Vec<f64>) -> AccessorPercentileArray<'static> {
+pub fn accessor_percentiles(unit: Vec<f64>) -> AccessorPercentileArray {
+    if unit.len() > 32 {
+        pgrx::error!("Too many percentiles: {} (max 32)", unit.len());
+    }
+
+    let mut percentile = [0.0f64; 32];
+    for (i, &val) in unit.iter().enumerate() {
+        percentile[i] = val;
+    }
+
     unsafe {
         flatten! {
-            AccessorPercentileArray{
-                len: unit.len().try_into().unwrap(),
-                percentile: unit.into(),
+            AccessorPercentileArray {
+                len: unit.len() as u64,
+                percentile,
             }
         }
     }

--- a/extension/src/aggregate_builder_tests.rs
+++ b/extension/src/aggregate_builder_tests.rs
@@ -87,13 +87,13 @@ mod tests {
 
     #[pg_test]
     fn test_anything_in_experimental_and_returns_first() {
-        Spi::connect(|mut client| {
+        Spi::connect_mut(|client| {
             let output = client
                 .update(
                     "SELECT toolkit_experimental.anything(val) \
                 FROM (VALUES ('foo'), ('bar'), ('baz')) as v(val)",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -105,8 +105,8 @@ mod tests {
 
     #[pg_test]
     fn test_anything_has_correct_fn_names_and_def() {
-        Spi::connect(|mut client| {
-            let spec = get_aggregate_spec(&mut client, "anything");
+        Spi::connect_mut(|client| {
+            let spec = get_aggregate_spec(client, "anything");
             // output is
             //   fn kind (`a`), volatility, parallel-safety, num args, final fn modify (is this right?)
             //   transition type (`internal`)
@@ -133,8 +133,8 @@ mod tests {
 
     #[pg_test]
     fn test_cagg_anything_has_correct_fn_names_and_def() {
-        Spi::connect(|mut client| {
-            let spec = get_aggregate_spec(&mut client, "cagg_anything");
+        Spi::connect_mut(|client| {
+            let spec = get_aggregate_spec(client, "cagg_anything");
             // output is
             //   fn kind (`a`), volatility, parallel-safety, num args, final fn modify (is this right?)
             //   transition type (`internal`)
@@ -161,8 +161,8 @@ mod tests {
 
     #[pg_test]
     fn test_parallel_anything_has_correct_fn_names_and_def() {
-        Spi::connect(|mut client| {
-            let spec = get_aggregate_spec(&mut client, "parallel_anything");
+        Spi::connect_mut(|client| {
+            let spec = get_aggregate_spec(client, "parallel_anything");
             // output is
             //   fn kind (`a`), volatility, parallel-safety, num args, final fn modify (is this right?)
             //   transition type (`internal`)
@@ -208,12 +208,11 @@ mod tests {
                 aggdeserialfn,
                 aggcombinefn)::TEXT
             FROM pg_proc, pg_aggregate
-            WHERE proname = '{}'
-              AND pg_proc.oid = aggfnoid;"#,
-                    aggregate_name
+            WHERE proname = '{aggregate_name}'
+              AND pg_proc.oid = aggfnoid;"#
                 ),
                 None,
-                None,
+                &[],
             )
             .unwrap()
             .first()

--- a/extension/src/asap.rs
+++ b/extension/src/asap.rs
@@ -202,8 +202,8 @@ mod tests {
     fn test_against_reference() {
         // Test our ASAP implementation against the reference implementation at http://www.futuredata.io.s3-website-us-west-2.amazonaws.com/asap/
         // The sample data is the first 100 points of the second sample data set.  Note that the dates are not important for this test.
-        Spi::connect(|mut client| {
-            client.update("SET timezone TO 'UTC'", None, None).unwrap();
+        Spi::connect_mut(|client| {
+            client.update("SET timezone TO 'UTC'", None, &[]).unwrap();
             let mut result = client.update(
                 "
                 SELECT value
@@ -223,7 +223,7 @@ mod tests {
                     ) AS v(i, val)
                 )) s",
                 None,
-                None).unwrap();
+            &[]).unwrap();
 
             assert_relative_eq!(
                 result.next().unwrap()[1].value::<f64>().unwrap().unwrap() as f32,
@@ -271,7 +271,7 @@ mod tests {
 
     #[pg_test]
     fn test_asap_equivalence() {
-        Spi::connect(|mut client| {
+        Spi::connect_mut(|client| {
             let mut value_result = client.update(
                 "
                 SELECT time::text, value
@@ -291,7 +291,7 @@ mod tests {
                     ) AS v(i, val)
                 )) s",
                 None,
-                None).unwrap();
+            &[]).unwrap();
 
             let mut tvec_result = client.update(
                 "
@@ -314,7 +314,7 @@ mod tests {
                     ), 10)
                 ))",
                 None,
-                None).unwrap();
+            &[]).unwrap();
 
             for _ in 0..10 {
                 let v = value_result.next().unwrap();

--- a/extension/src/counter_agg/accessors.rs
+++ b/extension/src/counter_agg/accessors.rs
@@ -21,13 +21,13 @@ pg_type! {
 ron_inout_funcs!(CounterInterpolatedRateAccessor);
 
 #[pg_extern(immutable, parallel_safe, name = "interpolated_rate")]
-fn counter_interpolated_rate_accessor<'a>(
+fn counter_interpolated_rate_accessor(
     start: crate::raw::TimestampTz,
     duration: crate::raw::Interval,
-    prev: Option<CounterSummary<'a>>,
-    next: Option<CounterSummary<'a>>,
-) -> CounterInterpolatedRateAccessor<'static> {
-    fn empty_summary<'b>() -> Option<CounterSummary<'b>> {
+    prev: Option<CounterSummary>,
+    next: Option<CounterSummary>,
+) -> CounterInterpolatedRateAccessor {
+    fn empty_summary() -> Option<CounterSummary> {
         let tmp = TSPoint { ts: 0, val: 0.0 };
         let tmp = MetricSummary::new(&tmp, None);
         let tmp = CounterSummary::from_internal_counter_summary(tmp);
@@ -62,13 +62,13 @@ pg_type! {
 ron_inout_funcs!(CounterInterpolatedDeltaAccessor);
 
 #[pg_extern(immutable, parallel_safe, name = "interpolated_delta")]
-fn counter_interpolated_delta_accessor<'a>(
+fn counter_interpolated_delta_accessor(
     start: crate::raw::TimestampTz,
     duration: crate::raw::Interval,
-    prev: Option<CounterSummary<'a>>,
-    next: Option<CounterSummary<'a>>,
-) -> CounterInterpolatedDeltaAccessor<'static> {
-    fn empty_summary<'b>() -> Option<CounterSummary<'b>> {
+    prev: Option<CounterSummary>,
+    next: Option<CounterSummary>,
+) -> CounterInterpolatedDeltaAccessor {
+    fn empty_summary() -> Option<CounterSummary> {
         let tmp = TSPoint { ts: 0, val: 0.0 };
         let tmp = MetricSummary::new(&tmp, None);
         let tmp = CounterSummary::from_internal_counter_summary(tmp);

--- a/extension/src/heartbeat_agg/accessors.rs
+++ b/extension/src/heartbeat_agg/accessors.rs
@@ -27,7 +27,7 @@ pg_type! {
     }
 }
 
-ron_inout_funcs!(HeartbeatInterpolatedUptimeAccessor);
+ron_inout_funcs!(HeartbeatInterpolatedUptimeAccessor<'input>);
 
 #[pg_extern(immutable, parallel_safe, name = "interpolated_uptime")]
 fn heartbeat_agg_interpolated_uptime_accessor<'a>(
@@ -61,7 +61,7 @@ pg_type! {
     }
 }
 
-ron_inout_funcs!(HeartbeatInterpolatedDowntimeAccessor);
+ron_inout_funcs!(HeartbeatInterpolatedDowntimeAccessor<'input>);
 
 #[pg_extern(immutable, parallel_safe, name = "interpolated_downtime")]
 fn heartbeat_agg_interpolated_downtime_accessor<'a>(
@@ -95,7 +95,7 @@ pg_type! {
     }
 }
 
-ron_inout_funcs!(HeartbeatInterpolateAccessor);
+ron_inout_funcs!(HeartbeatInterpolateAccessor<'input>);
 
 #[pg_extern(immutable, parallel_safe, name = "interpolate")]
 fn heartbeat_agg_interpolate_accessor<'a>(
@@ -138,7 +138,7 @@ ron_inout_funcs!(HeartbeatTrimToAccessor);
 fn heartbeat_agg_trim_to_accessor(
     start: crate::raw::TimestampTz,
     duration: default!(Option<crate::raw::Interval>, "NULL"),
-) -> HeartbeatTrimToAccessor<'static> {
+) -> HeartbeatTrimToAccessor {
     let end = duration
         .map(|intv| crate::datum_utils::ts_interval_sum_to_ms(&start, &intv))
         .unwrap_or(0);

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -47,6 +47,8 @@ mod pg_any_element;
 mod raw;
 mod stabilization_info;
 mod stabilization_tests;
+
+#[macro_use]
 mod type_builder;
 
 #[cfg(any(test, feature = "pg_test"))]
@@ -57,7 +59,7 @@ use pgrx::*;
 pgrx::pg_module_magic!();
 
 #[pg_guard]
-pub extern "C" fn _PG_init() {
+pub extern "C-unwind" fn _PG_init() {
     // Nothing to do here
 }
 

--- a/extension/src/lttb.rs
+++ b/extension/src/lttb.rs
@@ -436,24 +436,24 @@ mod tests {
 
     #[pg_test]
     fn test_lttb_equivalence() {
-        Spi::connect(|mut client| {
+        Spi::connect_mut(|client| {
             client
                 .update(
                     "CREATE TABLE test(time TIMESTAMPTZ, value DOUBLE PRECISION);",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
             client.update(
                 "INSERT INTO test
                 SELECT time, value
-                FROM toolkit_experimental.generate_periodic_normal_series('2020-01-01 UTC'::timestamptz, NULL);", None, None).unwrap();
+                FROM toolkit_experimental.generate_periodic_normal_series('2020-01-01 UTC'::timestamptz, NULL);", None, &[]).unwrap();
 
             client
                 .update(
                     "CREATE TABLE results1(time TIMESTAMPTZ, value DOUBLE PRECISION);",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
             client
@@ -464,7 +464,7 @@ mod tests {
                     (SELECT lttb(time, value, 100) FROM test)
                 );",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
 
@@ -472,7 +472,7 @@ mod tests {
                 .update(
                     "CREATE TABLE results2(time TIMESTAMPTZ, value DOUBLE PRECISION);",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
             client
@@ -485,12 +485,12 @@ mod tests {
                     )
                 );",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
 
             let delta = client
-                .update("SELECT count(*)  FROM results1 r1 FULL OUTER JOIN results2 r2 ON r1 = r2 WHERE r1 IS NULL OR r2 IS NULL;" , None, None)
+                .update("SELECT count(*)  FROM results1 r1 FULL OUTER JOIN results2 r2 ON r1 = r2 WHERE r1 IS NULL OR r2 IS NULL;" , None, &[])
                 .unwrap().first()
                 .get_one::<i64>().unwrap();
             assert_eq!(delta.unwrap(), 0);
@@ -499,8 +499,8 @@ mod tests {
 
     #[pg_test]
     fn test_lttb_result() {
-        Spi::connect(|mut client| {
-            client.update("SET timezone TO 'UTC'", None, None).unwrap();
+        Spi::connect_mut(|client| {
+            client.update("SET timezone TO 'UTC'", None, &[]).unwrap();
             let mut result = client
                 .update(
                     r#"SELECT unnest(lttb(ts, val, 5))::TEXT
@@ -518,7 +518,7 @@ mod tests {
                     ('2020-1-11'::timestamptz, 14)
                 ) AS v(ts, val)"#,
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
 
@@ -548,8 +548,8 @@ mod tests {
 
     #[pg_test]
     fn test_gp_lttb() {
-        Spi::connect(|mut client| {
-            client.update("SET timezone TO 'UTC'", None, None).unwrap();
+        Spi::connect_mut(|client| {
+            client.update("SET timezone TO 'UTC'", None, &[]).unwrap();
             let mut result = client
                 .update(
                     r#"SELECT unnest(toolkit_experimental.gp_lttb(ts, val, 7))::TEXT
@@ -567,7 +567,7 @@ mod tests {
                     ('2020-3-11'::timestamptz, 14)
                 ) AS v(ts, val)"#,
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
 
@@ -605,8 +605,8 @@ mod tests {
 
     #[pg_test]
     fn test_gp_lttb_with_gap() {
-        Spi::connect(|mut client| {
-            client.update("SET timezone TO 'UTC'", None, None).unwrap();
+        Spi::connect_mut(|client| {
+            client.update("SET timezone TO 'UTC'", None, &[]).unwrap();
             let mut result = client
                 .update(
                     r#"SELECT unnest(toolkit_experimental.gp_lttb(ts, val, '36hr', 5))::TEXT
@@ -622,7 +622,7 @@ mod tests {
                     ('2020-3-11'::timestamptz, 14)
                 ) AS v(ts, val)"#,
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
 

--- a/extension/src/nmost/min_by_float.rs
+++ b/extension/src/nmost/min_by_float.rs
@@ -20,7 +20,7 @@ pg_type! {
         data: DatumStore<'input>,
     }
 }
-ron_inout_funcs!(MinByFloats);
+ron_inout_funcs!(MinByFloats<'input>);
 
 impl<'input> From<MinByFloatTransType> for MinByFloats<'input> {
     fn from(item: MinByFloatTransType) -> Self {
@@ -139,13 +139,13 @@ mod tests {
 
     #[pg_test]
     fn min_by_float_correctness() {
-        Spi::connect(|mut client| {
-            client.update("SET timezone TO 'UTC'", None, None).unwrap();
+        Spi::connect_mut(|client| {
+            client.update("SET timezone TO 'UTC'", None, &[]).unwrap();
             client
                 .update(
                     "CREATE TABLE data(val DOUBLE PRECISION, category INT)",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
 
@@ -156,7 +156,7 @@ mod tests {
                     .update(
                         &format!("INSERT INTO data VALUES ({}.0/128, {})", i, i % 4),
                         None,
-                        None,
+                        &[],
                     )
                     .unwrap();
             }
@@ -166,7 +166,7 @@ mod tests {
                 .update(
                     "SELECT into_values(min_n_by(val, data, 3), NULL::data)::TEXT from data",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
             assert_eq!(
@@ -188,7 +188,7 @@ mod tests {
                 client.update(
                     "WITH aggs as (SELECT category, min_n_by(val, data, 5) as agg from data GROUP BY category)
                         SELECT into_values(rollup(agg), NULL::data)::TEXT FROM aggs",
-                        None, None,
+                        None, &[],
                     ).unwrap();
             assert_eq!(
                 result.next().unwrap()[1].value().unwrap(),

--- a/extension/src/nmost/min_by_time.rs
+++ b/extension/src/nmost/min_by_time.rs
@@ -18,7 +18,7 @@ pg_type! {
         data: DatumStore<'input>,
     }
 }
-ron_inout_funcs!(MinByTimes);
+ron_inout_funcs!(MinByTimes<'input>);
 
 impl<'input> From<MinByTimeTransType> for MinByTimes<'input> {
     fn from(item: MinByTimeTransType) -> Self {
@@ -133,13 +133,13 @@ mod tests {
 
     #[pg_test]
     fn min_by_time_correctness() {
-        Spi::connect(|mut client| {
-            client.update("SET timezone TO 'UTC'", None, None).unwrap();
+        Spi::connect_mut(|client| {
+            client.update("SET timezone TO 'UTC'", None, &[]).unwrap();
             client
                 .update(
                     "CREATE TABLE data(val TIMESTAMPTZ, category INT)",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
 
@@ -149,7 +149,7 @@ mod tests {
                 client.update(
                     &format!("INSERT INTO data VALUES ('2020-1-1 UTC'::timestamptz + {} * '1d'::interval, {})", i, i % 4),
                     None,
-                    None,
+                    &[]
                 ).unwrap();
             }
 
@@ -158,7 +158,7 @@ mod tests {
                 .update(
                     "SELECT into_values(min_n_by(val, data, 3), NULL::data)::TEXT from data",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
             assert_eq!(
@@ -180,7 +180,7 @@ mod tests {
                 client.update(
                     "WITH aggs as (SELECT category, min_n_by(val, data, 5) as agg from data GROUP BY category)
                         SELECT into_values(rollup(agg), NULL::data)::TEXT FROM aggs",
-                        None, None,
+                        None, &[],
                     ).unwrap();
             assert_eq!(
                 result.next().unwrap()[1].value().unwrap(),

--- a/extension/src/nmost/min_int.rs
+++ b/extension/src/nmost/min_int.rs
@@ -21,7 +21,7 @@ pg_type! {
         values : [i64; self.elements],
     }
 }
-ron_inout_funcs!(MinInts);
+ron_inout_funcs!(MinInts<'input>);
 
 impl<'input> From<&mut MinIntTransType> for MinInts<'input> {
     fn from(item: &mut MinIntTransType) -> Self {
@@ -110,18 +110,15 @@ pub fn min_n_int_to_values(agg: MinInts<'static>) -> SetOfIterator<'static, i64>
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_min_int_into_values<'a>(
+pub fn arrow_min_int_into_values(
     agg: MinInts<'static>,
-    _accessor: AccessorIntoValues<'a>,
-) -> SetOfIterator<'a, i64> {
+    _accessor: AccessorIntoValues,
+) -> SetOfIterator<'static, i64> {
     min_n_int_to_values(agg)
 }
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_min_int_into_array<'a>(
-    agg: MinInts<'static>,
-    _accessor: AccessorIntoArray<'a>,
-) -> Vec<i64> {
+pub fn arrow_min_int_into_array(agg: MinInts<'static>, _accessor: AccessorIntoArray) -> Vec<i64> {
     min_n_int_to_array(agg)
 }
 
@@ -181,10 +178,10 @@ mod tests {
 
     #[pg_test]
     fn min_int_correctness() {
-        Spi::connect(|mut client| {
-            client.update("SET timezone TO 'UTC'", None, None).unwrap();
+        Spi::connect_mut(|client| {
+            client.update("SET timezone TO 'UTC'", None, &[]).unwrap();
             client
-                .update("CREATE TABLE data(val INT8, category INT)", None, None)
+                .update("CREATE TABLE data(val INT8, category INT)", None, &[])
                 .unwrap();
 
             for i in 0..100 {
@@ -194,21 +191,21 @@ mod tests {
                     .update(
                         &format!("INSERT INTO data VALUES ({}, {})", i, i % 4),
                         None,
-                        None,
+                        &[],
                     )
                     .unwrap();
             }
 
             // Test into_array
             let result = client
-                .update("SELECT into_array(min_n(val, 5)) from data", None, None)
+                .update("SELECT into_array(min_n(val, 5)) from data", None, &[])
                 .unwrap()
                 .first()
                 .get_one::<Vec<i64>>()
                 .unwrap();
             assert_eq!(result.unwrap(), vec![0, 1, 2, 3, 4]);
             let result = client
-                .update("SELECT min_n(val, 5)->into_array() from data", None, None)
+                .update("SELECT min_n(val, 5)->into_array() from data", None, &[])
                 .unwrap()
                 .first()
                 .get_one::<Vec<i64>>()
@@ -220,7 +217,7 @@ mod tests {
                 .update(
                     "SELECT into_values(min_n(val, 3))::TEXT from data",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
             assert_eq!(result.next().unwrap()[1].value().unwrap(), Some("0"));
@@ -231,7 +228,7 @@ mod tests {
                 .update(
                     "SELECT (min_n(val, 3)->into_values())::TEXT from data",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
             assert_eq!(result.next().unwrap()[1].value().unwrap(), Some("0"));
@@ -244,7 +241,7 @@ mod tests {
                 client.update(
                     "WITH aggs as (SELECT category, min_n(val, 5) as agg from data GROUP BY category)
                         SELECT into_array(rollup(agg)) FROM aggs",
-                        None, None,
+                        None, &[],
                     ).unwrap().first().get_one::<Vec<i64>>().unwrap();
             assert_eq!(result.unwrap(), vec![0, 1, 2, 3, 4]);
         })

--- a/extension/src/serialization.rs
+++ b/extension/src/serialization.rs
@@ -15,7 +15,7 @@ mod functions;
 mod types;
 
 // basically timestamptz_out
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn _ts_toolkit_encode_timestamptz(
     dt: pg_sys::TimestampTz,
     buf: &mut [c_char; pg_sys::MAXDATELEN as _],
@@ -51,7 +51,7 @@ pub extern "C" fn _ts_toolkit_encode_timestamptz(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 // this is only going to be used to communicate with a rust lib we compile with this one
 #[allow(improper_ctypes_definitions)]
 pub extern "C" fn _ts_toolkit_decode_timestamptz(text: &str) -> i64 {
@@ -128,17 +128,14 @@ pub extern "C" fn _ts_toolkit_decode_timestamptz(text: &str) -> i64 {
                 let err = pg_sys::tm2timestamp(tm, fsec, &mut tz, &mut result);
                 if err != 0 {
                     // TODO pgrx error with correct errcode?
-                    panic!("timestamptz \"{}\" out of range", text)
+                    panic!("timestamptz \"{text}\" out of range")
                 }
                 result
             }
             pg_sys::DTK_EPOCH => pg_sys::SetEpochTimestamp(),
             pg_sys::DTK_LATE => pg_sys::TimestampTz::MAX,
             pg_sys::DTK_EARLY => pg_sys::TimestampTz::MIN,
-            _ => panic!(
-                "unexpected result {} when parsing timestamptz \"{}\"",
-                dtype, text
-            ),
+            _ => panic!("unexpected result {dtype} when parsing timestamptz \"{text}\""),
         }
     }
 }

--- a/extension/src/serialization/collations.rs
+++ b/extension/src/serialization/collations.rs
@@ -115,7 +115,7 @@ impl Serialize for PgCollationId {
                 pg_sys::Datum::from(self.0),
             );
             if tuple.is_null() {
-                pgrx::error!("no collation info for oid {}", self.0.as_u32());
+                pgrx::error!("no collation info for oid {}", self.0.to_u32());
             }
 
             let collation_tuple: Form_pg_collation = get_struct(tuple);
@@ -124,7 +124,7 @@ impl Serialize for PgCollationId {
             if namespace.is_null() {
                 pgrx::error!(
                     "invalid schema oid {}",
-                    (*collation_tuple).collnamespace.as_u32()
+                    (*collation_tuple).collnamespace.to_u32()
                 );
             }
 
@@ -198,10 +198,7 @@ impl<'de> Deserialize<'de> for PgCollationId {
 
             let namespace_id = pg_sys::LookupExplicitNamespace(namespace.as_ptr(), true);
             if namespace_id == pg_sys::InvalidOid {
-                return Err(D::Error::custom(format!(
-                    "invalid namespace {:?}",
-                    namespace
-                )));
+                return Err(D::Error::custom(format!("invalid namespace {namespace:?}")));
             }
 
             // COLLNAMEENCNSP is based on a triple `(collname, collencoding, collnamespace)`,
@@ -239,8 +236,7 @@ impl<'de> Deserialize<'de> for PgCollationId {
                     return Ok(PgCollationId(DEFAULT_COLLATION_OID));
                 }
                 return Err(D::Error::custom(format!(
-                    "invalid collation {:?}.{:?}",
-                    namespace, name
+                    "invalid collation {namespace:?}.{name:?}"
                 )));
             }
 

--- a/extension/src/serialization/functions.rs
+++ b/extension/src/serialization/functions.rs
@@ -22,7 +22,7 @@ impl_flat_serializable!(PgProcId);
 
 // FIXME upstream to pgrx
 // TODO use this or regprocedureout()?
-extern "C" {
+unsafe extern "C" {
     pub fn format_procedure_qualified(procedure_oid: pg_sys::Oid) -> *const c_char;
 }
 
@@ -51,7 +51,7 @@ impl<'de> Deserialize<'de> for PgProcId {
         // FIXME pgrx wraps all functions in rust wrappers, which makes them
         //       uncallable with DirectFunctionCall(). Is there a way to
         //       export both?
-        extern "C" {
+        unsafe extern "C-unwind" {
             #[allow(improper_ctypes)]
             fn regprocedurein(fcinfo: pg_sys::FunctionCallInfo) -> Datum;
         }

--- a/extension/src/serialization/types.rs
+++ b/extension/src/serialization/types.rs
@@ -218,14 +218,14 @@ impl Serialize for PgTypId {
                 pg_sys::Datum::from(self.0),
             );
             if tuple.is_null() {
-                pgrx::error!("no type info for oid {}", self.0.as_u32());
+                pgrx::error!("no type info for oid {}", self.0.to_u32());
             }
 
             let type_tuple: pg_sys::Form_pg_type = get_struct(tuple);
 
             let namespace = pg_sys::get_namespace_name((*type_tuple).typnamespace);
             if namespace.is_null() {
-                pgrx::error!("invalid schema oid {}", (*type_tuple).typnamespace.as_u32());
+                pgrx::error!("invalid schema oid {}", (*type_tuple).typnamespace.to_u32());
             }
 
             let namespace_len = CStr::from_ptr(namespace).to_bytes().len();
@@ -285,10 +285,7 @@ impl<'de> Deserialize<'de> for PgTypId {
 
             let namespace_id = pg_sys::LookupExplicitNamespace(namespace.as_ptr(), true);
             if namespace_id == pg_sys::InvalidOid {
-                return Err(D::Error::custom(format!(
-                    "invalid namespace {:?}",
-                    namespace
-                )));
+                return Err(D::Error::custom(format!("invalid namespace {namespace:?}")));
             }
 
             let type_id = pg_sys::GetSysCacheOid(
@@ -301,8 +298,7 @@ impl<'de> Deserialize<'de> for PgTypId {
             );
             if type_id == pg_sys::InvalidOid {
                 return Err(D::Error::custom(format!(
-                    "invalid type {:?}.{:?}",
-                    namespace, name
+                    "invalid type {namespace:?}.{name:?}"
                 )));
             }
 

--- a/extension/src/stabilization_tests.rs
+++ b/extension/src/stabilization_tests.rs
@@ -12,7 +12,7 @@ mod tests {
     // Test that any new features are added to the the experimental schema
     #[pg_test]
     fn test_schema_qualification() {
-        Spi::connect(|mut client| {
+        Spi::connect_mut(|client| {
             let stable_functions: HashSet<String> = stable_functions();
             let stable_types: HashSet<String> = stable_types();
             let stable_operators: HashSet<String> = stable_operators();
@@ -26,7 +26,7 @@ mod tests {
                     AND deptype = 'e'
                     ORDER BY 1",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .filter_map(|row| {
@@ -146,7 +146,7 @@ mod tests {
                 return;
             }
 
-            panic!("unexpectedly released features: {:#?}", unexpected_features)
+            panic!("unexpectedly released features: {unexpected_features:#?}")
         });
     }
 

--- a/extension/src/state_aggregate/accessors.rs
+++ b/extension/src/state_aggregate/accessors.rs
@@ -1,6 +1,8 @@
 use crate::{
     datum_utils::interval_to_ms,
+    pg_type,
     raw::{Interval, TimestampTz},
+    ron_inout_funcs,
     state_aggregate::*,
 };
 
@@ -12,7 +14,7 @@ pg_type! {
         prev_present: bool,
     }
 }
-ron_inout_funcs!(AccessorInterpolatedStateTimeline);
+ron_inout_funcs!(AccessorInterpolatedStateTimeline<'input>);
 
 #[pg_extern(immutable, parallel_safe, name = "interpolated_state_timeline")]
 fn accessor_state_agg_interpolated_interpolated_state_timeline<'a>(
@@ -38,7 +40,7 @@ pg_type! {
         prev_present: bool,
     }
 }
-ron_inout_funcs!(AccessorInterpolatedStateIntTimeline);
+ron_inout_funcs!(AccessorInterpolatedStateIntTimeline<'input>);
 
 #[pg_extern(immutable, parallel_safe, name = "interpolated_state_int_timeline")]
 fn accessor_state_agg_interpolated_interpolated_state_int_timeline<'a>(
@@ -68,7 +70,7 @@ pg_type! {
         prev_present: bool,
     }
 }
-ron_inout_funcs!(AccessorInterpolatedDurationIn);
+ron_inout_funcs!(AccessorInterpolatedDurationIn<'input>);
 pg_type! {
     struct AccessorInterpolatedDurationInInt<'input> {
         start: i64,
@@ -79,7 +81,7 @@ pg_type! {
         prev: StateAggData<'input>,
     }
 }
-ron_inout_funcs!(AccessorInterpolatedDurationInInt);
+ron_inout_funcs!(AccessorInterpolatedDurationInInt<'input>);
 
 #[pg_extern(immutable, parallel_safe, name = "interpolated_duration_in")]
 fn accessor_state_agg_interpolated_interpolated_duration_in<'a>(
@@ -131,7 +133,7 @@ pg_type! {
         prev_present: bool,
     }
 }
-ron_inout_funcs!(AccessorInterpolatedStatePeriods);
+ron_inout_funcs!(AccessorInterpolatedStatePeriods<'input>);
 pg_type! {
     struct AccessorInterpolatedStatePeriodsInt<'input> {
         start: i64,
@@ -142,7 +144,7 @@ pg_type! {
         prev: StateAggData<'input>,
     }
 }
-ron_inout_funcs!(AccessorInterpolatedStatePeriodsInt);
+ron_inout_funcs!(AccessorInterpolatedStatePeriodsInt<'input>);
 
 #[pg_extern(immutable, parallel_safe, name = "interpolated_state_periods")]
 fn accessor_state_agg_interpolated_interpolated_state_periods<'a>(
@@ -188,7 +190,7 @@ pg_type! {
         state_bytes: [u8; self.state_len],
     }
 }
-ron_inout_funcs!(AccessorDurationIn);
+ron_inout_funcs!(AccessorDurationIn<'input>);
 pg_type! {
     struct AccessorDurationInInt {
         state: i64,
@@ -206,7 +208,7 @@ fn accessor_state_agg_duration_in(state: String) -> AccessorDurationIn<'static> 
     }
 }
 #[pg_extern(immutable, parallel_safe, name = "duration_in")]
-fn accessor_state_agg_duration_in_int(state: i64) -> AccessorDurationInInt<'static> {
+fn accessor_state_agg_duration_in_int(state: i64) -> AccessorDurationInInt {
     crate::build! {
         AccessorDurationInInt {
             state,
@@ -220,7 +222,7 @@ pg_type! {
         state_bytes: [u8; self.state_len],
     }
 }
-ron_inout_funcs!(AccessorStatePeriods);
+ron_inout_funcs!(AccessorStatePeriods<'input>);
 pg_type! {
     struct AccessorStatePeriodsInt {
         state: i64,
@@ -238,7 +240,7 @@ fn accessor_state_agg_state_periods<'a>(state: String) -> AccessorStatePeriods<'
     }
 }
 #[pg_extern(immutable, parallel_safe, name = "state_periods")]
-fn accessor_state_agg_state_periods_int(state: i64) -> AccessorStatePeriodsInt<'static> {
+fn accessor_state_agg_state_periods_int(state: i64) -> AccessorStatePeriodsInt {
     crate::build! {
         AccessorStatePeriodsInt {
             state,
@@ -255,7 +257,7 @@ pg_type! {
         state_bytes: [u8; self.state_len],
     }
 }
-ron_inout_funcs!(AccessorDurationInRange);
+ron_inout_funcs!(AccessorDurationInRange<'input>);
 pg_type! {
     struct AccessorDurationInRangeInt {
         state: i64,
@@ -289,7 +291,7 @@ fn accessor_state_agg_duration_in_range_int(
     state: i64,
     start: TimestampTz,
     interval: default!(Option<crate::raw::Interval>, "NULL"),
-) -> AccessorDurationInRangeInt<'static> {
+) -> AccessorDurationInRangeInt {
     let interval = interval
         .map(|interval| crate::datum_utils::interval_to_ms(&start, &interval))
         .unwrap_or(NO_INTERVAL_MARKER);
@@ -310,7 +312,7 @@ pg_type! {
 ron_inout_funcs!(AccessorStateAt);
 
 #[pg_extern(immutable, parallel_safe, name = "state_at")]
-fn accessor_state_agg_state_at(time: TimestampTz) -> AccessorStateAt<'static> {
+fn accessor_state_agg_state_at(time: TimestampTz) -> AccessorStateAt {
     crate::build! {
         AccessorStateAt {
             time: time.into(),
@@ -326,7 +328,7 @@ pg_type! {
 ron_inout_funcs!(AccessorStateAtInt);
 
 #[pg_extern(immutable, parallel_safe, name = "state_at_int")]
-fn accessor_state_agg_state_at_int(time: TimestampTz) -> AccessorStateAtInt<'static> {
+fn accessor_state_agg_state_at_int(time: TimestampTz) -> AccessorStateAtInt {
     crate::build! {
         AccessorStateAtInt {
             time: time.into(),

--- a/extension/src/state_aggregate/rollup.rs
+++ b/extension/src/state_aggregate/rollup.rs
@@ -277,17 +277,17 @@ impl RollupTransState {
 }
 
 #[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
-pub fn compact_state_agg_rollup_trans<'a>(
+pub fn compact_state_agg_rollup_trans(
     state: Internal,
-    next: Option<CompactStateAgg<'a>>,
+    next: Option<CompactStateAgg>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Internal> {
     compact_state_agg_rollup_trans_inner(unsafe { state.to_inner() }, next, fcinfo).internal()
 }
 
-pub fn compact_state_agg_rollup_trans_inner<'a>(
+pub fn compact_state_agg_rollup_trans_inner(
     state: Option<Inner<RollupTransState>>,
-    next: Option<CompactStateAgg<'a>>,
+    next: Option<CompactStateAgg>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Inner<RollupTransState>> {
     unsafe {
@@ -310,9 +310,9 @@ pub fn compact_state_agg_rollup_trans_inner<'a>(
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn state_agg_rollup_trans<'a>(
+pub fn state_agg_rollup_trans(
     state: Internal,
-    next: Option<StateAgg<'a>>,
+    next: Option<StateAgg>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Internal> {
     compact_state_agg_rollup_trans_inner(
@@ -331,10 +331,10 @@ fn compact_state_agg_rollup_final(
     compact_state_agg_rollup_final_inner(unsafe { state.to_inner() }, fcinfo)
 }
 
-fn compact_state_agg_rollup_final_inner<'a>(
+fn compact_state_agg_rollup_final_inner(
     state: Option<Inner<RollupTransState>>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<CompactStateAgg<'a>> {
+) -> Option<CompactStateAgg<'static>> {
     unsafe {
         in_aggregate_context(fcinfo, || {
             let mut state = match state {
@@ -357,10 +357,10 @@ fn state_agg_rollup_final(
     state_agg_rollup_final_inner(unsafe { state.to_inner() }, fcinfo)
 }
 
-fn state_agg_rollup_final_inner<'a>(
+fn state_agg_rollup_final_inner(
     state: Option<Inner<RollupTransState>>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<StateAgg<'a>> {
+) -> Option<StateAgg<'static>> {
     unsafe {
         in_aggregate_context(fcinfo, || {
             let mut state = match state {

--- a/extension/src/stats_agg.rs
+++ b/extension/src/stats_agg.rs
@@ -1,5 +1,4 @@
 use pgrx::*;
-use twofloat::TwoFloat;
 
 use crate::{
     accessors::{
@@ -19,7 +18,8 @@ pub use stats_agg::stats1d::StatsSummary1D as InternalStatsSummary1D;
 pub use stats_agg::stats2d::StatsSummary2D as InternalStatsSummary2D;
 use stats_agg::XYPair;
 
-use self::Method::*;
+use crate::stats_agg::Method::*;
+use stats_agg::TwoFloat;
 
 use crate::raw::bytea;
 
@@ -56,7 +56,7 @@ pg_type! {
 ron_inout_funcs!(StatsSummary1D);
 ron_inout_funcs!(StatsSummary2D);
 
-impl<'input> StatsSummary1D<'input> {
+impl StatsSummary1D {
     fn to_internal(&self) -> InternalStatsSummary1D<f64> {
         InternalStatsSummary1D {
             n: self.n,
@@ -77,7 +77,7 @@ impl<'input> StatsSummary1D<'input> {
     }
 }
 
-impl<'input> StatsSummary2D<'input> {
+impl StatsSummary2D {
     fn to_internal(&self) -> InternalStatsSummary2D<f64> {
         InternalStatsSummary2D {
             n: self.n,
@@ -119,7 +119,7 @@ pub fn stats1d_trans_serialize(state: Internal) -> bytea {
 pub fn stats1d_trans_deserialize(bytes: bytea, _internal: Internal) -> Option<Internal> {
     stats1d_trans_deserialize_inner(bytes).internal()
 }
-pub fn stats1d_trans_deserialize_inner(bytes: bytea) -> Inner<StatsSummary1D<'static>> {
+pub fn stats1d_trans_deserialize_inner(bytes: bytea) -> Inner<StatsSummary1D> {
     let de: StatsSummary1D = crate::do_deserialize!(bytes, StatsSummary1DData);
     de.into()
 }
@@ -135,13 +135,13 @@ pub fn stats2d_trans_serialize(state: Internal) -> bytea {
 pub fn stats2d_trans_deserialize(bytes: bytea, _internal: Internal) -> Option<Internal> {
     stats2d_trans_deserialize_inner(bytes).internal()
 }
-pub fn stats2d_trans_deserialize_inner(bytes: bytea) -> Inner<StatsSummary2D<'static>> {
+pub fn stats2d_trans_deserialize_inner(bytes: bytea) -> Inner<StatsSummary2D> {
     let de: StatsSummary2D = crate::do_deserialize!(bytes, StatsSummary2DData);
     de.into()
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn stats1d_trans<'s>(
+pub fn stats1d_trans(
     state: Internal,
     val: Option<f64>,
     fcinfo: pg_sys::FunctionCallInfo,
@@ -149,7 +149,7 @@ pub fn stats1d_trans<'s>(
     stats1d_trans_inner(unsafe { state.to_inner() }, val, fcinfo).internal()
 }
 #[pg_extern(immutable, parallel_safe)]
-pub fn stats1d_tf_trans<'s>(
+pub fn stats1d_tf_trans(
     state: Internal,
     val: Option<f64>,
     fcinfo: pg_sys::FunctionCallInfo,
@@ -428,18 +428,18 @@ pub fn stats2d_tf_inv_trans_inner(
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn stats1d_summary_trans<'a>(
+pub fn stats1d_summary_trans(
     state: Internal,
-    value: Option<StatsSummary1D<'a>>,
+    value: Option<StatsSummary1D>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Internal> {
     stats1d_summary_trans_inner(unsafe { state.to_inner() }, value, fcinfo).internal()
 }
-pub fn stats1d_summary_trans_inner<'s>(
-    state: Option<Inner<StatsSummary1D<'s>>>,
-    value: Option<StatsSummary1D<'s>>,
+pub fn stats1d_summary_trans_inner(
+    state: Option<Inner<StatsSummary1D>>,
+    value: Option<StatsSummary1D>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<Inner<StatsSummary1D<'s>>> {
+) -> Option<Inner<StatsSummary1D>> {
     unsafe {
         in_aggregate_context(fcinfo, || match (state, value) {
             (state, None) => state,
@@ -456,18 +456,18 @@ pub fn stats1d_summary_trans_inner<'s>(
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn stats2d_summary_trans<'a>(
+pub fn stats2d_summary_trans(
     state: Internal,
-    value: Option<StatsSummary2D<'a>>,
+    value: Option<StatsSummary2D>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Internal> {
     stats2d_summary_trans_inner(unsafe { state.to_inner() }, value, fcinfo).internal()
 }
-pub fn stats2d_summary_trans_inner<'s>(
-    state: Option<Inner<StatsSummary2D<'s>>>,
-    value: Option<StatsSummary2D<'s>>,
+pub fn stats2d_summary_trans_inner(
+    state: Option<Inner<StatsSummary2D>>,
+    value: Option<StatsSummary2D>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<Inner<StatsSummary2D<'s>>> {
+) -> Option<Inner<StatsSummary2D>> {
     unsafe {
         in_aggregate_context(fcinfo, || match (state, value) {
             (state, None) => state,
@@ -484,18 +484,18 @@ pub fn stats2d_summary_trans_inner<'s>(
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn stats1d_summary_inv_trans<'a>(
+pub fn stats1d_summary_inv_trans(
     state: Internal,
-    value: Option<StatsSummary1D<'a>>,
+    value: Option<StatsSummary1D>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Internal> {
     stats1d_summary_inv_trans_inner(unsafe { state.to_inner() }, value, fcinfo).internal()
 }
-pub fn stats1d_summary_inv_trans_inner<'s>(
-    state: Option<Inner<StatsSummary1D<'s>>>,
+pub fn stats1d_summary_inv_trans_inner(
+    state: Option<Inner<StatsSummary1D>>,
     value: Option<StatsSummary1D>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<Inner<StatsSummary1D<'s>>> {
+) -> Option<Inner<StatsSummary1D>> {
     unsafe {
         in_aggregate_context(fcinfo, || match (state, &value) {
             (None, _) => panic!("Inverse function should never be called with NULL state"),
@@ -511,18 +511,18 @@ pub fn stats1d_summary_inv_trans_inner<'s>(
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn stats2d_summary_inv_trans<'a>(
+pub fn stats2d_summary_inv_trans(
     state: Internal,
-    value: Option<StatsSummary2D<'a>>,
+    value: Option<StatsSummary2D>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Internal> {
     stats2d_summary_inv_trans_inner(unsafe { state.to_inner() }, value, fcinfo).internal()
 }
-pub fn stats2d_summary_inv_trans_inner<'s>(
-    state: Option<Inner<StatsSummary2D<'s>>>,
+pub fn stats2d_summary_inv_trans_inner(
+    state: Option<Inner<StatsSummary2D>>,
     value: Option<StatsSummary2D>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<Inner<StatsSummary2D<'s>>> {
+) -> Option<Inner<StatsSummary2D>> {
     unsafe {
         in_aggregate_context(fcinfo, || match (state, &value) {
             (None, _) => panic!("Inverse function should never be called with NULL state"),
@@ -545,11 +545,11 @@ pub fn stats1d_combine(
 ) -> Option<Internal> {
     unsafe { stats1d_combine_inner(state1.to_inner(), state2.to_inner(), fcinfo).internal() }
 }
-pub fn stats1d_combine_inner<'s, 'v>(
-    state1: Option<Inner<StatsSummary1D<'s>>>,
-    state2: Option<Inner<StatsSummary1D<'v>>>,
+pub fn stats1d_combine_inner(
+    state1: Option<Inner<StatsSummary1D>>,
+    state2: Option<Inner<StatsSummary1D>>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<Inner<StatsSummary1D<'s>>> {
+) -> Option<Inner<StatsSummary1D>> {
     unsafe {
         in_aggregate_context(fcinfo, || match (state1, state2) {
             (None, None) => None,
@@ -579,11 +579,11 @@ pub fn stats2d_combine(
 ) -> Option<Internal> {
     unsafe { stats2d_combine_inner(state1.to_inner(), state2.to_inner(), fcinfo).internal() }
 }
-pub fn stats2d_combine_inner<'s, 'v>(
-    state1: Option<Inner<StatsSummary2D<'s>>>,
-    state2: Option<Inner<StatsSummary2D<'v>>>,
+pub fn stats2d_combine_inner(
+    state1: Option<Inner<StatsSummary2D>>,
+    state2: Option<Inner<StatsSummary2D>>,
     fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<Inner<StatsSummary2D<'s>>> {
+) -> Option<Inner<StatsSummary2D>> {
     unsafe {
         in_aggregate_context(fcinfo, || match (state1, state2) {
             (None, None) => None,
@@ -606,10 +606,7 @@ pub fn stats2d_combine_inner<'s, 'v>(
 }
 
 #[pg_extern(immutable, parallel_safe)]
-fn stats1d_final(
-    state: Internal,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<StatsSummary1D<'static>> {
+fn stats1d_final(state: Internal, fcinfo: pg_sys::FunctionCallInfo) -> Option<StatsSummary1D> {
     unsafe {
         in_aggregate_context(fcinfo, || match state.get() {
             None => None,
@@ -626,7 +623,7 @@ fn stats1d_tf_final(
     state: Internal,
     fcinfo: pg_sys::FunctionCallInfo,
     // return a normal stats summary here
-) -> Option<StatsSummary1D<'static>> {
+) -> Option<StatsSummary1D> {
     unsafe {
         in_aggregate_context(fcinfo, || match state.get() {
             None => None,
@@ -642,10 +639,7 @@ fn stats1d_tf_final(
 }
 
 #[pg_extern(immutable, parallel_safe)]
-fn stats2d_final(
-    state: Internal,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<StatsSummary2D<'static>> {
+fn stats2d_final(state: Internal, fcinfo: pg_sys::FunctionCallInfo) -> Option<StatsSummary2D> {
     unsafe {
         in_aggregate_context(fcinfo, || match state.get() {
             None => None,
@@ -658,10 +652,7 @@ fn stats2d_final(
 }
 
 #[pg_extern(immutable, parallel_safe)]
-fn stats2d_tf_final(
-    state: Internal,
-    fcinfo: pg_sys::FunctionCallInfo,
-) -> Option<StatsSummary2D<'static>> {
+fn stats2d_tf_final(state: Internal, fcinfo: pg_sys::FunctionCallInfo) -> Option<StatsSummary2D> {
     unsafe {
         in_aggregate_context(fcinfo, || match state.get() {
             None => None,
@@ -936,45 +927,38 @@ extension_sql!(
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats1d_average<'a>(
-    sketch: StatsSummary1D<'a>,
-    _accessor: AccessorAverage<'a>,
-) -> Option<f64> {
+pub fn arrow_stats1d_average(sketch: StatsSummary1D, _accessor: AccessorAverage) -> Option<f64> {
     stats1d_average(sketch)
 }
 
 #[pg_extern(name = "average", strict, immutable, parallel_safe)]
-pub(crate) fn stats1d_average<'a>(summary: StatsSummary1D<'a>) -> Option<f64> {
+pub(crate) fn stats1d_average(summary: StatsSummary1D) -> Option<f64> {
     summary.to_internal().avg()
 }
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats1d_sum<'a>(
-    sketch: StatsSummary1D<'a>,
-    _accessor: AccessorSum<'a>,
-) -> Option<f64> {
+pub fn arrow_stats1d_sum(sketch: StatsSummary1D, _accessor: AccessorSum) -> Option<f64> {
     stats1d_sum(sketch)
 }
 
 #[pg_extern(name = "sum", strict, immutable, parallel_safe)]
-pub(crate) fn stats1d_sum<'a>(summary: StatsSummary1D<'a>) -> Option<f64> {
+pub(crate) fn stats1d_sum(summary: StatsSummary1D) -> Option<f64> {
     summary.to_internal().sum()
 }
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats1d_stddev<'a>(
-    sketch: Option<StatsSummary1D<'a>>,
-    accessor: AccessorStdDev<'a>,
+pub fn arrow_stats1d_stddev(
+    sketch: Option<StatsSummary1D>,
+    accessor: AccessorStdDev,
 ) -> Option<f64> {
-    let method = String::from_utf8_lossy(accessor.bytes.as_slice());
-    stats1d_stddev(sketch, &method)
+    stats1d_stddev(sketch, accessor.method.as_str())
 }
 
 #[pg_extern(name = "stddev", immutable, parallel_safe)]
-fn stats1d_stddev<'a>(
-    summary: Option<StatsSummary1D<'a>>,
+fn stats1d_stddev(
+    summary: Option<StatsSummary1D>,
     method: default!(&str, "'sample'"),
 ) -> Option<f64> {
     match method_kind(method) {
@@ -985,17 +969,16 @@ fn stats1d_stddev<'a>(
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats1d_variance<'a>(
-    sketch: Option<StatsSummary1D<'a>>,
-    accessor: AccessorVariance<'a>,
+pub fn arrow_stats1d_variance(
+    sketch: Option<StatsSummary1D>,
+    accessor: AccessorVariance,
 ) -> Option<f64> {
-    let method = String::from_utf8_lossy(accessor.bytes.as_slice());
-    stats1d_variance(sketch, &method)
+    stats1d_variance(sketch, accessor.method.as_str())
 }
 
 #[pg_extern(name = "variance", immutable, parallel_safe)]
-fn stats1d_variance<'a>(
-    summary: Option<StatsSummary1D<'a>>,
+fn stats1d_variance(
+    summary: Option<StatsSummary1D>,
     method: default!(&str, "'sample'"),
 ) -> Option<f64> {
     match method_kind(method) {
@@ -1006,19 +989,12 @@ fn stats1d_variance<'a>(
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats1d_skewness<'a>(
-    sketch: StatsSummary1D<'a>,
-    accessor: AccessorSkewness<'a>,
-) -> Option<f64> {
-    let method = String::from_utf8_lossy(accessor.bytes.as_slice());
-    stats1d_skewness(sketch, &method)
+pub fn arrow_stats1d_skewness(sketch: StatsSummary1D, accessor: AccessorSkewness) -> Option<f64> {
+    stats1d_skewness(sketch, accessor.method.as_str())
 }
 
 #[pg_extern(name = "skewness", immutable, parallel_safe)]
-fn stats1d_skewness<'a>(
-    summary: StatsSummary1D<'a>,
-    method: default!(&str, "'sample'"),
-) -> Option<f64> {
+fn stats1d_skewness(summary: StatsSummary1D, method: default!(&str, "'sample'")) -> Option<f64> {
     match method_kind(method) {
         Population => summary.to_internal().skewness_pop(),
         Sample => summary.to_internal().skewness_samp(),
@@ -1027,19 +1003,12 @@ fn stats1d_skewness<'a>(
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats1d_kurtosis<'a>(
-    sketch: StatsSummary1D<'a>,
-    accessor: AccessorKurtosis<'a>,
-) -> Option<f64> {
-    let method = String::from_utf8_lossy(accessor.bytes.as_slice());
-    stats1d_kurtosis(sketch, &method)
+pub fn arrow_stats1d_kurtosis(sketch: StatsSummary1D, accessor: AccessorKurtosis) -> Option<f64> {
+    stats1d_kurtosis(sketch, accessor.method.as_str())
 }
 
 #[pg_extern(name = "kurtosis", immutable, parallel_safe)]
-fn stats1d_kurtosis<'a>(
-    summary: StatsSummary1D<'a>,
-    method: default!(&str, "'sample'"),
-) -> Option<f64> {
+fn stats1d_kurtosis(summary: StatsSummary1D, method: default!(&str, "'sample'")) -> Option<f64> {
     match method_kind(method) {
         Population => summary.to_internal().kurtosis_pop(),
         Sample => summary.to_internal().kurtosis_samp(),
@@ -1048,87 +1017,71 @@ fn stats1d_kurtosis<'a>(
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats1d_num_vals<'a>(
-    sketch: StatsSummary1D<'a>,
-    _accessor: AccessorNumVals<'a>,
-) -> i64 {
+pub fn arrow_stats1d_num_vals(sketch: StatsSummary1D, _accessor: AccessorNumVals) -> i64 {
     stats1d_num_vals(sketch)
 }
 
 #[pg_extern(name = "num_vals", strict, immutable, parallel_safe)]
-fn stats1d_num_vals<'a>(summary: StatsSummary1D<'a>) -> i64 {
+fn stats1d_num_vals(summary: StatsSummary1D) -> i64 {
     summary.to_internal().count()
 }
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_average_x<'a>(
-    sketch: StatsSummary2D<'a>,
-    _accessor: AccessorAverageX<'a>,
-) -> Option<f64> {
+pub fn arrow_stats2d_average_x(sketch: StatsSummary2D, _accessor: AccessorAverageX) -> Option<f64> {
     stats2d_average_x(sketch)
 }
 
 #[pg_extern(name = "average_x", strict, immutable, parallel_safe)]
-fn stats2d_average_x<'a>(summary: StatsSummary2D<'a>) -> Option<f64> {
+fn stats2d_average_x(summary: StatsSummary2D) -> Option<f64> {
     Some(summary.to_internal().avg()?.x)
 }
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_average_y<'a>(
-    sketch: StatsSummary2D<'a>,
-    _accessor: AccessorAverageY<'a>,
-) -> Option<f64> {
+pub fn arrow_stats2d_average_y(sketch: StatsSummary2D, _accessor: AccessorAverageY) -> Option<f64> {
     stats2d_average_y(sketch)
 }
 
 #[pg_extern(name = "average_y", strict, immutable, parallel_safe)]
-fn stats2d_average_y<'a>(summary: StatsSummary2D<'a>) -> Option<f64> {
+fn stats2d_average_y(summary: StatsSummary2D) -> Option<f64> {
     Some(summary.to_internal().avg()?.y)
 }
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_sum_x<'a>(
-    sketch: StatsSummary2D<'a>,
-    _accessor: AccessorSumX<'a>,
-) -> Option<f64> {
+pub fn arrow_stats2d_sum_x(sketch: StatsSummary2D, _accessor: AccessorSumX) -> Option<f64> {
     stats2d_sum_x(sketch)
 }
 
 #[pg_extern(name = "sum_x", strict, immutable, parallel_safe)]
-fn stats2d_sum_x<'a>(summary: StatsSummary2D<'a>) -> Option<f64> {
+fn stats2d_sum_x(summary: StatsSummary2D) -> Option<f64> {
     Some(summary.to_internal().sum()?.x)
 }
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_sum_y<'a>(
-    sketch: StatsSummary2D<'a>,
-    _accessor: AccessorSumY<'a>,
-) -> Option<f64> {
+pub fn arrow_stats2d_sum_y(sketch: StatsSummary2D, _accessor: AccessorSumY) -> Option<f64> {
     stats2d_sum_y(sketch)
 }
 
 #[pg_extern(name = "sum_y", strict, immutable, parallel_safe)]
-fn stats2d_sum_y<'a>(summary: StatsSummary2D<'a>) -> Option<f64> {
+fn stats2d_sum_y(summary: StatsSummary2D) -> Option<f64> {
     Some(summary.to_internal().sum()?.y)
 }
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_stdddev_x<'a>(
-    sketch: Option<StatsSummary2D<'a>>,
-    accessor: AccessorStdDevX<'a>,
+pub fn arrow_stats2d_stdddev_x(
+    sketch: Option<StatsSummary2D>,
+    accessor: AccessorStdDevX,
 ) -> Option<f64> {
-    let method = String::from_utf8_lossy(accessor.bytes.as_slice());
-    stats2d_stddev_x(sketch, &method)
+    stats2d_stddev_x(sketch, accessor.method.as_str())
 }
 
 #[pg_extern(name = "stddev_x", immutable, parallel_safe)]
-fn stats2d_stddev_x<'a>(
-    summary: Option<StatsSummary2D<'a>>,
+fn stats2d_stddev_x(
+    summary: Option<StatsSummary2D>,
     method: default!(&str, "'sample'"),
 ) -> Option<f64> {
     match method_kind(method) {
@@ -1139,17 +1092,16 @@ fn stats2d_stddev_x<'a>(
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_stdddev_y<'a>(
-    sketch: Option<StatsSummary2D<'a>>,
-    accessor: AccessorStdDevY<'a>,
+pub fn arrow_stats2d_stdddev_y(
+    sketch: Option<StatsSummary2D>,
+    accessor: AccessorStdDevY,
 ) -> Option<f64> {
-    let method = String::from_utf8_lossy(accessor.bytes.as_slice());
-    stats2d_stddev_y(sketch, &method)
+    stats2d_stddev_y(sketch, accessor.method.as_str())
 }
 
 #[pg_extern(name = "stddev_y", immutable, parallel_safe)]
-fn stats2d_stddev_y<'a>(
-    summary: Option<StatsSummary2D<'a>>,
+fn stats2d_stddev_y(
+    summary: Option<StatsSummary2D>,
     method: default!(&str, "'sample'"),
 ) -> Option<f64> {
     match method_kind(method) {
@@ -1160,17 +1112,16 @@ fn stats2d_stddev_y<'a>(
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_variance_x<'a>(
-    sketch: Option<StatsSummary2D<'a>>,
-    accessor: AccessorVarianceX<'a>,
+pub fn arrow_stats2d_variance_x(
+    sketch: Option<StatsSummary2D>,
+    accessor: AccessorVarianceX,
 ) -> Option<f64> {
-    let method = String::from_utf8_lossy(accessor.bytes.as_slice());
-    stats2d_variance_x(sketch, &method)
+    stats2d_variance_x(sketch, accessor.method.as_str())
 }
 
 #[pg_extern(name = "variance_x", immutable, parallel_safe)]
-fn stats2d_variance_x<'a>(
-    summary: Option<StatsSummary2D<'a>>,
+fn stats2d_variance_x(
+    summary: Option<StatsSummary2D>,
     method: default!(&str, "'sample'"),
 ) -> Option<f64> {
     match method_kind(method) {
@@ -1181,17 +1132,16 @@ fn stats2d_variance_x<'a>(
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_variance_y<'a>(
-    sketch: Option<StatsSummary2D<'a>>,
-    accessor: AccessorVarianceY<'a>,
+pub fn arrow_stats2d_variance_y(
+    sketch: Option<StatsSummary2D>,
+    accessor: AccessorVarianceY,
 ) -> Option<f64> {
-    let method = String::from_utf8_lossy(accessor.bytes.as_slice());
-    stats2d_variance_y(sketch, &method)
+    stats2d_variance_y(sketch, accessor.method.as_str())
 }
 
 #[pg_extern(name = "variance_y", immutable, parallel_safe)]
-fn stats2d_variance_y<'a>(
-    summary: Option<StatsSummary2D<'a>>,
+fn stats2d_variance_y(
+    summary: Option<StatsSummary2D>,
     method: default!(&str, "'sample'"),
 ) -> Option<f64> {
     match method_kind(method) {
@@ -1202,19 +1152,15 @@ fn stats2d_variance_y<'a>(
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_skewness_x<'a>(
-    sketch: StatsSummary2D<'a>,
-    accessor: AccessorSkewnessX<'a>,
+pub fn arrow_stats2d_skewness_x(
+    sketch: StatsSummary2D,
+    accessor: AccessorSkewnessX,
 ) -> Option<f64> {
-    let method = String::from_utf8_lossy(accessor.bytes.as_slice());
-    stats2d_skewness_x(sketch, &method)
+    stats2d_skewness_x(sketch, accessor.method.as_str())
 }
 
 #[pg_extern(name = "skewness_x", strict, immutable, parallel_safe)]
-fn stats2d_skewness_x<'a>(
-    summary: StatsSummary2D<'a>,
-    method: default!(&str, "'sample'"),
-) -> Option<f64> {
+fn stats2d_skewness_x(summary: StatsSummary2D, method: default!(&str, "'sample'")) -> Option<f64> {
     match method_kind(method) {
         Population => Some(summary.to_internal().skewness_pop()?.x),
         Sample => Some(summary.to_internal().skewness_samp()?.x),
@@ -1223,19 +1169,15 @@ fn stats2d_skewness_x<'a>(
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_skewness_y<'a>(
-    sketch: StatsSummary2D<'a>,
-    accessor: AccessorSkewnessY<'a>,
+pub fn arrow_stats2d_skewness_y(
+    sketch: StatsSummary2D,
+    accessor: AccessorSkewnessY,
 ) -> Option<f64> {
-    let method = String::from_utf8_lossy(accessor.bytes.as_slice());
-    stats2d_skewness_y(sketch, &method)
+    stats2d_skewness_y(sketch, accessor.method.as_str())
 }
 
 #[pg_extern(name = "skewness_y", strict, immutable, parallel_safe)]
-fn stats2d_skewness_y<'a>(
-    summary: StatsSummary2D<'a>,
-    method: default!(&str, "'sample'"),
-) -> Option<f64> {
+fn stats2d_skewness_y(summary: StatsSummary2D, method: default!(&str, "'sample'")) -> Option<f64> {
     match method_kind(method) {
         Population => Some(summary.to_internal().skewness_pop()?.y),
         Sample => Some(summary.to_internal().skewness_samp()?.y),
@@ -1244,19 +1186,15 @@ fn stats2d_skewness_y<'a>(
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_kurtosis_x<'a>(
-    sketch: StatsSummary2D<'a>,
-    accessor: AccessorKurtosisX<'a>,
+pub fn arrow_stats2d_kurtosis_x(
+    sketch: StatsSummary2D,
+    accessor: AccessorKurtosisX,
 ) -> Option<f64> {
-    let method = String::from_utf8_lossy(accessor.bytes.as_slice());
-    stats2d_kurtosis_x(sketch, &method)
+    stats2d_kurtosis_x(sketch, accessor.method.as_str())
 }
 
 #[pg_extern(name = "kurtosis_x", strict, immutable, parallel_safe)]
-fn stats2d_kurtosis_x<'a>(
-    summary: StatsSummary2D<'a>,
-    method: default!(&str, "'sample'"),
-) -> Option<f64> {
+fn stats2d_kurtosis_x(summary: StatsSummary2D, method: default!(&str, "'sample'")) -> Option<f64> {
     match method_kind(method) {
         Population => Some(summary.to_internal().kurtosis_pop()?.x),
         Sample => Some(summary.to_internal().kurtosis_samp()?.x),
@@ -1265,19 +1203,15 @@ fn stats2d_kurtosis_x<'a>(
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_kurtosis_y<'a>(
-    sketch: StatsSummary2D<'a>,
-    accessor: AccessorKurtosisY<'a>,
+pub fn arrow_stats2d_kurtosis_y(
+    sketch: StatsSummary2D,
+    accessor: AccessorKurtosisY,
 ) -> Option<f64> {
-    let method = String::from_utf8_lossy(accessor.bytes.as_slice());
-    stats2d_kurtosis_y(sketch, &method)
+    stats2d_kurtosis_y(sketch, accessor.method.as_str())
 }
 
 #[pg_extern(name = "kurtosis_y", strict, immutable, parallel_safe)]
-fn stats2d_kurtosis_y<'a>(
-    summary: StatsSummary2D<'a>,
-    method: default!(&str, "'sample'"),
-) -> Option<f64> {
+fn stats2d_kurtosis_y(summary: StatsSummary2D, method: default!(&str, "'sample'")) -> Option<f64> {
     match method_kind(method) {
         Population => Some(summary.to_internal().kurtosis_pop()?.y),
         Sample => Some(summary.to_internal().kurtosis_samp()?.y),
@@ -1286,101 +1220,88 @@ fn stats2d_kurtosis_y<'a>(
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_num_vals<'a>(
-    sketch: StatsSummary2D<'a>,
-    _accessor: AccessorNumVals<'a>,
-) -> i64 {
+pub fn arrow_stats2d_num_vals(sketch: StatsSummary2D, _accessor: AccessorNumVals) -> i64 {
     stats2d_num_vals(sketch)
 }
 
 #[pg_extern(name = "num_vals", strict, immutable, parallel_safe)]
-fn stats2d_num_vals<'a>(summary: StatsSummary2D<'a>) -> i64 {
+fn stats2d_num_vals(summary: StatsSummary2D) -> i64 {
     summary.to_internal().count()
 }
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_slope<'a>(
-    sketch: StatsSummary2D<'a>,
-    _accessor: AccessorSlope<'a>,
-) -> Option<f64> {
+pub fn arrow_stats2d_slope(sketch: StatsSummary2D, _accessor: AccessorSlope) -> Option<f64> {
     stats2d_slope(sketch)
 }
 
 #[pg_extern(name = "slope", strict, immutable, parallel_safe)]
-fn stats2d_slope<'a>(summary: StatsSummary2D<'a>) -> Option<f64> {
+fn stats2d_slope(summary: StatsSummary2D) -> Option<f64> {
     summary.to_internal().slope()
 }
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_corr<'a>(
-    sketch: StatsSummary2D<'a>,
-    _accessor: AccessorCorr<'a>,
-) -> Option<f64> {
+pub fn arrow_stats2d_corr(sketch: StatsSummary2D, _accessor: AccessorCorr) -> Option<f64> {
     stats2d_corr(sketch)
 }
 
 #[pg_extern(name = "corr", strict, immutable, parallel_safe)]
-fn stats2d_corr<'a>(summary: StatsSummary2D<'a>) -> Option<f64> {
+fn stats2d_corr(summary: StatsSummary2D) -> Option<f64> {
     summary.to_internal().corr()
 }
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_intercept<'a>(
-    sketch: StatsSummary2D<'a>,
-    _accessor: AccessorIntercept<'a>,
+pub fn arrow_stats2d_intercept(
+    sketch: StatsSummary2D,
+    _accessor: AccessorIntercept,
 ) -> Option<f64> {
     stats2d_intercept(sketch)
 }
 
 #[pg_extern(name = "intercept", strict, immutable, parallel_safe)]
-fn stats2d_intercept<'a>(summary: StatsSummary2D<'a>) -> Option<f64> {
+fn stats2d_intercept(summary: StatsSummary2D) -> Option<f64> {
     summary.to_internal().intercept()
 }
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_x_intercept<'a>(
-    sketch: StatsSummary2D<'a>,
-    _accessor: AccessorXIntercept<'a>,
+pub fn arrow_stats2d_x_intercept(
+    sketch: StatsSummary2D,
+    _accessor: AccessorXIntercept,
 ) -> Option<f64> {
     stats2d_x_intercept(sketch)
 }
 
 #[pg_extern(name = "x_intercept", strict, immutable, parallel_safe)]
-fn stats2d_x_intercept<'a>(summary: StatsSummary2D<'a>) -> Option<f64> {
+fn stats2d_x_intercept(summary: StatsSummary2D) -> Option<f64> {
     summary.to_internal().x_intercept()
 }
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_determination_coeff<'a>(
-    sketch: StatsSummary2D<'a>,
-    _accessor: AccessorDeterminationCoeff<'a>,
+pub fn arrow_stats2d_determination_coeff(
+    sketch: StatsSummary2D,
+    _accessor: AccessorDeterminationCoeff,
 ) -> Option<f64> {
     stats2d_determination_coeff(sketch)
 }
 
 #[pg_extern(name = "determination_coeff", strict, immutable, parallel_safe)]
-fn stats2d_determination_coeff<'a>(summary: StatsSummary2D<'a>) -> Option<f64> {
+fn stats2d_determination_coeff(summary: StatsSummary2D) -> Option<f64> {
     summary.to_internal().determination_coeff()
 }
 
 #[pg_operator(immutable, parallel_safe)]
 #[opname(->)]
-pub fn arrow_stats2d_covar<'a>(
-    sketch: Option<StatsSummary2D<'a>>,
-    accessor: AccessorCovar<'a>,
-) -> Option<f64> {
-    let method = String::from_utf8_lossy(accessor.bytes.as_slice());
-    stats2d_covar(sketch, &method)
+pub fn arrow_stats2d_covar(sketch: Option<StatsSummary2D>, accessor: AccessorCovar) -> Option<f64> {
+    stats2d_covar(sketch, accessor.method.as_str())
 }
 
 #[pg_extern(name = "covariance", immutable, parallel_safe)]
-fn stats2d_covar<'a>(
-    summary: Option<StatsSummary2D<'a>>,
+fn stats2d_covar(
+    summary: Option<StatsSummary2D>,
     method: default!(&str, "'sample'"),
 ) -> Option<f64> {
     match method_kind(method) {
@@ -1389,10 +1310,22 @@ fn stats2d_covar<'a>(
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(
+    Clone, Copy, Debug, serde::Serialize, serde::Deserialize, flat_serialize_macro::FlatSerializable,
+)]
+#[repr(u8)]
 pub enum Method {
-    Population,
-    Sample,
+    Population = 1,
+    Sample = 2,
+}
+
+impl Method {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Population => "population",
+            Sample => "sample",
+        }
+    }
 }
 
 #[track_caller]
@@ -1424,7 +1357,7 @@ pub fn as_method(method: &str) -> Option<Method> {
 //     macro_rules! select_one {
 //         ($client:expr, $stmt:expr, $type:ty) => {
 //             $client
-//                 .update($stmt, None, None)
+//                 .update($stmt, None, &[])
 //                 .first()
 //                 .get_one::<$type>()
 //                 .unwrap()
@@ -1451,7 +1384,7 @@ pub fn as_method(method: &str) -> Option<Method> {
 
 //     // #[pg_test]
 //     // fn test_combine_aggregate(){
-//     //     Spi::connect(|mut client| {
+//     //     Spi::connect_mut(|client| {
 
 //     //     });
 //     // }
@@ -1475,12 +1408,12 @@ mod tests {
 
     #[pg_test]
     fn test_stats_agg_text_io() {
-        Spi::connect(|mut client| {
+        Spi::connect_mut(|client| {
             client
                 .update(
                     "CREATE TABLE test_table (test_x DOUBLE PRECISION, test_y DOUBLE PRECISION)",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
 
@@ -1488,7 +1421,7 @@ mod tests {
                 .update(
                     "SELECT stats_agg(test_y, test_x)::TEXT FROM test_table",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -1497,14 +1430,14 @@ mod tests {
             assert!(test.is_none());
 
             client
-                .update("INSERT INTO test_table VALUES (10, 10);", None, None)
+                .update("INSERT INTO test_table VALUES (10, 10);", None, &[])
                 .unwrap();
 
             let test = client
                 .update(
                     "SELECT stats_agg(test_y, test_x)::TEXT FROM test_table",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -1517,13 +1450,13 @@ mod tests {
             );
 
             client
-                .update("INSERT INTO test_table VALUES (20, 20);", None, None)
+                .update("INSERT INTO test_table VALUES (20, 20);", None, &[])
                 .unwrap();
             let test = client
                 .update(
                     "SELECT stats_agg(test_y, test_x)::TEXT FROM test_table",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -1540,16 +1473,16 @@ mod tests {
                     .update(
                         "SELECT skewness_x(stats_agg(test_y, test_x)) FROM test_table",
                         None,
-                        None
+                        &[]
                     )
                     .unwrap()
                     .first()
                     .get_one::<f64>(),
                 client
                     .update(
-                        &format!("SELECT skewness_x('{}'::StatsSummary2D)", expected),
+                        &format!("SELECT skewness_x('{expected}'::StatsSummary2D)"),
                         None,
-                        None
+                        &[]
                     )
                     .unwrap()
                     .first()
@@ -1560,16 +1493,16 @@ mod tests {
                     .update(
                         "SELECT kurtosis_y(stats_agg(test_y, test_x)) FROM test_table",
                         None,
-                        None
+                        &[]
                     )
                     .unwrap()
                     .first()
                     .get_one::<f64>(),
                 client
                     .update(
-                        &format!("SELECT kurtosis_y('{}'::StatsSummary2D)", expected),
+                        &format!("SELECT kurtosis_y('{expected}'::StatsSummary2D)"),
                         None,
-                        None
+                        &[]
                     )
                     .unwrap()
                     .first()
@@ -1580,16 +1513,16 @@ mod tests {
                     .update(
                         "SELECT covariance(stats_agg(test_y, test_x)) FROM test_table",
                         None,
-                        None
+                        &[]
                     )
                     .unwrap()
                     .first()
                     .get_one::<f64>(),
                 client
                     .update(
-                        &format!("SELECT covariance('{}'::StatsSummary2D)", expected),
+                        &format!("SELECT covariance('{expected}'::StatsSummary2D)"),
                         None,
-                        None
+                        &[]
                     )
                     .unwrap()
                     .first()
@@ -1600,9 +1533,9 @@ mod tests {
             assert_eq!(
                 client
                     .update(
-                        &format!("SELECT '{}'::StatsSummary2D::TEXT", expected),
+                        &format!("SELECT '{expected}'::StatsSummary2D::TEXT"),
                         None,
-                        None
+                        &[]
                     )
                     .unwrap()
                     .first()
@@ -1613,13 +1546,13 @@ mod tests {
             );
 
             client
-                .update("INSERT INTO test_table VALUES ('NaN', 30);", None, None)
+                .update("INSERT INTO test_table VALUES ('NaN', 30);", None, &[])
                 .unwrap();
             let test = client
                 .update(
                     "SELECT stats_agg(test_y, test_x)::TEXT FROM test_table",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -1629,13 +1562,13 @@ mod tests {
             assert_eq!(test, "(version:1,n:3,sx:NaN,sx2:NaN,sx3:NaN,sx4:NaN,sy:60,sy2:200,sy3:0,sy4:20000,sxy:NaN)");
 
             client
-                .update("INSERT INTO test_table VALUES (40, 'Inf');", None, None)
+                .update("INSERT INTO test_table VALUES (40, 'Inf');", None, &[])
                 .unwrap();
             let test = client
                 .update(
                     "SELECT stats_agg(test_y, test_x)::TEXT FROM test_table",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -1692,14 +1625,14 @@ mod tests {
         x_values: Vec<f64>,
         y_values: Vec<f64>,
         seed: u64,
-        gen: SmallRng,
+        r#gen: SmallRng,
     }
 
     impl TestState {
         pub fn new(runs: usize, values: usize, seed: Option<u64>) -> TestState {
             let seed = match seed {
                 Some(s) => s,
-                None => SmallRng::from_entropy().gen(),
+                None => SmallRng::from_entropy().gen_range(0..u64::MAX),
             };
 
             TestState {
@@ -1709,7 +1642,7 @@ mod tests {
                 x_values: Vec::new(),
                 y_values: Vec::new(),
                 seed,
-                gen: SmallRng::seed_from_u64(seed),
+                r#gen: SmallRng::seed_from_u64(seed),
             }
         }
 
@@ -1720,18 +1653,18 @@ mod tests {
 
             // We'll cluster the exponential components of the random values around a particular value
             let exp_base = self
-                .gen
+                .r#gen
                 .gen_range((f64::MIN_EXP / 10) as f64..(f64::MAX_EXP / 10) as f64);
 
             for _ in 0..self.values {
-                let exp = self.gen.gen_range((exp_base - 2.)..=(exp_base + 2.));
-                let mantissa = self.gen.gen_range((1.)..2.);
-                let sign = [-1., 1.].choose(&mut self.gen).unwrap();
+                let exp = self.r#gen.gen_range((exp_base - 2.)..=(exp_base + 2.));
+                let mantissa = self.r#gen.gen_range((1.)..2.);
+                let sign = [-1., 1.].choose(&mut self.r#gen).unwrap();
                 self.x_values.push(sign * mantissa * exp.exp2());
 
-                let exp = self.gen.gen_range((exp_base - 2.)..=(exp_base + 2.));
-                let mantissa = self.gen.gen_range((1.)..2.);
-                let sign = [-1., 1.].choose(&mut self.gen).unwrap();
+                let exp = self.r#gen.gen_range((exp_base - 2.)..=(exp_base + 2.));
+                let mantissa = self.r#gen.gen_range((1.)..2.);
+                let sign = [-1., 1.].choose(&mut self.r#gen).unwrap();
                 self.y_values.push(sign * mantissa * exp.exp2());
             }
         }
@@ -1757,7 +1690,7 @@ mod tests {
         do_moving_agg: bool,
     ) {
         warning!("pg_cmd={} ; tk_cmd={}", pg_cmd, tk_cmd);
-        let pg_row = client.update(pg_cmd, None, None).unwrap().first();
+        let pg_row = client.update(pg_cmd, None, &[]).unwrap().first();
         let (pg_result, pg_moving_agg_result) = if do_moving_agg {
             pg_row.get_two::<f64, f64>().unwrap()
         } else {
@@ -1766,13 +1699,13 @@ mod tests {
         let pg_result = pg_result.unwrap();
 
         let (tk_result, arrow_result, tk_moving_agg_result) = client
-            .update(tk_cmd, None, None)
+            .update(tk_cmd, None, &[])
             .unwrap()
             .first()
             .get_three::<f64, f64, f64>()
             .unwrap();
         let (tk_result, arrow_result) = (tk_result.unwrap(), arrow_result.unwrap());
-        assert_eq!(tk_result, arrow_result, "Arrow didn't match in {}", tk_cmd);
+        assert_eq!(tk_result, arrow_result, "Arrow didn't match in {tk_cmd}");
 
         let result = if allowed_diff == 0.0 {
             pg_result == tk_result
@@ -1811,15 +1744,15 @@ mod tests {
     }
 
     fn pg1d_aggx(agg: &str) -> String {
-        format!("SELECT {agg}(test_x)::float, (SELECT {agg}(test_x) OVER (ORDER BY test_x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM test_table LIMIT 1 OFFSET 3)::float FROM test_table", agg = agg)
+        format!("SELECT {agg}(test_x)::float, (SELECT {agg}(test_x) OVER (ORDER BY test_x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM test_table LIMIT 1 OFFSET 3)::float FROM test_table")
     }
 
     fn pg1d_aggy(agg: &str) -> String {
-        format!("SELECT {agg}(test_y), (SELECT {agg}(test_y) OVER (ORDER BY test_x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM test_table LIMIT 1 OFFSET 3) FROM test_table", agg = agg)
+        format!("SELECT {agg}(test_y), (SELECT {agg}(test_y) OVER (ORDER BY test_x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM test_table LIMIT 1 OFFSET 3) FROM test_table")
     }
 
     fn pg2d_agg(agg: &str) -> String {
-        format!("SELECT {agg}(test_y, test_x)::float, (SELECT {agg}(test_y, test_x) OVER (ORDER BY test_x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM test_table LIMIT 1 OFFSET 3)::float FROM test_table", agg = agg)
+        format!("SELECT {agg}(test_y, test_x)::float, (SELECT {agg}(test_y, test_x) OVER (ORDER BY test_x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM test_table LIMIT 1 OFFSET 3)::float FROM test_table")
     }
 
     fn tk1d_agg(agg: &str) -> String {
@@ -1828,8 +1761,7 @@ mod tests {
             {agg}(stats_agg(test_x))::float, \
             (stats_agg(test_x)->{agg}())::float, \
             {agg}((SELECT stats_agg(test_x) OVER (ORDER BY test_x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM test_table LIMIT 1 OFFSET 3))::float \
-        FROM test_table",
-            agg = agg
+        FROM test_table"
         )
     }
 
@@ -1839,9 +1771,7 @@ mod tests {
             {agg}(stats_agg(test_x), '{arg}'), \
             stats_agg(test_x)->{agg}('{arg}'), \
             {agg}((SELECT stats_agg(test_x) OVER (ORDER BY test_x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM test_table LIMIT 1 OFFSET 3), '{arg}') \
-        FROM test_table",
-            agg = agg,
-            arg = arg
+        FROM test_table"
         )
     }
 
@@ -1851,8 +1781,7 @@ mod tests {
             {agg}(stats_agg(test_y, test_x))::float, \
             (stats_agg(test_y, test_x)->{agg}())::float, \
             {agg}((SELECT stats_agg(test_y, test_x) OVER (ORDER BY test_x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM test_table LIMIT 1 OFFSET 3))::float \
-        FROM test_table",
-            agg = agg
+        FROM test_table"
         )
     }
 
@@ -1862,27 +1791,25 @@ mod tests {
             {agg}(stats_agg(test_y, test_x), '{arg}'), \
             stats_agg(test_y, test_x)->{agg}('{arg}'), \
             {agg}((SELECT stats_agg(test_y, test_x) OVER (ORDER BY test_x ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) FROM test_table LIMIT 1 OFFSET 3), '{arg}') \
-        FROM test_table",
-            agg = agg,
-            arg = arg
+        FROM test_table"
         )
     }
 
     fn pg_moment_pop_query(moment: i32, column: &str) -> String {
-        format!("select sum(({} - a.avg)^{}) / count({}) / (stddev_pop({})^{}) from test_table, (select avg({}) from test_table) a", column, moment, column, column, moment, column)
+        format!("select sum(({column} - a.avg)^{moment}) / count({column}) / (stddev_pop({column})^{moment}) from test_table, (select avg({column}) from test_table) a")
     }
 
     fn pg_moment_samp_query(moment: i32, column: &str) -> String {
-        format!("select sum(({} - a.avg)^{}) / (count({}) - 1) / (stddev_samp({})^{}) from test_table, (select avg({}) from test_table) a", column, moment, column, column, moment, column)
+        format!("select sum(({column} - a.avg)^{moment}) / (count({column}) - 1) / (stddev_samp({column})^{moment}) from test_table, (select avg({column}) from test_table) a")
     }
 
     fn test_aggs(state: &mut TestState) {
-        Spi::connect(|mut client| {
+        Spi::connect_mut(|client| {
             client
                 .update(
                     "CREATE TABLE test_table (test_x DOUBLE PRECISION, test_y DOUBLE PRECISION)",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
 
@@ -1904,7 +1831,7 @@ mod tests {
                             .trim_end_matches(',')
                     ),
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
 
@@ -1917,7 +1844,7 @@ mod tests {
 
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggx("avg"),
                 &tk1d_agg("average"),
                 NONE,
@@ -1925,7 +1852,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggx("sum"),
                 &tk1d_agg("sum"),
                 NONE,
@@ -1933,7 +1860,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggx("count"),
                 &tk1d_agg("num_vals"),
                 NONE,
@@ -1941,7 +1868,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggx("stddev"),
                 &tk1d_agg("stddev"),
                 EPS2,
@@ -1949,7 +1876,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggx("stddev_pop"),
                 &tk1d_agg_arg("stddev", "population"),
                 EPS2,
@@ -1957,7 +1884,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggx("stddev_samp"),
                 &tk1d_agg_arg("stddev", "sample"),
                 EPS2,
@@ -1965,7 +1892,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggx("variance"),
                 &tk1d_agg("variance"),
                 EPS3,
@@ -1973,7 +1900,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggx("var_pop"),
                 &tk1d_agg_arg("variance", "population"),
                 EPS3,
@@ -1981,7 +1908,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggx("var_samp"),
                 &tk1d_agg_arg("variance", "sample"),
                 EPS3,
@@ -1990,7 +1917,7 @@ mod tests {
 
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg2d_agg("regr_avgx"),
                 &tk2d_agg("average_x"),
                 NONE,
@@ -1998,7 +1925,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg2d_agg("regr_avgy"),
                 &tk2d_agg("average_y"),
                 NONE,
@@ -2006,7 +1933,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggx("sum"),
                 &tk2d_agg("sum_x"),
                 NONE,
@@ -2014,7 +1941,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggy("sum"),
                 &tk2d_agg("sum_y"),
                 NONE,
@@ -2022,7 +1949,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggx("stddev"),
                 &tk2d_agg("stddev_x"),
                 EPS2,
@@ -2030,7 +1957,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggy("stddev"),
                 &tk2d_agg("stddev_y"),
                 EPS2,
@@ -2038,7 +1965,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggx("stddev_pop"),
                 &tk2d_agg_arg("stddev_x", "population"),
                 EPS2,
@@ -2046,7 +1973,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggy("stddev_pop"),
                 &tk2d_agg_arg("stddev_y", "population"),
                 EPS2,
@@ -2054,7 +1981,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggx("stddev_samp"),
                 &tk2d_agg_arg("stddev_x", "sample"),
                 EPS2,
@@ -2062,7 +1989,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggy("stddev_samp"),
                 &tk2d_agg_arg("stddev_y", "sample"),
                 EPS2,
@@ -2070,7 +1997,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggx("variance"),
                 &tk2d_agg("variance_x"),
                 EPS3,
@@ -2078,7 +2005,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggy("variance"),
                 &tk2d_agg("variance_y"),
                 EPS3,
@@ -2086,7 +2013,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggx("var_pop"),
                 &tk2d_agg_arg("variance_x", "population"),
                 EPS3,
@@ -2094,7 +2021,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggy("var_pop"),
                 &tk2d_agg_arg("variance_y", "population"),
                 EPS3,
@@ -2102,7 +2029,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggx("var_samp"),
                 &tk2d_agg_arg("variance_x", "sample"),
                 EPS3,
@@ -2110,7 +2037,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg1d_aggy("var_samp"),
                 &tk2d_agg_arg("variance_y", "sample"),
                 EPS3,
@@ -2118,7 +2045,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg2d_agg("regr_count"),
                 &tk2d_agg("num_vals"),
                 NONE,
@@ -2127,7 +2054,7 @@ mod tests {
 
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg2d_agg("regr_slope"),
                 &tk2d_agg("slope"),
                 EPS1,
@@ -2135,7 +2062,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg2d_agg("corr"),
                 &tk2d_agg("corr"),
                 EPS1,
@@ -2143,7 +2070,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg2d_agg("regr_intercept"),
                 &tk2d_agg("intercept"),
                 EPS1,
@@ -2154,17 +2081,17 @@ mod tests {
             {
                 let query = tk2d_agg("x_intercept");
                 let (result, arrow_result) = client
-                    .update(&query, None, None)
+                    .update(&query, None, &[])
                     .unwrap()
                     .first()
                     .get_two::<f64, f64>()
                     .unwrap();
-                assert_eq!(result, arrow_result, "Arrow didn't match in {}", query);
+                assert_eq!(result, arrow_result, "Arrow didn't match in {query}");
             }
 
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg2d_agg("regr_r2"),
                 &tk2d_agg("determination_coeff"),
                 EPS1,
@@ -2172,7 +2099,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg2d_agg("covar_pop"),
                 &tk2d_agg_arg("covariance", "population"),
                 BILLIONTH,
@@ -2180,7 +2107,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg2d_agg("covar_samp"),
                 &tk2d_agg_arg("covariance", "sample"),
                 BILLIONTH,
@@ -2190,7 +2117,7 @@ mod tests {
             // Skewness and kurtosis don't have aggregate functions in postgres, but we can compute them
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg_moment_pop_query(3, "test_x"),
                 &tk1d_agg_arg("skewness", "population"),
                 BILLIONTH,
@@ -2198,7 +2125,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg_moment_pop_query(3, "test_x"),
                 &tk2d_agg_arg("skewness_x", "population"),
                 BILLIONTH,
@@ -2206,7 +2133,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg_moment_pop_query(3, "test_y"),
                 &tk2d_agg_arg("skewness_y", "population"),
                 BILLIONTH,
@@ -2214,7 +2141,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg_moment_pop_query(4, "test_x"),
                 &tk1d_agg_arg("kurtosis", "population"),
                 BILLIONTH,
@@ -2222,7 +2149,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg_moment_pop_query(4, "test_x"),
                 &tk2d_agg_arg("kurtosis_x", "population"),
                 BILLIONTH,
@@ -2230,7 +2157,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg_moment_pop_query(4, "test_y"),
                 &tk2d_agg_arg("kurtosis_y", "population"),
                 BILLIONTH,
@@ -2239,7 +2166,7 @@ mod tests {
 
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg_moment_samp_query(3, "test_x"),
                 &tk1d_agg_arg("skewness", "sample"),
                 BILLIONTH,
@@ -2247,7 +2174,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg_moment_samp_query(3, "test_x"),
                 &tk2d_agg_arg("skewness_x", "sample"),
                 BILLIONTH,
@@ -2255,7 +2182,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg_moment_samp_query(3, "test_y"),
                 &tk2d_agg_arg("skewness_y", "sample"),
                 BILLIONTH,
@@ -2263,7 +2190,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg_moment_samp_query(4, "test_x"),
                 &tk1d_agg_arg("kurtosis", "sample"),
                 BILLIONTH,
@@ -2271,7 +2198,7 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg_moment_samp_query(4, "test_x"),
                 &tk2d_agg_arg("kurtosis_x", "sample"),
                 BILLIONTH,
@@ -2279,20 +2206,20 @@ mod tests {
             );
             check_agg_equivalence(
                 state,
-                &mut client,
+                client,
                 &pg_moment_samp_query(4, "test_y"),
                 &tk2d_agg_arg("kurtosis_y", "sample"),
                 BILLIONTH,
                 false,
             );
 
-            client.update("DROP TABLE test_table", None, None).unwrap();
+            client.update("DROP TABLE test_table", None, &[]).unwrap();
         });
     }
 
     #[pg_test]
     fn stats_agg_rolling() {
-        Spi::connect(|mut client| {
+        Spi::connect_mut(|client| {
             client
                 .update(
                     "
@@ -2312,13 +2239,13 @@ INSERT INTO prices (
 );
 ",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
 
             let mut vals = client.update(
                 "SELECT stddev(data.stats_agg) FROM (SELECT stats_agg(price) OVER (ORDER BY ts RANGE '50 minutes' PRECEDING) FROM prices) data",
-                None, None
+                None, &[]
             ).unwrap();
             assert!(vals.next().unwrap()[1]
                 .value::<f64>()
@@ -2330,7 +2257,7 @@ INSERT INTO prices (
 
             let mut vals = client.update(
                 "SELECT slope(data.stats_agg) FROM (SELECT stats_agg((EXTRACT(minutes FROM ts)), price) OVER (ORDER BY ts RANGE '50 minutes' PRECEDING) FROM prices) data;",
-                None, None
+                None, &[]
             ).unwrap();
             assert!(vals.next().unwrap()[1].value::<f64>().unwrap().is_none()); // trendline is zero initially
             assert!(vals.next().unwrap()[1].value::<f64>().unwrap().is_some());

--- a/extension/src/time_vector/pipeline/arithmetic.rs
+++ b/extension/src/time_vector/pipeline/arithmetic.rs
@@ -293,15 +293,15 @@ mod tests {
 
     #[pg_test]
     fn test_simple_arith_binops() {
-        Spi::connect(|mut client| {
-            client.update("SET timezone TO 'UTC'", None, None).unwrap();
+        Spi::connect_mut(|client| {
+            client.update("SET timezone TO 'UTC'", None, &[]).unwrap();
             // using the search path trick for this test b/c the operator is
             // difficult to spot otherwise.
             let sp = client
                 .update(
                     "SELECT format(' %s, toolkit_experimental',current_setting('search_path'))",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -309,7 +309,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
             client
-                .update(&format!("SET LOCAL search_path TO {}", sp), None, None)
+                .update(&format!("SET LOCAL search_path TO {sp}"), None, &[])
                 .unwrap();
 
             // we use a subselect to guarantee order
@@ -322,12 +322,9 @@ mod tests {
 
             let val = client
                 .update(
-                    &format!(
-                        "SELECT (series -> add(1.0))::TEXT FROM ({}) s",
-                        create_series
-                    ),
+                    &format!("SELECT (series -> add(1.0))::TEXT FROM ({create_series}) s"),
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -346,12 +343,9 @@ mod tests {
 
             let val = client
                 .update(
-                    &format!(
-                        "SELECT (series -> sub(3.0))::TEXT FROM ({}) s",
-                        create_series
-                    ),
+                    &format!("SELECT (series -> sub(3.0))::TEXT FROM ({create_series}) s"),
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -370,12 +364,9 @@ mod tests {
 
             let val = client
                 .update(
-                    &format!(
-                        "SELECT (series -> mul(2.0))::TEXT FROM ({}) s",
-                        create_series
-                    ),
+                    &format!("SELECT (series -> mul(2.0))::TEXT FROM ({create_series}) s"),
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -394,12 +385,9 @@ mod tests {
 
             let val = client
                 .update(
-                    &format!(
-                        "SELECT (series -> div(5.0))::TEXT FROM ({}) s",
-                        create_series
-                    ),
+                    &format!("SELECT (series -> div(5.0))::TEXT FROM ({create_series}) s"),
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -418,12 +406,9 @@ mod tests {
 
             let val = client
                 .update(
-                    &format!(
-                        "SELECT (series -> mod(5.0))::TEXT FROM ({}) s",
-                        create_series
-                    ),
+                    &format!("SELECT (series -> mod(5.0))::TEXT FROM ({create_series}) s"),
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -442,12 +427,9 @@ mod tests {
 
             let val = client
                 .update(
-                    &format!(
-                        "SELECT (series -> power(2.0))::TEXT FROM ({}) s",
-                        create_series
-                    ),
+                    &format!("SELECT (series -> power(2.0))::TEXT FROM ({create_series}) s"),
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -466,12 +448,9 @@ mod tests {
 
             let val = client
                 .update(
-                    &format!(
-                        "SELECT (series -> logn(10.0))::TEXT FROM ({}) s",
-                        create_series
-                    ),
+                    &format!("SELECT (series -> logn(10.0))::TEXT FROM ({create_series}) s"),
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -492,15 +471,15 @@ mod tests {
 
     #[pg_test]
     fn test_simple_arith_unaryops() {
-        Spi::connect(|mut client| {
-            client.update("SET timezone TO 'UTC'", None, None).unwrap();
+        Spi::connect_mut(|client| {
+            client.update("SET timezone TO 'UTC'", None, &[]).unwrap();
             // using the search path trick for this test b/c the operator is
             // difficult to spot otherwise.
             let sp = client
                 .update(
                     "SELECT format(' %s, toolkit_experimental',current_setting('search_path'))",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -508,7 +487,7 @@ mod tests {
                 .unwrap()
                 .unwrap();
             client
-                .update(&format!("SET LOCAL search_path TO {}", sp), None, None)
+                .update(&format!("SET LOCAL search_path TO {sp}"), None, &[])
                 .unwrap();
 
             // we use a subselect to guarantee order
@@ -521,9 +500,9 @@ mod tests {
 
             let val = client
                 .update(
-                    &format!("SELECT (series -> abs())::TEXT FROM ({}) s", create_series),
+                    &format!("SELECT (series -> abs())::TEXT FROM ({create_series}) s"),
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -558,9 +537,9 @@ mod tests {
 
             let val = client
                 .update(
-                    &format!("SELECT (series -> ceil())::TEXT FROM ({}) s", create_series),
+                    &format!("SELECT (series -> ceil())::TEXT FROM ({create_series}) s"),
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -579,12 +558,9 @@ mod tests {
 
             let val = client
                 .update(
-                    &format!(
-                        "SELECT (series -> floor())::TEXT FROM ({}) s",
-                        create_series
-                    ),
+                    &format!("SELECT (series -> floor())::TEXT FROM ({create_series}) s"),
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -637,12 +613,9 @@ mod tests {
 
             let val = client
                 .update(
-                    &format!(
-                        "SELECT (series -> round())::TEXT FROM ({}) s",
-                        create_series
-                    ),
+                    &format!("SELECT (series -> round())::TEXT FROM ({create_series}) s"),
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -661,9 +634,9 @@ mod tests {
 
             let val = client
                 .update(
-                    &format!("SELECT (series -> sign())::TEXT FROM ({}) s", create_series),
+                    &format!("SELECT (series -> sign())::TEXT FROM ({create_series}) s"),
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -698,12 +671,9 @@ mod tests {
 
             let val = client
                 .update(
-                    &format!(
-                        "SELECT (series -> trunc())::TEXT FROM ({}) s",
-                        create_series
-                    ),
+                    &format!("SELECT (series -> trunc())::TEXT FROM ({create_series}) s"),
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()

--- a/extension/src/time_vector/pipeline/fill_to.rs
+++ b/extension/src/time_vector/pipeline/fill_to.rs
@@ -146,15 +146,15 @@ mod tests {
 
     #[pg_test]
     fn test_pipeline_fill_to() {
-        Spi::connect(|mut client| {
-            client.update("SET timezone TO 'UTC'", None, None).unwrap();
+        Spi::connect_mut(|client| {
+            client.update("SET timezone TO 'UTC'", None, &[]).unwrap();
             // using the search path trick for this test b/c the operator is
             // difficult to spot otherwise.
             let sp = client
                 .update(
                     "SELECT format(' %s, toolkit_experimental',current_setting('search_path'))",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -162,14 +162,14 @@ mod tests {
                 .unwrap()
                 .unwrap();
             client
-                .update(&format!("SET LOCAL search_path TO {}", sp), None, None)
+                .update(&format!("SET LOCAL search_path TO {sp}"), None, &[])
                 .unwrap();
 
             client
                 .update(
                     "CREATE TABLE series(time timestamptz, value double precision)",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
             client
@@ -182,14 +182,14 @@ mod tests {
                     ('2020-01-06 UTC'::TIMESTAMPTZ, 30),   \
                     ('2020-01-09 UTC'::TIMESTAMPTZ, 40.0)",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
 
             let val = client.update(
                 "SELECT (timevector(time, value) -> fill_to('24 hours', 'locf'))::TEXT FROM series",
                 None,
-                None
+                &[]
             )
                 .unwrap().first()
                 .get_one::<String>().unwrap();
@@ -211,7 +211,7 @@ mod tests {
             let val = client.update(
                 "SELECT (timevector(time, value) -> fill_to('24 hours', 'linear'))::TEXT FROM series",
                 None,
-                None
+                &[]
             )
                 .unwrap().first()
                 .get_one::<String>().unwrap();
@@ -233,7 +233,7 @@ mod tests {
             let val = client.update(
                 "SELECT (timevector(time, value) -> fill_to('24 hours', 'nearest'))::TEXT FROM series",
                 None,
-                None
+                &[]
             )
                 .unwrap().first()
                 .get_one::<String>().unwrap();
@@ -255,7 +255,7 @@ mod tests {
             let val = client.update(
                 "SELECT (timevector(time, value) -> fill_to('10 hours', 'nearest'))::TEXT FROM series",
                 None,
-                None
+                &[]
             )
                 .unwrap().first()
                 .get_one::<String>().unwrap();

--- a/extension/src/time_vector/pipeline/lambda/executor.rs
+++ b/extension/src/time_vector/pipeline/lambda/executor.rs
@@ -196,7 +196,7 @@ where
         // For now it seems OK to suppress these warnings here with
         // #[allow(improper_ctypes)]
         #[allow(improper_ctypes)]
-        extern "C" {
+        unsafe extern "C-unwind" {
             fn interval_pl(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum;
             fn interval_mi(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum;
             fn interval_mul(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum;

--- a/extension/src/time_vector/pipeline/lambda/parser.rs
+++ b/extension/src/time_vector/pipeline/lambda/parser.rs
@@ -168,7 +168,7 @@ fn parse_primary<'a>(
                 let var_name = var_name_or_expr.as_str();
                 known_vars
                     .entry(var_name)
-                    .and_modify(|_| panic!("duplicate var {}", var_name))
+                    .and_modify(|_| panic!("duplicate var {var_name}"))
                     .or_insert_with(|| (var_value.ty().clone(), var_expressions.len()));
                 var_expressions.push(var_value);
             }
@@ -259,10 +259,9 @@ fn build_binary_op(
             //      actually is, but it seems easier to just revers the value here if
             //      they're in an unexpected order.
             (Double, Interval) => Binary(Mul, right.into(), left.into(), Interval),
-            (l, r) => panic!(
-                "no operator `{:?} * {:?}` only `DOUBLE * DOUBLE` and `INTERVAL * FLOAT`",
-                l, r
-            ),
+            (l, r) => {
+                panic!("no operator `{l:?} * {r:?}` only `DOUBLE * DOUBLE` and `INTERVAL * FLOAT`")
+            }
         },
 
         divide => {
@@ -368,7 +367,7 @@ fn parse_timestamptz(val: &str) -> i64 {
     // FIXME pgrx wraps all functions in rust wrappers, which makes them
     //       uncallable with DirectFunctionCall(). Is there a way to
     //       export both?
-    extern "C" {
+    unsafe extern "C-unwind" {
         #[allow(improper_ctypes)]
         fn timestamptz_in(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum;
     }
@@ -390,7 +389,7 @@ fn parse_interval(val: &str) -> *mut pg_sys::Interval {
     // FIXME pgrx wraps all functions in rust wrappers, which makes them
     //       uncallable with DirectFunctionCall(). Is there a way to
     //       export both?
-    extern "C" {
+    unsafe extern "C-unwind" {
         #[allow(improper_ctypes)]
         fn interval_in(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum;
     }

--- a/extension/src/time_vector/pipeline/sort.rs
+++ b/extension/src/time_vector/pipeline/sort.rs
@@ -65,15 +65,15 @@ mod tests {
 
     #[pg_test]
     fn test_pipeline_sort() {
-        Spi::connect(|mut client| {
-            client.update("SET timezone TO 'UTC'", None, None).unwrap();
+        Spi::connect_mut(|client| {
+            client.update("SET timezone TO 'UTC'", None, &[]).unwrap();
             // using the search path trick for this test b/c the operator is
             // difficult to spot otherwise.
             let sp = client
                 .update(
                     "SELECT format(' %s, toolkit_experimental',current_setting('search_path'))",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -81,14 +81,14 @@ mod tests {
                 .unwrap()
                 .unwrap();
             client
-                .update(&format!("SET LOCAL search_path TO {}", sp), None, None)
+                .update(&format!("SET LOCAL search_path TO {sp}"), None, &[])
                 .unwrap();
 
             client
                 .update(
                     "CREATE TABLE series(time timestamptz, value double precision)",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
             client
@@ -102,7 +102,7 @@ mod tests {
                     ('2020-01-05 UTC'::TIMESTAMPTZ, 30), \
                     ('2020-01-02 12:00:00 UTC'::TIMESTAMPTZ, NULL)",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap();
 
@@ -110,7 +110,7 @@ mod tests {
                 .update(
                     "SELECT (timevector(time, value))::TEXT FROM series",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -132,7 +132,7 @@ mod tests {
                 .update(
                     "SELECT (timevector(time, value) -> sort())::TEXT FROM series",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()

--- a/extension/src/time_weighted_average/accessors.rs
+++ b/extension/src/time_weighted_average/accessors.rs
@@ -23,13 +23,13 @@ pg_type! {
 ron_inout_funcs!(TimeWeightInterpolatedAverageAccessor);
 
 #[pg_extern(immutable, parallel_safe, name = "interpolated_average")]
-fn time_weight_interpolated_average_accessor<'a>(
+fn time_weight_interpolated_average_accessor(
     start: crate::raw::TimestampTz,
     duration: crate::raw::Interval,
-    prev: default!(Option<TimeWeightSummary<'a>>, "NULL"),
-    next: default!(Option<TimeWeightSummary<'a>>, "NULL"),
-) -> TimeWeightInterpolatedAverageAccessor<'static> {
-    fn empty_summary<'b>() -> Option<TimeWeightSummary<'b>> {
+    prev: default!(Option<TimeWeightSummary>, "NULL"),
+    next: default!(Option<TimeWeightSummary>, "NULL"),
+) -> TimeWeightInterpolatedAverageAccessor {
+    fn empty_summary() -> Option<TimeWeightSummary> {
         Some(unsafe {
             flatten!(TimeWeightSummary {
                 first: TSPoint { ts: 0, val: 0.0 },
@@ -72,14 +72,14 @@ pg_type! {
 ron_inout_funcs!(TimeWeightInterpolatedIntegralAccessor);
 
 #[pg_extern(immutable, parallel_safe, name = "interpolated_integral")]
-fn time_weight_interpolated_integral_accessor<'a>(
+fn time_weight_interpolated_integral_accessor(
     start: crate::raw::TimestampTz,
     interval: crate::raw::Interval,
-    prev: default!(Option<TimeWeightSummary<'a>>, "NULL"),
-    next: default!(Option<TimeWeightSummary<'a>>, "NULL"),
+    prev: default!(Option<TimeWeightSummary>, "NULL"),
+    next: default!(Option<TimeWeightSummary>, "NULL"),
     unit: default!(String, "'second'"),
-) -> TimeWeightInterpolatedIntegralAccessor<'static> {
-    fn empty_summary<'b>() -> Option<TimeWeightSummary<'b>> {
+) -> TimeWeightInterpolatedIntegralAccessor {
+    fn empty_summary() -> Option<TimeWeightSummary> {
         Some(unsafe {
             flatten!(TimeWeightSummary {
                 first: TSPoint { ts: 0, val: 0.0 },

--- a/extension/src/utilities.rs
+++ b/extension/src/utilities.rs
@@ -131,12 +131,12 @@ mod tests {
 
     #[pg_test]
     fn test_to_epoch() {
-        Spi::connect(|mut client| {
+        Spi::connect_mut(|client| {
             let test_val = client
                 .update(
                     "SELECT to_epoch('2021-01-01 00:00:00+03'::timestamptz)",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -146,7 +146,7 @@ mod tests {
             assert!((test_val - 1609448400f64).abs() < f64::EPSILON);
 
             let test_val = client
-                .update("SELECT to_epoch('epoch'::timestamptz)", None, None)
+                .update("SELECT to_epoch('epoch'::timestamptz)", None, &[])
                 .unwrap()
                 .first()
                 .get_one::<f64>()
@@ -158,7 +158,7 @@ mod tests {
                 .update(
                     "SELECT to_epoch('epoch'::timestamptz - interval '42 seconds')",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -171,12 +171,12 @@ mod tests {
 
     #[pg_test]
     fn test_days_in_month() {
-        Spi::connect(|mut client| {
+        Spi::connect_mut(|client| {
             let test_val = client
                 .update(
                     "SELECT days_in_month('2021-01-01 00:00:00+03'::timestamptz)",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -186,12 +186,12 @@ mod tests {
             assert_eq!(test_val, 31);
         });
 
-        Spi::connect(|mut client| {
+        Spi::connect_mut(|client| {
             let test_val = client
                 .update(
                     "SELECT days_in_month('2020-02-03 00:00:00+03'::timestamptz)",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -200,12 +200,12 @@ mod tests {
                 .unwrap();
             assert_eq!(test_val, 29);
         });
-        Spi::connect(|mut client| {
+        Spi::connect_mut(|client| {
             let test_val = client
                 .update(
                     "SELECT days_in_month('2023-01-31 00:00:00+00'::timestamptz)",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -217,12 +217,12 @@ mod tests {
     }
     #[pg_test]
     fn test_monthly_normalize() {
-        Spi::connect(|mut client| {
+        Spi::connect_mut(|client| {
             let test_val = client
                 .update(
                     "SELECT month_normalize(1000,'2021-01-01 00:00:00+03'::timestamptz)",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -231,12 +231,12 @@ mod tests {
                 .unwrap();
             assert_eq!(test_val, 981.8548387096774f64);
         });
-        Spi::connect(|mut client| {
+        Spi::connect_mut(|client| {
             let test_val = client
                 .update(
                     "SELECT month_normalize(1000,'2021-01-01 00:00:00+03'::timestamptz,30.5)",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()
@@ -245,12 +245,12 @@ mod tests {
                 .unwrap();
             assert_eq!(test_val, 983.8709677419355f64);
         });
-        Spi::connect(|mut client| {
+        Spi::connect_mut(|client| {
             let test_val = client
                 .update(
                     "SELECT month_normalize(1000,'2021-01-01 00:00:00+03'::timestamptz,30)",
                     None,
-                    None,
+                    &[],
                 )
                 .unwrap()
                 .first()

--- a/tools/build
+++ b/tools/build
@@ -45,7 +45,10 @@ find_profile() {
 
 [ $# -ge 1 ] || usage
 
+# check versions
+cargo --version
 rustc --version
+rustup --version
 
 while [ $# -gt 0 ]; do
     arg="$1"

--- a/tools/dependencies.sh
+++ b/tools/dependencies.sh
@@ -14,7 +14,7 @@ TSDB_PG_VERSIONS='15 16 17'
 CARGO_EDIT=0.11.2
 
 # Keep synchronized with extension/Cargo.toml and `cargo install --version N.N.N cargo-pgrx` in Readme.md .
-PGRX_VERSION=0.12.9
+PGRX_VERSION=0.16.0
 
 RUST_TOOLCHAIN=1.89.0
 RUST_PROFILE=minimal

--- a/tools/post-install/src/main.rs
+++ b/tools/post-install/src/main.rs
@@ -29,7 +29,7 @@ macro_rules! path {
 
 fn main() {
     if let Err(err) = try_main() {
-        eprintln!("{}", err);
+        eprintln!("{err}");
         process::exit(1);
     }
 }
@@ -78,17 +78,16 @@ fn get_extension_info_from_pg_config(pg_config: &str) -> xshell::Result<Extensio
 
     let control_contents = fs::read_to_string(&control_file).unwrap_or_else(|e| {
         panic!(
-            "cannot read control file {} due to {}",
-            control_file.to_string_lossy(),
-            e,
+            "cannot read control file {} due to {e}",
+            control_file.to_string_lossy()
         )
     });
 
     let current_version = get_current_version(&control_contents);
-    eprintln!("Generating Version {}", current_version);
+    eprintln!("Generating Version {current_version}");
 
     let upgradeable_from = get_upgradeable_from(&control_contents);
-    eprintln!("Upgradable From {:?}", upgradeable_from);
+    eprintln!("Upgradable From {upgradeable_from:?}");
 
     let extension_info = ExtensionInfo {
         control_file,
@@ -137,17 +136,16 @@ fn get_extension_info_from_dir(root: &str) -> xshell::Result<ExtensionInfo> {
 
     let control_contents = fs::read_to_string(&control_file).unwrap_or_else(|e| {
         panic!(
-            "cannot read control file {} due to {}",
-            control_file.to_string_lossy(),
-            e,
+            "cannot read control file {} due to {e}",
+            control_file.to_string_lossy()
         )
     });
 
     let current_version = get_current_version(&control_contents);
-    eprintln!("Generating Version {}", current_version);
+    eprintln!("Generating Version {current_version}");
 
     let upgradeable_from = get_upgradeable_from(&control_contents);
-    eprintln!("Upgradable From {:?}", upgradeable_from);
+    eprintln!("Upgradable From {upgradeable_from:?}");
 
     let extension_info = ExtensionInfo {
         control_file,
@@ -204,11 +202,11 @@ fn add_version_to_install_script(
     }: &ExtensionInfo,
 ) {
     let install_script =
-        path!(extension_dir / format!("timescaledb_toolkit--{}.sql", current_version));
+        path!(extension_dir / format!("timescaledb_toolkit--{current_version}.sql"));
 
     let versioned_script = install_script.with_extension("sql.tmp");
 
-    let module_path = format!("$libdir/timescaledb_toolkit-{}", current_version);
+    let module_path = format!("$libdir/timescaledb_toolkit-{current_version}");
 
     transform_file_to(&install_script, &versioned_script, |line| {
         assert!(
@@ -285,7 +283,7 @@ fn get_field_val<'a>(contents: &'a str, field: &str) -> &'a str {
         .filter(|line| line.contains(field))
         .map(get_quoted_field)
         .next()
-        .unwrap_or_else(|| panic!("cannot read field `{}` in control file", field))
+        .unwrap_or_else(|| panic!("cannot read field `{field}` in control file"))
 }
 
 // given a `<field name> = '<field value>'` extract `<field value>`
@@ -293,13 +291,13 @@ fn get_quoted_field(line: &str) -> &str {
     let quoted = line
         .split('=')
         .nth(1)
-        .unwrap_or_else(|| panic!("cannot find value in line `{}`", line));
+        .unwrap_or_else(|| panic!("cannot find value in line `{line}`"));
 
     quoted
         .trim_start()
         .split_terminator('\'')
         .find(|s| !s.is_empty())
-        .unwrap_or_else(|| panic!("unquoted value in line `{}`", line))
+        .unwrap_or_else(|| panic!("unquoted value in line `{line}`"))
 }
 
 //
@@ -309,19 +307,14 @@ fn get_quoted_field(line: &str) -> &str {
 fn open_file(path: impl AsRef<Path>) -> BufReader<File> {
     let path = path.as_ref();
     let file = File::open(path)
-        .unwrap_or_else(|e| panic!("cannot open file `{}` due to {}", path.to_string_lossy(), e,));
+        .unwrap_or_else(|e| panic!("cannot open file `{}` due to {e}", path.to_string_lossy()));
     BufReader::new(file)
 }
 
 fn create_file(path: impl AsRef<Path>) -> BufWriter<File> {
     let path = path.as_ref();
-    let file = File::create(path).unwrap_or_else(|e| {
-        panic!(
-            "cannot create file `{}` due to {}",
-            path.to_string_lossy(),
-            e,
-        )
-    });
+    let file = File::create(path)
+        .unwrap_or_else(|e| panic!("cannot create file `{}` due to {e}", path.to_string_lossy()));
     BufWriter::new(file)
 }
 
@@ -330,10 +323,9 @@ fn rename_file(from: impl AsRef<Path>, to: impl AsRef<Path>) {
     let to = to.as_ref();
     fs::rename(from, to).unwrap_or_else(|e| {
         panic!(
-            "cannot rename `{}` to `{}` due to `{}`",
+            "cannot rename `{}` to `{}` due to `{e}`",
             from.to_string_lossy(),
-            to.to_string_lossy(),
-            e,
+            to.to_string_lossy()
         )
     });
 }
@@ -349,16 +341,11 @@ fn transform_file_to(
     let mut from = open_file(from_path);
 
     for line in (&mut from).lines() {
-        let line = line.unwrap_or_else(|e| {
-            panic!("cannot read `{}` due to {}", from_path.to_string_lossy(), e,)
-        });
+        let line = line
+            .unwrap_or_else(|e| panic!("cannot read `{}` due to {e}", from_path.to_string_lossy()));
 
         writeln!(&mut to, "{}", transform(line)).unwrap_or_else(|e| {
-            panic!(
-                "cannot write to `{}` due to {}",
-                to_path.to_string_lossy(),
-                e,
-            )
+            panic!("cannot write to `{}` due to {e}", to_path.to_string_lossy())
         });
     }
 

--- a/tools/post-install/src/update_script.rs
+++ b/tools/post-install/src/update_script.rs
@@ -67,17 +67,17 @@ pub(crate) fn generate_from_install(
             Some(Create::Type(create)) => script_creator.handle_create_type(create),
             Some(Create::Schema(create)) => {
                 // TODO is there something more principled to do here?
-                writeln!(script_creator.upgrade_file, "CREATE SCHEMA {}", create).unwrap();
+                writeln!(script_creator.upgrade_file, "CREATE SCHEMA {create}").unwrap();
             }
             Some(Create::Operator(create)) => script_creator.handle_create_operator(create),
             Some(Create::Cast(create)) => {
                 // TODO we don't have a stable one of these yet
                 // JOSH - we should probably check if the FUNCTION is experimental also
                 if create.contains("toolkit_experimental.") || create.starts_with("(tests.") {
-                    writeln!(script_creator.upgrade_file, "CREATE CAST {}", create).unwrap();
+                    writeln!(script_creator.upgrade_file, "CREATE CAST {create}").unwrap();
                     continue;
                 }
-                unimplemented!("unprepared for stable CAST: {}", create)
+                unimplemented!("unprepared for stable CAST: {create}")
             }
             None => continue,
         }
@@ -136,10 +136,10 @@ where
                 if create.is_some() {
                     return create;
                 }
-                unreachable!("unexpected CREATE `{}`", trimmed)
+                unreachable!("unexpected CREATE `{trimmed}`")
             }
 
-            writeln!(self.upgrade_file, "{}", line).unwrap();
+            writeln!(self.upgrade_file, "{line}").unwrap();
         }
         return None;
 
@@ -218,12 +218,12 @@ where
         let type_name = extract_name(&create);
 
         if type_name.starts_with("toolkit_experimental") || type_name.starts_with("tests") {
-            writeln!(self.upgrade_file, "CREATE TYPE {}", create).unwrap();
+            writeln!(self.upgrade_file, "CREATE TYPE {create}").unwrap();
             return;
         }
 
         if self.new_stabilizations.new_types.contains(&type_name) {
-            writeln!(self.upgrade_file, "CREATE TYPE {}", create).unwrap();
+            writeln!(self.upgrade_file, "CREATE TYPE {create}").unwrap();
             return;
         }
 
@@ -260,19 +260,15 @@ where
                 Some(value) => value,
             };
             if alter_statement.is_empty() {
-                write!(
-                    &mut alter_statement,
-                    "ALTER TYPE {name} SET (",
-                    name = type_name
-                )
-                .expect("cannot write ALTER");
+                write!(&mut alter_statement, "ALTER TYPE {type_name} SET (")
+                    .expect("cannot write ALTER");
             } else {
                 alter_statement.push_str(", ");
             }
             write!(
                 &mut alter_statement,
-                "{} = {}",
-                ALTERABLE_PROPERTIES[i], value
+                "{} = {value}",
+                ALTERABLE_PROPERTIES[i]
             )
             .expect("cannot write ALTER");
         }
@@ -280,7 +276,7 @@ where
             alter_statement.push_str(");");
         }
 
-        writeln!(self.upgrade_file, "{}", alter_statement).expect("cannot write ALTER TYPE");
+        writeln!(self.upgrade_file, "{alter_statement}").expect("cannot write ALTER TYPE");
     }
 
     fn handle_create_operator(&mut self, create: String) {
@@ -362,7 +358,7 @@ where
             let field = split.next().unwrap().trim();
             let value = split
                 .next()
-                .unwrap_or_else(|| panic!("no value for field {}", field))
+                .unwrap_or_else(|| panic!("no value for field {field}"))
                 .trim();
             assert_eq!(split.next(), None);
 
@@ -374,10 +370,7 @@ where
                 }
             }
             if !found_match && !allow_no_match {
-                panic!(
-                    "{} is not considered an acceptable property for this object",
-                    field
-                )
+                panic!("{field} is not considered an acceptable property for this object")
             }
         }
 
@@ -412,7 +405,7 @@ fn parse_arg_types(stmt: &str) -> Vec<Vec<String>> {
     // with arbitrary interior whitespace and comments into a
     // `Vec<Vec<type segment>>`
     let stmt = stmt.trim_start();
-    assert!(stmt.starts_with('('), "stmt.starts_with('(') {}", stmt);
+    assert!(stmt.starts_with('('), "stmt.starts_with('(') {stmt}");
     let end = stmt.find(')').expect("cannot find ')' for arg list");
     let args = &stmt[1..end];
     let mut types = vec![];
@@ -512,23 +505,23 @@ fn version(s: &str) -> Version {
     let version = Version {
         major: nums
             .next()
-            .unwrap_or_else(|| panic!("no major version in `{}`", s))
+            .unwrap_or_else(|| panic!("no major version in `{s}`"))
             .parse()
-            .unwrap_or_else(|e| panic!("error {} for major version in `{}`", e, s)),
+            .unwrap_or_else(|e| panic!("error {e} for major version in `{s}`")),
         minor: nums
             .next()
-            .unwrap_or_else(|| panic!("no minor version in `{}`", s))
+            .unwrap_or_else(|| panic!("no minor version in `{s}`"))
             .parse()
-            .unwrap_or_else(|e| panic!("error {} for minor version in `{}`", e, s)),
+            .unwrap_or_else(|e| panic!("error {e} for minor version in `{s}`")),
         patch: nums
             .next()
             .unwrap_or("0")
             .trim_end_matches("-dev")
             .parse()
-            .unwrap_or_else(|e| panic!("error {} for major version in `{}`", e, s)),
+            .unwrap_or_else(|e| panic!("error {e} for major version in `{s}`")),
     };
     if nums.next().is_some() {
-        panic!("extra `.`s in `{}`", s)
+        panic!("extra `.`s in `{s}`")
     }
     version
 }

--- a/tools/sql-doctester/Cargo.toml
+++ b/tools/sql-doctester/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 bytecount = "0.6.2"
 clap = { version = "3.2.15", features = ["wrap_help"] }
 colored = "2.0.0"
-postgres = "=0.19.7" # pinned because we pin tokio-postgres
+postgres = "=0.19.10" # pinned because we pin tokio-postgres
 pulldown-cmark = "0.8.0"
 rayon = "1.5"
-tokio-postgres = "=0.7.10" # pinned because 0.7.11 added `SimpleQueryMessage::RowDescription`
+tokio-postgres = "=0.7.13" # pinned because 0.7.11 added `SimpleQueryMessage::RowDescription`
 uuid = { version = "0.8", features = ["v4"] }
 walkdir = "2"

--- a/tools/sql-doctester/src/main.rs
+++ b/tools/sql-doctester/src/main.rs
@@ -61,7 +61,7 @@ fn main() {
             test.header.bold().dimmed()
         );
         let _ = writeln!(&mut out, "{}", error.annotate_position(&test.text));
-        let _ = writeln!(&mut out, "{}\n", error);
+        let _ = writeln!(&mut out, "{error}\n");
     };
 
     runner::run_tests(connection_config, startup_script, all_tests, on_error);

--- a/tools/sql-doctester/src/parser.rs
+++ b/tools/sql-doctester/src/parser.rs
@@ -69,8 +69,7 @@ pub fn extract_tests_from_string(s: &str, file_stem: &str) -> TestFile {
 
                 if let BlockKind::Output = code_block_info.kind {
                     panic!(
-                        "found output with no test test.\n{}:{} {:?}",
-                        file_stem, current_line, heading_stack
+                        "found output with no test test.\n{file_stem}:{current_line} {heading_stack:?}"
                     )
                 }
 
@@ -78,7 +77,7 @@ pub fn extract_tests_from_string(s: &str, file_stem: &str) -> TestFile {
 
                 stateless &= code_block_info.transactional;
                 let mut test = Test {
-                    location: format!("{}:{}", file_stem, current_line),
+                    location: format!("{file_stem}:{current_line}"),
                     header: if heading_stack.is_empty() {
                         "<root>".to_string()
                     } else {
@@ -115,8 +114,7 @@ pub fn extract_tests_from_string(s: &str, file_stem: &str) -> TestFile {
                                         && !code_block_info.precision_limits.is_empty()
                                     {
                                         panic!(
-                                            "cannot have precision limits on both test and output.\n{}:{} {:?}",
-                                            file_stem, current_line, heading_stack
+                                            "cannot have precision limits on both test and output.\n{file_stem}:{current_line} {heading_stack:?}"
                                         )
                                     }
                                     test.precision_limits = code_block_info.precision_limits;
@@ -208,7 +206,7 @@ fn parse_code_block_info(info: &str) -> CodeBlockInfo {
             p if p.starts_with("precision") => {
                 // syntax `precision(col: bytes)`
                 let precision_err =
-                    || -> ! { panic!("invalid syntax for `precision(col: bytes)` found `{}`", p) };
+                    || -> ! { panic!("invalid syntax for `precision(col: bytes)` found `{p}`") };
                 let arg = &p["precision".len()..];
                 if arg.as_bytes().first() != Some(&b'(') || arg.as_bytes().last() != Some(&b')') {
                     precision_err()
@@ -222,7 +220,7 @@ fn parse_code_block_info(info: &str) -> CodeBlockInfo {
                 let length = args[1].trim().parse().unwrap_or_else(|_| precision_err());
                 let old = info.precision_limits.insert(column, length);
                 if old.is_some() {
-                    panic!("duplicate precision for column {}", column)
+                    panic!("duplicate precision for column {column}")
                 }
             }
             _ => {}

--- a/tools/update-tester/src/installer.rs
+++ b/tools/update-tester/src/installer.rs
@@ -129,7 +129,7 @@ fn tag_version(version: &str) -> String {
         return version.into();
     }
 
-    format!("{}.0", version)
+    format!("{version}.0")
 }
 
 //-----------------------//
@@ -137,7 +137,7 @@ fn tag_version(version: &str) -> String {
 //-----------------------//
 
 fn version_is_installed(pg_config: &str, version: &str) -> xshell::Result<bool> {
-    let binary_name = format!("timescaledb_toolkit-{}.so", version);
+    let binary_name = format!("timescaledb_toolkit-{version}.so");
     let bin_dir = cmd!("{pg_config} --pkglibdir").read()?;
     let installed_files = read_dir(bin_dir)?;
     let installed = installed_files.into_iter().any(|file| {

--- a/tools/update-tester/src/main.rs
+++ b/tools/update-tester/src/main.rs
@@ -195,7 +195,7 @@ fn main() {
                     test.header.bold().dimmed()
                 );
                 eprintln!("{}", error.annotate_position(&test.text));
-                eprintln!("{}\n", error);
+                eprintln!("{error}\n");
             };
 
             let res = try_main(
@@ -209,7 +209,7 @@ fn main() {
                 on_error,
             );
             if let Err(err) = res {
-                eprintln!("{}", err);
+                eprintln!("{err}");
                 process::exit(1);
             }
             if num_errors > 0 {
@@ -240,11 +240,11 @@ fn main() {
                     test.header.bold().dimmed()
                 );
                 eprintln!("{}", error.annotate_position(&test.text));
-                eprintln!("{}\n", error);
+                eprintln!("{error}\n");
             };
             let res = try_create_objects(&connection_config, on_error);
             if let Err(err) = res {
-                eprintln!("{}", err);
+                eprintln!("{err}");
                 process::exit(1);
             }
             if num_errors > 0 {
@@ -276,17 +276,17 @@ fn main() {
                     test.header.bold().dimmed()
                 );
                 eprintln!("{}", error.annotate_position(&test.text));
-                eprintln!("{}\n", error);
+                eprintln!("{error}\n");
             };
 
             let root_dir = ".";
             let res = try_validate_objects(&connection_config, root_dir, on_error);
             if let Err(err) = res {
-                eprintln!("{}", err);
+                eprintln!("{err}");
                 process::exit(1);
             }
             if num_errors > 0 {
-                eprintln!("{} {}\n", num_errors, "Tests Failed".bold().red());
+                eprintln!("{num_errors} {}\n", "Tests Failed".bold().red());
                 eprintln!("{}\n", "Validation Failed".bold().red());
                 process::exit(1)
             }
@@ -367,7 +367,7 @@ fn get_version_info(root_dir: &str) -> xshell::Result<(String, Vec<String>)> {
         .to_owned();
 
     let upgradable_from = get_upgradeable_from(&control_contents)
-        .unwrap_or_else(|e| panic!("{} in control file {}", e, control_contents));
+        .unwrap_or_else(|e| panic!("{e} in control file {control_contents}"));
 
     Ok((current_version, upgradable_from))
 }
@@ -378,7 +378,7 @@ fn get_version_info(root_dir: &str) -> xshell::Result<(String, Vec<String>)> {
 
 // run a command, only printing the output on failure
 fn quietly_run(cmd: Cmd) -> xshell::Result<()> {
-    let display = format!("{}", cmd);
+    let display = format!("{cmd}");
     let output = cmd.ignore_status().output()?;
     if !output.status.success() {
         io::stdout()
@@ -388,9 +388,8 @@ fn quietly_run(cmd: Cmd) -> xshell::Result<()> {
             .write_all(&output.stderr)
             .expect("cannot write to stdout");
         panic!(
-            "{} `{}` exited with a non-zero error code {}",
+            "{} `{display}` exited with a non-zero error code {}",
             "ERROR".bold().red(),
-            display,
             output.status
         )
     }

--- a/tools/update-tester/src/parser.rs
+++ b/tools/update-tester/src/parser.rs
@@ -116,8 +116,7 @@ pub fn extract_tests_from_string(s: &str, file_stem: &str) -> TestFile {
 
                 if let BlockKind::Output = code_block_info.kind {
                     panic!(
-                        "found output with no test test.\n{}:{} {:?}",
-                        file_stem, current_line, heading_stack
+                        "found output with no test test.\n{file_stem}:{current_line} {heading_stack:?}"
                     )
                 }
 
@@ -125,7 +124,7 @@ pub fn extract_tests_from_string(s: &str, file_stem: &str) -> TestFile {
 
                 stateless &= code_block_info.transactional;
                 let mut test = Test {
-                    location: format!("{}:{}", file_stem, current_line),
+                    location: format!("{file_stem}:{current_line}"),
                     header: if heading_stack.is_empty() {
                         "<root>".to_string()
                     } else {
@@ -165,8 +164,7 @@ pub fn extract_tests_from_string(s: &str, file_stem: &str) -> TestFile {
                                         && !code_block_info.precision_limits.is_empty()
                                     {
                                         panic!(
-                                            "cannot have precision limits on both test and output.\n{}:{} {:?}",
-                                            file_stem, current_line, heading_stack
+                                            "cannot have precision limits on both test and output.\n{file_stem}:{current_line} {heading_stack:?}",
                                         )
                                     }
                                     test.precision_limits = code_block_info.precision_limits;
@@ -273,7 +271,7 @@ fn parse_code_block_info(info: &str) -> CodeBlockInfo {
             p if p.starts_with("precision") => {
                 // syntax `precision(col: bytes)`
                 let precision_err =
-                    || -> ! { panic!("invalid syntax for `precision(col: bytes)` found `{}`", p) };
+                    || -> ! { panic!("invalid syntax for `precision(col: bytes)` found `{p}`") };
                 let arg = &p["precision".len()..];
                 if arg.as_bytes().first() != Some(&b'(') || arg.as_bytes().last() != Some(&b')') {
                     precision_err()
@@ -287,7 +285,7 @@ fn parse_code_block_info(info: &str) -> CodeBlockInfo {
                 let length = args[1].trim().parse().unwrap_or_else(|_| precision_err());
                 let old = info.precision_limits.insert(column, length);
                 if old.is_some() {
-                    panic!("duplicate precision for column {}", column)
+                    panic!("duplicate precision for column {column}")
                 }
             }
             _ => {}


### PR DESCRIPTION
- c-unwind changes: we need to declare the functions that potentially do long jumps as `extern "C-unwind"`
- Lifetime constraint errors in PostgresType derive macro
- API changes (as_u32 → to_u32) and mutability requirements
- using `let mut state = state;` pattern in serialize functions:
- changed the `pg_type!` macro such that it routes the lifetime and no lifetime versions to two different implementations:
  - `pg_type_impl!` vs `pg_type_no_lifetime_impl!`
  - the no_lifetime version doesn't derive the generated struct from PostgresType because it can't handle generic lifetimes properly as it generates functions where none of the input parameter is bound to the returned type. For this reason the 'lifetimed' version needs to implement much of the same functionality that the 'no life time' version gets for free: type registration and I/O functions
  - I made an effor to get rid of lifetimes whereever it was feasible, so we rely on the factory PostgresType derive as much as possible
  - a common theme of the removable lifetimes is getting rid of self referencing arrays like `[i64; self.num_intervals]`
- Get rid of lifetimes from accessors by:
  - converting `bytes: [u8; self.len]` to the actual enum being represented
  - replace self.len with an upper bound when it is known like AccessorIntegral
  - use an upper bound imposed by serde (32) like in AccessorPercentileArray
  - handle consequences at other places, where accessors used with lifetime
  - modified accessor\! macro to use new lifetime-free macros
- Removed lifetimes where they were not bound to anything
- SPI API changes where:
  - `Spi::connect(|mut client| {})` is replaced by `Spi::connect_mut(|client| {})`
  - `client.update(query, None, None)` is replaced by `client.update(query, None, &[])`
- created two implementation of `ron_inout_funcs!` and it dispatches between the ones that needs or doesn't need lifetime:
   - `ron_inout_funcs_impl!` vs `ron_inout_funcs_no_lifetime_impl!`
 - made the lifetime choice explicit at the call site (previously lifetime was always assumed)
   - `ron_inout_funcs!(CountMinSketch)` vs new `ron_inout_funcs!(CountMinSketch<'input>)`
- handle new clippy warnings due to compiler/clippy upgrade