### PR TITLE
Update CI/Build versions of Ubuntu and Rockylinux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ jobs:
           container:
             os: ubuntu
             version: "26.04"
+        - pgversion: 15
+          container:
+            os: rockylinux
+            version: "10"
     env:
       # TODO Why?  Cargo default is to pass `-C incremental` to rustc; why don't we want that?
       #   https://doc.rust-lang.org/rustc/codegen-options/index.html#incremental

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,10 @@ jobs:
             skip: true
         - container:
             schedule: false
+        - pgversion: 15
+          container:
+            os: ubuntu
+            version: "26.04"
     env:
       # TODO Why?  Cargo default is to pass `-C incremental` to rustc; why don't we want that?
       #   https://doc.rust-lang.org/rustc/codegen-options/index.html#incremental

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
         pgversion: [15, 16, 17, 18]
         container:
         - os: rockylinux
+          version: "10"
+          image: rockylinux-10-x86_64
+          schedule: true
+        - os: rockylinux
           version: "9"
           image: rockylinux-9-x86_64
           schedule: true
@@ -66,12 +70,12 @@ jobs:
           image: debian-11-amd64
           schedule: ${{ inputs.all-platforms || ( github.event_name == 'schedule' && github.event.schedule == '0 6 * * 1-4' ) }}
         - os: ubuntu
-          version: "24.04"
-          image: ubuntu-24.04-amd64
+          version: "26.04"
+          image: ubuntu-26.04-amd64
           schedule: true
         - os: ubuntu
-          version: "22.04"
-          image: ubuntu-22.04-amd64
+          version: "24.04"
+          image: ubuntu-24.04-amd64
           schedule: ${{ inputs.all-platforms || ( github.event_name == 'schedule' && github.event.schedule == '0 6 * * 1-4' ) }}
         exclude:
         - container:

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -20,6 +20,14 @@ ENV CARGO_HOME=/usr/local/cargo
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV PATH="${CARGO_HOME}/bin:/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin"
 
+# TODO: Remove once pgrx v1.18.1 is released.
+RUN printf '%s\n' \
+        'SECTIONS {' \
+        '  .pgrxsc : { KEEP(*(.pgrxsc)) }' \
+        '} INSERT AFTER .rodata;' \
+        > /usr/local/share/keep-pgrxsc.ld
+ENV RUSTFLAGS="-C link-arg=-Wl,-T,/usr/local/share/keep-pgrxsc.ld"
+
 COPY docker/ci/setup.sh /
 COPY tools/dependencies.sh /
 # TODO simple option processing a la build and testbin would make this less error-prone

--- a/docker/ci/setup.sh
+++ b/docker/ci/setup.sh
@@ -44,6 +44,40 @@ case $OS_NAME in
         ;;
 esac
 
+# Once we completely drop support of PG15 and el/8 we should revert this fix
+# 9d4157a8bde08d778684c6371daea9814fa176ea
+should_skip_postgres_version() {
+    pg=$1
+
+    if [ "$OS_NAME" = rockylinux ] && [ "$OS_VERSION" = 8 ] && [ "$pg" = 18 ]; then
+        echo "Skipping PostgreSQL $pg on EL $OS_VERSION"
+        return 0
+    fi
+
+    if [ "$OS_NAME" = ubuntu ] && [ "$OS_VERSION" = 26.04 ] && [ "$pg" = 15 ]; then
+        echo "Skipping PostgreSQL $pg on $OS_NAME $OS_VERSION"
+        return 0
+    fi
+
+    return 1
+}
+
+should_skip_timescaledb_version() {
+    pg=$1
+
+    if [ "$OS_NAME" = rockylinux ] && [ "$OS_VERSION" = 8 ] && [ "$pg" = 18 ]; then
+        echo "Skipping TimescaleDB for PostgreSQL $pg on EL $OS_VERSION; no package is available"
+        return 0
+    fi
+
+    if [ "$OS_NAME" = ubuntu ] && [ "$OS_VERSION" = 26.04 ] && [ "$pg" = 15 ]; then
+        echo "Skipping TimescaleDB for PostgreSQL $pg on $OS_NAME $OS_VERSION; no package is available"
+        return 0
+    fi
+
+    return 1
+}
+
 if $privileged; then
     # Phase 1 - cross-platform prerequisites
     useradd -u 1001 -md "$BUILDER_HOME" $BUILDER_USERNAME
@@ -107,6 +141,9 @@ metadata_expire=300
 EOF
 
             for pg in $PG_VERSIONS; do
+                if should_skip_postgres_version "$pg"; then
+                    continue
+                fi
                 yum -q -y install \
                     postgresql$pg-devel \
                     postgresql$pg-server
@@ -115,6 +152,9 @@ EOF
             done;
 
             for pg in $TSDB_PG_VERSIONS; do
+                if should_skip_timescaledb_version "$pg"; then
+                    continue
+                fi
                 yum -q -y install timescaledb-2-postgresql-$pg
             done
 
@@ -175,6 +215,9 @@ EOF
             apt-get -qq update
 
             for pg in $PG_VERSIONS; do
+                if should_skip_postgres_version "$pg"; then
+                    continue
+                fi
                 apt-get -qq install \
                         postgresql-$pg \
                         postgresql-server-dev-$pg
@@ -183,6 +226,9 @@ EOF
             done
 
             for pg in $TSDB_PG_VERSIONS; do
+                if should_skip_timescaledb_version "$pg"; then
+                    continue
+                fi
                 # timescaledb packages Recommend toolkit, which we don't want here.
                 apt-get -qq install --no-install-recommends timescaledb-2-postgresql-$pg
             done

--- a/docker/ci/setup.sh
+++ b/docker/ci/setup.sh
@@ -22,7 +22,7 @@ if [ $# -ne 6 ]; then
 fi
 
 ARCH=$1
-OS_NAME=$2
+OS_NAME=${2##*/}
 OS_VERSION=$3
 OS_CODE_NAME=$4
 BUILDER_USERNAME=$5

--- a/docker/ci/setup.sh
+++ b/docker/ci/setup.sh
@@ -70,6 +70,11 @@ should_skip_timescaledb_version() {
         return 0
     fi
 
+    if [ "$OS_NAME" = rockylinux ] && [ "$OS_VERSION" = 10 ] && [ "$pg" = 15 ]; then
+        echo "Skipping TimescaleDB for PostgreSQL $pg on EL $OS_VERSION; no package is available"
+        return 0
+    fi
+
     if [ "$OS_NAME" = ubuntu ] && [ "$OS_VERSION" = 26.04 ] && [ "$pg" = 15 ]; then
         echo "Skipping TimescaleDB for PostgreSQL $pg on $OS_NAME $OS_VERSION; no package is available"
         return 0
@@ -103,8 +108,14 @@ if $privileged; then
                     dnf -qy install ruby-devel rubygems
                     ;;
 
+                10)
+                    yum -qy install dnf-plugins-core
+                    dnf config-manager --enable crb
+                    dnf -qy install ruby-devel rubygems
+                    ;;
+
                 *)
-                    echo >&2 'only 7 - 9 supported'
+                    echo >&2 'only 8 - 10 supported'
                     exit 5
                     ;;
             esac

--- a/tools/dependencies.sh
+++ b/tools/dependencies.sh
@@ -20,9 +20,9 @@ RUST_TOOLCHAIN=1.89.0
 RUST_PROFILE=minimal
 RUST_COMPONENTS=clippy,rustfmt
 
-# We use fpm 1.14.2 to build RPMs.
+# We use fpm to build RPMs.
 # TODO Use rpmbuild directly.
-FPM_VERSION=1.14.2
+FPM_VERSION=1.17.0
 
 GH_DEB_URL=https://github.com/cli/cli/releases/download/v2.16.1/gh_2.16.1_linux_amd64.deb
 GH_DEB_SHA256=d0ba8693b6e4c1bde6683ccfa971a15c00b9fe92865074d48609959d04399dc7

--- a/tools/dependencies.sh
+++ b/tools/dependencies.sh
@@ -8,8 +8,8 @@
 # information across all those.
 
 PG_VERSIONS='15 16 17 18'
-# TODO: extend this with 18 this once TimescaleDB supports PostgreSQL 18
-TSDB_PG_VERSIONS='15 16 17'
+
+TSDB_PG_VERSIONS='15 16 17 18'
 
 CARGO_EDIT=0.11.2
 


### PR DESCRIPTION
* Add **Ubuntu 26.04**
* Add **al/10**. 

skips building
* **al/8 + pg18**
* **al/10 + pg15**
*  **Ubuntu 26.04 + pg15** 

since these couples are no longer supported by timescaledb