### PR TITLE
Adjust ci setup for recent ubuntu versions

### DIFF
--- a/docker/ci/setup.sh
+++ b/docker/ci/setup.sh
@@ -165,11 +165,7 @@ EOF
             #   certificate store, which we trust docker to provide a good copy
             #   of.  May as well just put [trusted=yes] into sources.list instead
             #   of bothering with apt-key...
-            if [ "${OS_NAME}" = "ubuntu" ]; then
-                curl -Ls https://packagecloud.io/timescale/timescaledb/gpgkey | apt-key add -
-            else
-                curl -Ls https://packagecloud.io/timescale/timescaledb/gpgkey | gpg --dearmor -o /etc/apt/trusted.gpg.d/timescale_timescaledb.gpg
-            fi
+            curl -Ls https://packagecloud.io/timescale/timescaledb/gpgkey | gpg --dearmor -o /etc/apt/trusted.gpg.d/timescale_timescaledb.gpg
 
             mkdir -p /etc/apt/sources.list.d
             cat > /etc/apt/sources.list.d/timescaledb.list <<EOF


### PR DESCRIPTION
apt-key is deprecated and no longer present in recent versions
