### PR TITLE
Update rust version to 1.89

### DIFF
--- a/crates/asap/src/lib.rs
+++ b/crates/asap/src/lib.rs
@@ -239,7 +239,7 @@ struct Metrics<'a> {
 }
 
 impl Metrics<'_> {
-    fn new(values: &[f64]) -> Metrics {
+    fn new(values: &[f64]) -> Metrics<'_> {
         Metrics {
             len: values.len() as u32,
             values,

--- a/crates/udd-sketch/src/lib.rs
+++ b/crates/udd-sketch/src/lib.rs
@@ -144,7 +144,7 @@ impl SketchHashMap {
         self.entry_upsert(key, 1);
     }
 
-    fn iter(&self) -> SketchHashIterator {
+    fn iter(&self) -> SketchHashIterator<'_> {
         SketchHashIterator {
             container: self,
             next_key: self.head,
@@ -402,7 +402,7 @@ impl UDDSketch {
         self.alpha = 2.0 * self.alpha / (1.0 + self.alpha.powi(2)); // See https://arxiv.org/pdf/2004.08604.pdf Equation 4
     }
 
-    pub fn bucket_iter(&self) -> SketchHashIterator {
+    pub fn bucket_iter(&self) -> SketchHashIterator<'_> {
         self.buckets.iter()
     }
 }

--- a/extension/src/bin/pgrx_embed.rs
+++ b/extension/src/bin/pgrx_embed.rs
@@ -1,1 +1,3 @@
+// so we can support upgrading pgrx
+#![allow(unexpected_cfgs)]
 ::pgrx::pgrx_embed!();

--- a/extension/src/frequency.rs
+++ b/extension/src/frequency.rs
@@ -43,7 +43,7 @@ const DEFAULT_ZETA_SKEW: f64 = 1.1;
 
 // probability of the nth element of a zeta distribution
 fn zeta_eq_n(skew: f64, n: u64) -> f64 {
-    1.0 / zeta(skew) * (n as f64).powf(-1. * skew)
+    1.0 / zeta(skew) * (n as f64).powf(-skew)
 }
 // cumulative distribution <= n in a zeta distribution
 fn zeta_le_n(skew: f64, n: u64) -> f64 {
@@ -1398,7 +1398,7 @@ pub fn topn(
     agg: SpaceSavingAggregate<'_>,
     n: i32,
     ty: Option<AnyElement>,
-) -> SetOfIterator<AnyElement> {
+) -> SetOfIterator<'_, AnyElement> {
     // If called with a NULL, assume type matches
     if ty.is_some() && ty.unwrap().oid().as_u32() != agg.type_oid {
         pgrx::error!("mischatched types")
@@ -1433,7 +1433,7 @@ pub fn topn(
 pub fn default_topn(
     agg: SpaceSavingAggregate<'_>,
     ty: Option<AnyElement>,
-) -> SetOfIterator<AnyElement> {
+) -> SetOfIterator<'_, AnyElement> {
     if agg.topn == 0 {
         pgrx::error!("frequency aggregates require a N parameter to topn")
     }
@@ -1442,7 +1442,7 @@ pub fn default_topn(
 }
 
 #[pg_extern(immutable, parallel_safe, name = "topn")]
-pub fn topn_bigint(agg: SpaceSavingBigIntAggregate<'_>, n: i32) -> SetOfIterator<i64> {
+pub fn topn_bigint(agg: SpaceSavingBigIntAggregate<'_>, n: i32) -> SetOfIterator<'_, i64> {
     validate_topn_for_mcv_agg(
         n,
         agg.topn,
@@ -1471,7 +1471,7 @@ pub fn arrow_topn_bigint<'a>(
 }
 
 #[pg_extern(immutable, parallel_safe, name = "topn")]
-pub fn default_topn_bigint(agg: SpaceSavingBigIntAggregate<'_>) -> SetOfIterator<i64> {
+pub fn default_topn_bigint(agg: SpaceSavingBigIntAggregate<'_>) -> SetOfIterator<'_, i64> {
     if agg.topn == 0 {
         pgrx::error!("frequency aggregates require a N parameter to topn")
     }
@@ -1489,7 +1489,7 @@ pub fn arrow_default_topn_bigint<'a>(
 }
 
 #[pg_extern(immutable, parallel_safe, name = "topn")]
-pub fn topn_text(agg: SpaceSavingTextAggregate<'_>, n: i32) -> SetOfIterator<String> {
+pub fn topn_text(agg: SpaceSavingTextAggregate<'_>, n: i32) -> SetOfIterator<'_, String> {
     validate_topn_for_mcv_agg(
         n,
         agg.topn,
@@ -1521,7 +1521,7 @@ pub fn arrow_topn_text<'a>(
 }
 
 #[pg_extern(immutable, parallel_safe, name = "topn")]
-pub fn default_topn_text(agg: SpaceSavingTextAggregate<'_>) -> SetOfIterator<String> {
+pub fn default_topn_text(agg: SpaceSavingTextAggregate<'_>) -> SetOfIterator<'_, String> {
     if agg.topn == 0 {
         pgrx::error!("frequency aggregates require a N parameter to topn")
     }

--- a/extension/src/gauge_agg.rs
+++ b/extension/src/gauge_agg.rs
@@ -519,7 +519,7 @@ fn arrow_with_bounds<'a>(
 }
 
 #[pg_extern(strict, immutable, parallel_safe, schema = "toolkit_experimental")]
-fn with_bounds(summary: GaugeSummary<'_>, bounds: tstzrange) -> GaugeSummary {
+fn with_bounds(summary: GaugeSummary<'_>, bounds: tstzrange) -> GaugeSummary<'_> {
     // TODO dedup with previous by using apply_bounds
     unsafe {
         let ptr = bounds.0.cast_mut_ptr();

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -1,3 +1,5 @@
+// so we can support upgrading pgrx
+#![allow(unexpected_cfgs)]
 // so we can allow very new Clippy lints
 #![allow(unknown_lints)]
 // flat_serialize! alignment checks hit this for any single byte field (of which all pg_types! have two by default)

--- a/extension/src/state_aggregate.rs
+++ b/extension/src/state_aggregate.rs
@@ -270,7 +270,7 @@ pub mod toolkit_experimental {
             interval_start: i64,
             interval_len: i64,
             prev: Option<CompactStateAgg>,
-        ) -> CompactStateAgg {
+        ) -> CompactStateAgg<'_> {
             if self.durations.is_empty() {
                 pgrx::error!("unable to interpolate interval on state aggregate with no data");
             }

--- a/extension/src/time_vector.rs
+++ b/extension/src/time_vector.rs
@@ -36,7 +36,7 @@ pg_type! {
         flags: u8,         // extra information about the stored data
         internal_padding: [u8; 3],  // required to be aligned
         points: [TSPoint; self.num_points],
-        null_val: [u8; (self.num_points + 7)/ 8], // bit vector, must be last element for alignment purposes
+        null_val: [u8; self.num_points.div_ceil(8)], // bit vector, must be last element for alignment purposes
     }
 }
 

--- a/extension/src/time_vector/pipeline/aggregation.rs
+++ b/extension/src/time_vector/pipeline/aggregation.rs
@@ -191,7 +191,7 @@ ALTER FUNCTION "arrow_run_pipeline_then_stats_agg" SUPPORT toolkit_experimental.
 )]
 pub fn sum_pipeline_element<'a>(
     accessor: AccessorSum<'_>,
-) -> toolkit_experimental::PipelineThenSum {
+) -> toolkit_experimental::PipelineThenSum<'_> {
     let _ = accessor;
     build! {
         PipelineThenSum {
@@ -279,7 +279,7 @@ ALTER FUNCTION "arrow_pipeline_then_sum" SUPPORT toolkit_experimental.pipeline_s
 #[pg_extern(immutable, parallel_safe, schema = "toolkit_experimental")]
 pub fn average_pipeline_element(
     accessor: AccessorAverage<'_>,
-) -> toolkit_experimental::PipelineThenAverage {
+) -> toolkit_experimental::PipelineThenAverage<'_> {
     let _ = accessor;
     build! {
         PipelineThenAverage {
@@ -376,7 +376,7 @@ ALTER FUNCTION "arrow_pipeline_then_average" SUPPORT toolkit_experimental.pipeli
 )]
 pub fn num_vals_pipeline_element(
     accessor: AccessorNumVals<'_>,
-) -> toolkit_experimental::PipelineThenNumVals {
+) -> toolkit_experimental::PipelineThenNumVals<'_> {
     let _ = accessor;
     build! {
         PipelineThenNumVals {

--- a/tools/dependencies.sh
+++ b/tools/dependencies.sh
@@ -16,7 +16,7 @@ CARGO_EDIT=0.11.2
 # Keep synchronized with extension/Cargo.toml and `cargo install --version N.N.N cargo-pgrx` in Readme.md .
 PGRX_VERSION=0.12.9
 
-RUST_TOOLCHAIN=1.82.0
+RUST_TOOLCHAIN=1.89.0
 RUST_PROFILE=minimal
 RUST_COMPONENTS=clippy,rustfmt
 

--- a/tools/post-install/Cargo.toml
+++ b/tools/post-install/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-xshell = "0.1.14"
+xshell = "0.1.17"
 walkdir = "2"

--- a/tools/post-install/src/main.rs
+++ b/tools/post-install/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use std::{
     env,
     fs::{self, File},

--- a/tools/update-tester/Cargo.toml
+++ b/tools/update-tester/Cargo.toml
@@ -14,7 +14,7 @@ clap = { version = "3.2.15", features = ["wrap_help"] }
 postgres = "0.19.1"
 semver = "1.0.9"
 toml_edit = "0.14.3"
-xshell = "0.1.14"
+xshell = "0.1.17"
 pulldown-cmark = "0.8.0"
 walkdir = "2.3.2"
 bytecount = "0.6.3"

--- a/tools/update-tester/src/installer.rs
+++ b/tools/update-tester/src/installer.rs
@@ -1,3 +1,5 @@
+#![allow(unexpected_cfgs)]
+
 use std::{collections::HashSet, path::Path};
 
 use colored::Colorize;


### PR DESCRIPTION
so it supports edition2025 feature needed for the upcoming pgrx upgrade

plus handle the fallouts, related to new clippy warnings