### PR TITLE
Fix `max_n` and `max_n_by` when used on empty tables

### DIFF
--- a/extension/src/nmost/max_by_float.rs
+++ b/extension/src/nmost/max_by_float.rs
@@ -107,7 +107,7 @@ pub fn max_n_by_float_to_values(
                 .into_iter()
                 .zip(agg.data.clone().into_anyelement_iter()),
         ),
-        None => TableIterator::new(std::iter::empty()),
+        None => TableIterator::empty(),
     }
 }
 

--- a/extension/src/nmost/max_by_float.rs
+++ b/extension/src/nmost/max_by_float.rs
@@ -225,7 +225,7 @@ mod tests {
     }
 
     #[pg_test]
-    fn max_n_by_empty_input_returns_null() {
+    fn max_by_float_empty_input_returns_null() {
         Spi::connect_mut(|client| {
             client.update(
                 "CREATE TABLE data(ts TIMESTAMPTZ, value DOUBLE PRECISION);", None, &[],
@@ -240,7 +240,7 @@ mod tests {
     }
 
     #[pg_test]
-    fn max_n_by_into_values_empty_returns_no_rows() {
+    fn max_by_float_into_values_empty_returns_no_rows() {
         Spi::connect_mut(|client| {
             client.update(
                 "CREATE TABLE data(ts TIMESTAMPTZ, value DOUBLE PRECISION);", None, &[],

--- a/extension/src/nmost/max_by_float.rs
+++ b/extension/src/nmost/max_by_float.rs
@@ -238,10 +238,12 @@ mod tests {
                 .update("SELECT max_n_by(value, ts, 1)::TEXT FROM data", None, &[])
                 .unwrap();
 
-            assert!(result.next().unwrap()[1]
-                .value::<String>()
-                .unwrap()
-                .is_none());
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<String>()
+                    .unwrap()
+                    .is_none()
+            );
         })
     }
 

--- a/extension/src/nmost/max_by_float.rs
+++ b/extension/src/nmost/max_by_float.rs
@@ -110,7 +110,6 @@ pub fn max_n_by_float_to_values(
         ),
         None => TableIterator::new(std::iter::empty()),
     }
-    
 }
 
 extension_sql!(
@@ -227,33 +226,46 @@ mod tests {
     #[pg_test]
     fn max_by_float_empty_input_returns_null() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(ts TIMESTAMPTZ, value DOUBLE PRECISION);", None, &[],
-            ).unwrap();
+            client
+                .update(
+                    "CREATE TABLE data(ts TIMESTAMPTZ, value DOUBLE PRECISION);",
+                    None,
+                    &[],
+                )
+                .unwrap();
 
-            let mut result = client.update(
-            "SELECT max_n_by(value, ts, 1)::TEXT FROM data", None, &[],
-                ).unwrap();
+            let mut result = client
+                .update("SELECT max_n_by(value, ts, 1)::TEXT FROM data", None, &[])
+                .unwrap();
 
-            assert!(result.next().unwrap()[1].value::<String>().unwrap().is_none());
+            assert!(result.next().unwrap()[1]
+                .value::<String>()
+                .unwrap()
+                .is_none());
         })
     }
 
     #[pg_test]
     fn max_by_float_into_values_empty_returns_no_rows() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(ts TIMESTAMPTZ, value DOUBLE PRECISION);", None, &[],
-            ).unwrap();
+            client
+                .update(
+                    "CREATE TABLE data(ts TIMESTAMPTZ, value DOUBLE PRECISION);",
+                    None,
+                    &[],
+                )
+                .unwrap();
 
-            let mut result = client.update(
-                "SELECT * FROM into_values((
+            let mut result = client
+                .update(
+                    "SELECT * FROM into_values((
                     SELECT max_n_by(value, ts, 1)
                     FROM data
                 ), NULL::timestamptz)",
-                None,
-                &[],
-            ).unwrap();
+                    None,
+                    &[],
+                )
+                .unwrap();
 
             assert!(result.next().is_none());
         })

--- a/extension/src/nmost/max_by_float.rs
+++ b/extension/src/nmost/max_by_float.rs
@@ -88,10 +88,9 @@ pub fn max_n_by_float_rollup_trans(
 #[pg_extern(immutable, parallel_safe)]
 pub fn max_n_by_float_final(state: Internal) -> Option<MaxByFloats<'static>> {
     unsafe {
-        match state.to_inner::<MaxByFloatTransType>() {
-            Some(state) => Some(state.clone().into()),
-            None => None,
-        }
+        state
+            .to_inner::<MaxByFloatTransType>()
+            .map(|state| state.clone().into())
     }
 }
 

--- a/extension/src/nmost/max_by_float.rs
+++ b/extension/src/nmost/max_by_float.rs
@@ -86,22 +86,31 @@ pub fn max_n_by_float_rollup_trans(
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn max_n_by_float_final(state: Internal) -> MaxByFloats<'static> {
-    unsafe { state.to_inner::<MaxByFloatTransType>().unwrap().clone() }.into()
+pub fn max_n_by_float_final(state: Internal) -> Option<MaxByFloats<'static>> {
+    unsafe {
+        match state.to_inner::<MaxByFloatTransType>() {
+            Some(state) => Some(state.clone().into()),
+            None => None,
+        }
+    }
 }
 
 #[pg_extern(name = "into_values", immutable, parallel_safe)]
 pub fn max_n_by_float_to_values(
-    agg: MaxByFloats<'static>,
+    agg: Option<MaxByFloats<'static>>,
     _dummy: Option<AnyElement>,
 ) -> TableIterator<'static, (name!(value, f64), name!(data, AnyElement))> {
-    TableIterator::new(
-        agg.values
-            .values
-            .clone()
-            .into_iter()
-            .zip(agg.data.clone().into_anyelement_iter()),
-    )
+    match agg {
+        Some(agg) => TableIterator::new(
+            agg.values
+                .values
+                .clone()
+                .into_iter()
+                .zip(agg.data.clone().into_anyelement_iter()),
+        ),
+        None => TableIterator::new(std::iter::empty()),
+    }
+    
 }
 
 extension_sql!(
@@ -211,6 +220,41 @@ mod tests {
                 result.next().unwrap()[1].value().unwrap(),
                 Some("(0.7421875,\"(0.7421875,3)\")")
             );
+            assert!(result.next().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn max_n_by_empty_input_returns_null() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(ts TIMESTAMPTZ, value DOUBLE PRECISION);", None, &[],
+            ).unwrap();
+
+            let mut result = client.update(
+            "SELECT max_n_by(value, ts, 1)::TEXT FROM data", None, &[],
+                ).unwrap();
+
+            assert!(result.next().unwrap()[1].value::<String>().unwrap().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn max_n_by_into_values_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(ts TIMESTAMPTZ, value DOUBLE PRECISION);", None, &[],
+            ).unwrap();
+
+            let mut result = client.update(
+                "SELECT * FROM into_values((
+                    SELECT max_n_by(value, ts, 1)
+                    FROM data
+                ), NULL::timestamptz)",
+                None,
+                &[],
+            ).unwrap();
+
             assert!(result.next().is_none());
         })
     }

--- a/extension/src/nmost/max_by_int.rs
+++ b/extension/src/nmost/max_by_int.rs
@@ -229,10 +229,12 @@ mod tests {
                 .update("SELECT max_n_by(val, data, 1)::TEXT FROM data", None, &[])
                 .unwrap();
 
-            assert!(result.next().unwrap()[1]
-                .value::<String>()
-                .unwrap()
-                .is_none());
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<String>()
+                    .unwrap()
+                    .is_none()
+            );
         })
     }
 

--- a/extension/src/nmost/max_by_int.rs
+++ b/extension/src/nmost/max_by_int.rs
@@ -85,22 +85,31 @@ pub fn max_n_by_int_rollup_trans(
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn max_n_by_int_final(state: Internal) -> MaxByInts<'static> {
-    unsafe { state.to_inner::<MaxByIntTransType>().unwrap().clone() }.into()
+pub fn max_n_by_int_final(state: Internal) -> Option<MaxByInts<'static>> {
+    unsafe { 
+        match state.to_inner::<MaxByIntTransType>() {
+            Some(state) => Some(state.clone().into()),
+            None => None,
+        } 
+    }
 }
 
 #[pg_extern(name = "into_values", immutable, parallel_safe)]
 pub fn max_n_by_int_to_values(
-    agg: MaxByInts<'static>,
+    agg: Option<MaxByInts<'static>>,
     _dummy: Option<AnyElement>,
 ) -> TableIterator<'static, (name!(value, i64), name!(data, AnyElement))> {
-    TableIterator::new(
-        agg.values
-            .values
-            .clone()
-            .into_iter()
-            .zip(agg.data.clone().into_anyelement_iter()),
-    )
+    match agg {
+        Some(agg) => TableIterator::new(
+            agg.values
+                .values
+                .clone()
+                .into_iter()
+                .zip(agg.data.clone().into_anyelement_iter()),
+        ),
+        None => TableIterator::new(std::iter::empty()),
+    }
+    
 }
 
 extension_sql!(
@@ -206,6 +215,40 @@ mod tests {
                 result.next().unwrap()[1].value().unwrap(),
                 Some("(95,\"(95,3)\")")
             );
+            assert!(result.next().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn max_by_int_empty_input_returns_null() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(val INT8, category INT)", None, &[],
+            ).unwrap();
+
+            let mut result = client.update(
+                "SELECT max_n_by(val, data, 1)::TEXT FROM data", None, &[],
+            ).unwrap();
+
+            assert!(result.next().unwrap()[1].value::<String>().unwrap().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn max_by_int_into_values_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(val INT8, category INT)", None, &[],
+            ).unwrap();
+
+            let mut result = client.update(
+                "SELECT into_values(
+                    max_n_by(val, data, 1),
+                    NULL::DATA)::TEXT FROM data",
+                None,
+                &[],
+            ).unwrap();
+
             assert!(result.next().is_none());
         })
     }

--- a/extension/src/nmost/max_by_int.rs
+++ b/extension/src/nmost/max_by_int.rs
@@ -86,11 +86,11 @@ pub fn max_n_by_int_rollup_trans(
 
 #[pg_extern(immutable, parallel_safe)]
 pub fn max_n_by_int_final(state: Internal) -> Option<MaxByInts<'static>> {
-    unsafe { 
+    unsafe {
         match state.to_inner::<MaxByIntTransType>() {
             Some(state) => Some(state.clone().into()),
             None => None,
-        } 
+        }
     }
 }
 
@@ -109,7 +109,6 @@ pub fn max_n_by_int_to_values(
         ),
         None => TableIterator::new(std::iter::empty()),
     }
-    
 }
 
 extension_sql!(
@@ -222,32 +221,37 @@ mod tests {
     #[pg_test]
     fn max_by_int_empty_input_returns_null() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(val INT8, category INT)", None, &[],
-            ).unwrap();
+            client
+                .update("CREATE TABLE data(val INT8, category INT)", None, &[])
+                .unwrap();
 
-            let mut result = client.update(
-                "SELECT max_n_by(val, data, 1)::TEXT FROM data", None, &[],
-            ).unwrap();
+            let mut result = client
+                .update("SELECT max_n_by(val, data, 1)::TEXT FROM data", None, &[])
+                .unwrap();
 
-            assert!(result.next().unwrap()[1].value::<String>().unwrap().is_none());
+            assert!(result.next().unwrap()[1]
+                .value::<String>()
+                .unwrap()
+                .is_none());
         })
     }
 
     #[pg_test]
     fn max_by_int_into_values_empty_returns_no_rows() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(val INT8, category INT)", None, &[],
-            ).unwrap();
+            client
+                .update("CREATE TABLE data(val INT8, category INT)", None, &[])
+                .unwrap();
 
-            let mut result = client.update(
-                "SELECT into_values(
+            let mut result = client
+                .update(
+                    "SELECT into_values(
                     max_n_by(val, data, 1),
                     NULL::DATA)::TEXT FROM data",
-                None,
-                &[],
-            ).unwrap();
+                    None,
+                    &[],
+                )
+                .unwrap();
 
             assert!(result.next().is_none());
         })

--- a/extension/src/nmost/max_by_int.rs
+++ b/extension/src/nmost/max_by_int.rs
@@ -87,10 +87,9 @@ pub fn max_n_by_int_rollup_trans(
 #[pg_extern(immutable, parallel_safe)]
 pub fn max_n_by_int_final(state: Internal) -> Option<MaxByInts<'static>> {
     unsafe {
-        match state.to_inner::<MaxByIntTransType>() {
-            Some(state) => Some(state.clone().into()),
-            None => None,
-        }
+        state
+            .to_inner::<MaxByIntTransType>()
+            .map(|state| state.clone().into())
     }
 }
 

--- a/extension/src/nmost/max_by_int.rs
+++ b/extension/src/nmost/max_by_int.rs
@@ -106,7 +106,7 @@ pub fn max_n_by_int_to_values(
                 .into_iter()
                 .zip(agg.data.clone().into_anyelement_iter()),
         ),
-        None => TableIterator::new(std::iter::empty()),
+        None => TableIterator::empty(),
     }
 }
 

--- a/extension/src/nmost/max_by_time.rs
+++ b/extension/src/nmost/max_by_time.rs
@@ -86,7 +86,7 @@ pub fn max_n_by_time_rollup_trans(
 
 #[pg_extern(immutable, parallel_safe)]
 pub fn max_n_by_time_final(state: Internal) -> Option<MaxByTimes<'static>> {
-    unsafe { 
+    unsafe {
         match state.to_inner::<MaxByTimeTransType>() {
             Some(state) => Some(state.clone().into()),
             None => None,
@@ -116,7 +116,6 @@ pub fn max_n_by_time_to_values(
         ),
         None => TableIterator::new(std::iter::empty()),
     }
-    
 }
 
 extension_sql!(
@@ -231,37 +230,44 @@ mod tests {
     #[pg_test]
     fn max_by_time_empty_input_return_null() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
-                None,
-                &[],
-            ).unwrap();
+            client
+                .update(
+                    "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
+                    None,
+                    &[],
+                )
+                .unwrap();
 
-            let mut result = client.update(
-                "SELECT max_n_by(val, data, 1)::TEXT FROM data", 
-                None,
-                &[],
-            ).unwrap();
+            let mut result = client
+                .update("SELECT max_n_by(val, data, 1)::TEXT FROM data", None, &[])
+                .unwrap();
 
-            assert!(result.next().unwrap()[1].value::<String>().unwrap().is_none());
+            assert!(result.next().unwrap()[1]
+                .value::<String>()
+                .unwrap()
+                .is_none());
         })
     }
 
     #[pg_test]
     fn max_by_time_into_values_empty_returns_no_rows() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
-                None,
-                &[],
-            ).unwrap();
+            client
+                .update(
+                    "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
+                    None,
+                    &[],
+                )
+                .unwrap();
 
-            let mut result = client.update(
-                "SELECT into_values(max_n_by(val, data, 1),
+            let mut result = client
+                .update(
+                    "SELECT into_values(max_n_by(val, data, 1),
                 NULL::data)::TEXT FROM data",
-                None,
-                &[],
-            ).unwrap();
+                    None,
+                    &[],
+                )
+                .unwrap();
 
             assert!(result.next().is_none());
         })

--- a/extension/src/nmost/max_by_time.rs
+++ b/extension/src/nmost/max_by_time.rs
@@ -242,10 +242,12 @@ mod tests {
                 .update("SELECT max_n_by(val, data, 1)::TEXT FROM data", None, &[])
                 .unwrap();
 
-            assert!(result.next().unwrap()[1]
-                .value::<String>()
-                .unwrap()
-                .is_none());
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<String>()
+                    .unwrap()
+                    .is_none()
+            );
         })
     }
 

--- a/extension/src/nmost/max_by_time.rs
+++ b/extension/src/nmost/max_by_time.rs
@@ -87,10 +87,9 @@ pub fn max_n_by_time_rollup_trans(
 #[pg_extern(immutable, parallel_safe)]
 pub fn max_n_by_time_final(state: Internal) -> Option<MaxByTimes<'static>> {
     unsafe {
-        match state.to_inner::<MaxByTimeTransType>() {
-            Some(state) => Some(state.clone().into()),
-            None => None,
-        }
+        state
+            .to_inner::<MaxByTimeTransType>()
+            .map(|state| state.clone().into())
     }
 }
 

--- a/extension/src/nmost/max_by_time.rs
+++ b/extension/src/nmost/max_by_time.rs
@@ -85,13 +85,18 @@ pub fn max_n_by_time_rollup_trans(
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn max_n_by_time_final(state: Internal) -> MaxByTimes<'static> {
-    unsafe { state.to_inner::<MaxByTimeTransType>().unwrap().clone() }.into()
+pub fn max_n_by_time_final(state: Internal) -> Option<MaxByTimes<'static>> {
+    unsafe { 
+        match state.to_inner::<MaxByTimeTransType>() {
+            Some(state) => Some(state.clone().into()),
+            None => None,
+        }
+    }
 }
 
 #[pg_extern(name = "into_values", immutable, parallel_safe)]
 pub fn max_n_by_time_to_values(
-    agg: MaxByTimes<'static>,
+    agg: Option<MaxByTimes<'static>>,
     _dummy: Option<AnyElement>,
 ) -> TableIterator<
     'static,
@@ -100,14 +105,18 @@ pub fn max_n_by_time_to_values(
         name!(data, AnyElement),
     ),
 > {
-    TableIterator::new(
-        agg.values
-            .values
-            .clone()
-            .into_iter()
-            .map(crate::raw::TimestampTz::from)
-            .zip(agg.data.clone().into_anyelement_iter()),
-    )
+    match agg {
+        Some(agg) => TableIterator::new(
+            agg.values
+                .values
+                .clone()
+                .into_iter()
+                .map(crate::raw::TimestampTz::from)
+                .zip(agg.data.clone().into_anyelement_iter()),
+        ),
+        None => TableIterator::new(std::iter::empty()),
+    }
+    
 }
 
 extension_sql!(
@@ -215,6 +224,45 @@ mod tests {
                 result.next().unwrap()[1].value().unwrap(),
                 Some("(\"2020-04-05 00:00:00+00\",\"(\"\"2020-04-05 00:00:00+00\"\",3)\")")
             );
+            assert!(result.next().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn max_by_time_empty_input_return_null() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
+                None,
+                &[],
+            ).unwrap();
+
+            let mut result = client.update(
+                "SELECT max_n_by(val, data, 1)::TEXT FROM data", 
+                None,
+                &[],
+            ).unwrap();
+
+            assert!(result.next().unwrap()[1].value::<String>().unwrap().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn max_by_time_into_values_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
+                None,
+                &[],
+            ).unwrap();
+
+            let mut result = client.update(
+                "SELECT into_values(max_n_by(val, data, 1),
+                NULL::data)::TEXT FROM data",
+                None,
+                &[],
+            ).unwrap();
+
             assert!(result.next().is_none());
         })
     }

--- a/extension/src/nmost/max_by_time.rs
+++ b/extension/src/nmost/max_by_time.rs
@@ -113,7 +113,7 @@ pub fn max_n_by_time_to_values(
                 .map(crate::raw::TimestampTz::from)
                 .zip(agg.data.clone().into_anyelement_iter()),
         ),
-        None => TableIterator::new(std::iter::empty()),
+        None => TableIterator::empty(),
     }
 }
 

--- a/extension/src/nmost/max_float.rs
+++ b/extension/src/nmost/max_float.rs
@@ -109,11 +109,8 @@ pub fn max_n_float_deserialize(bytes: bytea, _internal: Internal) -> Option<Inte
 
 #[pg_extern(immutable, parallel_safe)]
 pub fn max_n_float_final(state: Internal) -> Option<MaxFloats<'static>> {
-    let mut state = unsafe { state.to_inner::<MaxFloatTransType>() };
-    match state {
-        Some(mut state) => Some((&mut *state).into()),
-        None => None,
-    }
+    let state = unsafe { state.to_inner::<MaxFloatTransType>() };
+    state.map(|mut state| (&mut *state).into())
 }
 
 #[pg_extern(name = "into_array", immutable, parallel_safe)]

--- a/extension/src/nmost/max_float.rs
+++ b/extension/src/nmost/max_float.rs
@@ -108,9 +108,12 @@ pub fn max_n_float_deserialize(bytes: bytea, _internal: Internal) -> Option<Inte
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn max_n_float_final(state: Internal) -> MaxFloats<'static> {
-    let mut state = unsafe { state.to_inner::<MaxFloatTransType>().unwrap() };
-    (&mut *state).into()
+pub fn max_n_float_final(state: Internal) -> Option<MaxFloats<'static>> {
+    let mut state = unsafe { state.to_inner::<MaxFloatTransType>() };
+    match state {
+        Some(mut state) => Some((&mut *state).into()),
+        None => None,
+    }
 }
 
 #[pg_extern(name = "into_array", immutable, parallel_safe)]

--- a/extension/src/nmost/max_float.rs
+++ b/extension/src/nmost/max_float.rs
@@ -293,64 +293,71 @@ mod tests {
     #[pg_test]
     fn max_float_final_returns_null_on_empty_input() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(val DOUBLE PRECISION);",
-                None,
-                &[],
-            ).unwrap();
+            client
+                .update("CREATE TABLE data(val DOUBLE PRECISION);", None, &[])
+                .unwrap();
 
-            let mut result = client.update(
-                "SELECT max_n(val, 1) FROM data",
-                None,
-                &[],
-            ).unwrap();
+            let mut result = client
+                .update("SELECT max_n(val, 1) FROM data", None, &[])
+                .unwrap();
 
-            assert!(result.next().unwrap()[1].value::<String>().unwrap().is_none());
+            assert!(result.next().unwrap()[1]
+                .value::<String>()
+                .unwrap()
+                .is_none());
         })
     }
 
     #[pg_test]
     fn max_float_empty_input_returns_null() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(val DOUBLE PRECISION, category INT);",
-                None,
-                &[],
-            ).unwrap();
+            client
+                .update(
+                    "CREATE TABLE data(val DOUBLE PRECISION, category INT);",
+                    None,
+                    &[],
+                )
+                .unwrap();
 
-            let mut result = client.update(
-                "SELECT max_n(val, 1)->into_array() FROM data",
-                None,
-                &[],
-            ).unwrap();
+            let mut result = client
+                .update("SELECT max_n(val, 1)->into_array() FROM data", None, &[])
+                .unwrap();
 
-            assert!(result.next().unwrap()[1].value::<Vec<f64>>().unwrap().is_none());
+            assert!(result.next().unwrap()[1]
+                .value::<Vec<f64>>()
+                .unwrap()
+                .is_none());
 
-            let mut result = client.update(
-                "SELECT (max_n(val, 1)->into_values())::TEXT FROM data",
-                None,
-                &[],
-            ).unwrap();
+            let mut result = client
+                .update(
+                    "SELECT (max_n(val, 1)->into_values())::TEXT FROM data",
+                    None,
+                    &[],
+                )
+                .unwrap();
 
             assert!(result.next().is_none());
-
         })
     }
 
     #[pg_test]
     fn max_float_into_values_empty_returns_no_rows() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(val DOUBLE PRECISION, category INT);",
-                None,
-                &[],
-            ).unwrap();
+            client
+                .update(
+                    "CREATE TABLE data(val DOUBLE PRECISION, category INT);",
+                    None,
+                    &[],
+                )
+                .unwrap();
 
-            let mut result = client.update(
-                "SELECT into_values(max_n(val, 1))::TEXT FROM data",
-                None,
-                &[],
-            ).unwrap();
+            let mut result = client
+                .update(
+                    "SELECT into_values(max_n(val, 1))::TEXT FROM data",
+                    None,
+                    &[],
+                )
+                .unwrap();
 
             assert!(result.next().is_none());
         })
@@ -359,19 +366,22 @@ mod tests {
     #[pg_test]
     fn max_float_into_array_empty_returns_no_rows() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(val DOUBLE PRECISION, category INT);",
-                None,
-                &[],
-            ).unwrap();
+            client
+                .update(
+                    "CREATE TABLE data(val DOUBLE PRECISION, category INT);",
+                    None,
+                    &[],
+                )
+                .unwrap();
 
-            let mut result = client.update(
-                "SELECT into_array(max_n(val, 1)) FROM data",
-                None,
-                &[],
-            ).unwrap();
+            let mut result = client
+                .update("SELECT into_array(max_n(val, 1)) FROM data", None, &[])
+                .unwrap();
 
-            assert!(result.next().unwrap()[1].value::<Vec<f64>>().unwrap().is_none());
+            assert!(result.next().unwrap()[1]
+                .value::<Vec<f64>>()
+                .unwrap()
+                .is_none());
         })
     }
 }

--- a/extension/src/nmost/max_float.rs
+++ b/extension/src/nmost/max_float.rs
@@ -304,10 +304,12 @@ mod tests {
                 .update("SELECT max_n(val, 1) FROM data", None, &[])
                 .unwrap();
 
-            assert!(result.next().unwrap()[1]
-                .value::<String>()
-                .unwrap()
-                .is_none());
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<String>()
+                    .unwrap()
+                    .is_none()
+            );
         })
     }
 
@@ -326,10 +328,12 @@ mod tests {
                 .update("SELECT max_n(val, 1)->into_array() FROM data", None, &[])
                 .unwrap();
 
-            assert!(result.next().unwrap()[1]
-                .value::<Vec<f64>>()
-                .unwrap()
-                .is_none());
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<Vec<f64>>()
+                    .unwrap()
+                    .is_none()
+            );
 
             let mut result = client
                 .update(
@@ -381,10 +385,12 @@ mod tests {
                 .update("SELECT into_array(max_n(val, 1)) FROM data", None, &[])
                 .unwrap();
 
-            assert!(result.next().unwrap()[1]
-                .value::<Vec<f64>>()
-                .unwrap()
-                .is_none());
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<Vec<f64>>()
+                    .unwrap()
+                    .is_none()
+            );
         })
     }
 }

--- a/extension/src/nmost/max_float.rs
+++ b/extension/src/nmost/max_float.rs
@@ -289,4 +289,89 @@ mod tests {
             );
         })
     }
+
+    #[pg_test]
+    fn max_float_final_returns_null_on_empty_input() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(val DOUBLE PRECISION);",
+                None,
+                &[],
+            ).unwrap();
+
+            let mut result = client.update(
+                "SELECT max_n(val, 1) FROM data",
+                None,
+                &[],
+            ).unwrap();
+
+            assert!(result.next().unwrap()[1].value::<String>().unwrap().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn max_float_empty_input_returns_null() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(val DOUBLE PRECISION, category INT);",
+                None,
+                &[],
+            ).unwrap();
+
+            let mut result = client.update(
+                "SELECT max_n(val, 1)->into_array() FROM data",
+                None,
+                &[],
+            ).unwrap();
+
+            assert!(result.next().unwrap()[1].value::<Vec<f64>>().unwrap().is_none());
+
+            let mut result = client.update(
+                "SELECT (max_n(val, 1)->into_values())::TEXT FROM data",
+                None,
+                &[],
+            ).unwrap();
+
+            assert!(result.next().is_none());
+
+        })
+    }
+
+    #[pg_test]
+    fn max_float_into_values_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(val DOUBLE PRECISION, category INT);",
+                None,
+                &[],
+            ).unwrap();
+
+            let mut result = client.update(
+                "SELECT into_values(max_n(val, 1))::TEXT FROM data",
+                None,
+                &[],
+            ).unwrap();
+
+            assert!(result.next().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn max_float_into_array_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(val DOUBLE PRECISION, category INT);",
+                None,
+                &[],
+            ).unwrap();
+
+            let mut result = client.update(
+                "SELECT into_array(max_n(val, 1)) FROM data",
+                None,
+                &[],
+            ).unwrap();
+
+            assert!(result.next().unwrap()[1].value::<Vec<f64>>().unwrap().is_none());
+        })
+    }
 }

--- a/extension/src/nmost/max_int.rs
+++ b/extension/src/nmost/max_int.rs
@@ -103,11 +103,8 @@ pub fn max_n_int_deserialize(bytes: bytea, _internal: Internal) -> Option<Intern
 
 #[pg_extern(immutable, parallel_safe)]
 pub fn max_n_int_final(state: Internal) -> Option<MaxInts<'static>> {
-    let mut state = unsafe { state.to_inner::<MaxIntTransType>() };
-    match state {
-        Some(mut state) => Some((&mut *state).into()),
-        None => None,
-    }
+    let state = unsafe { state.to_inner::<MaxIntTransType>() };
+    state.map(|mut state| (&mut *state).into())
 }
 
 #[pg_extern(name = "into_array", immutable, parallel_safe)]

--- a/extension/src/nmost/max_int.rs
+++ b/extension/src/nmost/max_int.rs
@@ -255,4 +255,86 @@ mod tests {
             assert_eq!(result.unwrap(), vec![99, 98, 97, 96, 95]);
         })
     }
+
+    #[pg_test]
+    fn max_int_final_returns_null_on_empty_input() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(val INT8);",
+                None,
+                &[],
+            ).unwrap();
+
+            let mut result = client.update(
+                "SELECT max_n(val, 1) FROM data",
+                None,
+                &[],
+            ).unwrap();
+
+            assert!(result.next().unwrap()[1].value::<String>().unwrap().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn max_int_empty_returns_null() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(val INT8, category INT);",
+                None,
+                &[],
+            ).unwrap();
+
+            let mut result = client.update(
+                "SELECT max_n(val, 1)->into_array() FROM data",
+                None,
+                &[],
+            ).unwrap();
+
+            assert!(result.next().unwrap()[1].value::<Vec<i64>>().unwrap().is_none());
+
+            let mut result = client.update(
+                "SELECT (max_n(val, 1)->into_values())::TEXT FROM data",
+                None,
+                &[],
+            ).unwrap();
+        })
+    }
+
+    #[pg_test]
+    fn max_int_into_values_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(val INT8, category INT);",
+                None,
+                &[],
+            ).unwrap();
+
+            let mut result = client.update(
+                "SELECT into_values(max_n(val, 1))::TEXT FROM data",
+                None,
+                &[],
+            ).unwrap();
+
+            assert!(result.next().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn max_int_into_array_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(val INT8, category INT);",
+                None,
+                &[],
+            ).unwrap();
+
+            let mut result = client.update(
+                "SELECT into_array(max_n(val, 1)) FROM data",
+                None,
+                &[],
+            ).unwrap();
+
+            assert!(result.next().unwrap()[1].value::<Vec<f64>>().unwrap().is_none());
+        })
+    }
 }

--- a/extension/src/nmost/max_int.rs
+++ b/extension/src/nmost/max_int.rs
@@ -297,6 +297,8 @@ mod tests {
                 None,
                 &[],
             ).unwrap();
+
+            assert!(result.next().is_none());
         })
     }
 

--- a/extension/src/nmost/max_int.rs
+++ b/extension/src/nmost/max_int.rs
@@ -270,10 +270,12 @@ mod tests {
                 .update("SELECT max_n(val, 1) FROM data", None, &[])
                 .unwrap();
 
-            assert!(result.next().unwrap()[1]
-                .value::<String>()
-                .unwrap()
-                .is_none());
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<String>()
+                    .unwrap()
+                    .is_none()
+            );
         })
     }
 
@@ -288,10 +290,12 @@ mod tests {
                 .update("SELECT max_n(val, 1)->into_array() FROM data", None, &[])
                 .unwrap();
 
-            assert!(result.next().unwrap()[1]
-                .value::<Vec<i64>>()
-                .unwrap()
-                .is_none());
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<Vec<i64>>()
+                    .unwrap()
+                    .is_none()
+            );
 
             let mut result = client
                 .update(
@@ -335,10 +339,12 @@ mod tests {
                 .update("SELECT into_array(max_n(val, 1)) FROM data", None, &[])
                 .unwrap();
 
-            assert!(result.next().unwrap()[1]
-                .value::<Vec<f64>>()
-                .unwrap()
-                .is_none());
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<Vec<f64>>()
+                    .unwrap()
+                    .is_none()
+            );
         })
     }
 }

--- a/extension/src/nmost/max_int.rs
+++ b/extension/src/nmost/max_int.rs
@@ -259,44 +259,44 @@ mod tests {
     #[pg_test]
     fn max_int_final_returns_null_on_empty_input() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(val INT8);",
-                None,
-                &[],
-            ).unwrap();
+            client
+                .update("CREATE TABLE data(val INT8);", None, &[])
+                .unwrap();
 
-            let mut result = client.update(
-                "SELECT max_n(val, 1) FROM data",
-                None,
-                &[],
-            ).unwrap();
+            let mut result = client
+                .update("SELECT max_n(val, 1) FROM data", None, &[])
+                .unwrap();
 
-            assert!(result.next().unwrap()[1].value::<String>().unwrap().is_none());
+            assert!(result.next().unwrap()[1]
+                .value::<String>()
+                .unwrap()
+                .is_none());
         })
     }
 
     #[pg_test]
     fn max_int_empty_returns_null() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(val INT8, category INT);",
-                None,
-                &[],
-            ).unwrap();
+            client
+                .update("CREATE TABLE data(val INT8, category INT);", None, &[])
+                .unwrap();
 
-            let mut result = client.update(
-                "SELECT max_n(val, 1)->into_array() FROM data",
-                None,
-                &[],
-            ).unwrap();
+            let mut result = client
+                .update("SELECT max_n(val, 1)->into_array() FROM data", None, &[])
+                .unwrap();
 
-            assert!(result.next().unwrap()[1].value::<Vec<i64>>().unwrap().is_none());
+            assert!(result.next().unwrap()[1]
+                .value::<Vec<i64>>()
+                .unwrap()
+                .is_none());
 
-            let mut result = client.update(
-                "SELECT (max_n(val, 1)->into_values())::TEXT FROM data",
-                None,
-                &[],
-            ).unwrap();
+            let mut result = client
+                .update(
+                    "SELECT (max_n(val, 1)->into_values())::TEXT FROM data",
+                    None,
+                    &[],
+                )
+                .unwrap();
 
             assert!(result.next().is_none());
         })
@@ -305,17 +305,17 @@ mod tests {
     #[pg_test]
     fn max_int_into_values_empty_returns_no_rows() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(val INT8, category INT);",
-                None,
-                &[],
-            ).unwrap();
+            client
+                .update("CREATE TABLE data(val INT8, category INT);", None, &[])
+                .unwrap();
 
-            let mut result = client.update(
-                "SELECT into_values(max_n(val, 1))::TEXT FROM data",
-                None,
-                &[],
-            ).unwrap();
+            let mut result = client
+                .update(
+                    "SELECT into_values(max_n(val, 1))::TEXT FROM data",
+                    None,
+                    &[],
+                )
+                .unwrap();
 
             assert!(result.next().is_none());
         })
@@ -324,19 +324,18 @@ mod tests {
     #[pg_test]
     fn max_int_into_array_empty_returns_no_rows() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(val INT8, category INT);",
-                None,
-                &[],
-            ).unwrap();
+            client
+                .update("CREATE TABLE data(val INT8, category INT);", None, &[])
+                .unwrap();
 
-            let mut result = client.update(
-                "SELECT into_array(max_n(val, 1)) FROM data",
-                None,
-                &[],
-            ).unwrap();
+            let mut result = client
+                .update("SELECT into_array(max_n(val, 1)) FROM data", None, &[])
+                .unwrap();
 
-            assert!(result.next().unwrap()[1].value::<Vec<f64>>().unwrap().is_none());
+            assert!(result.next().unwrap()[1]
+                .value::<Vec<f64>>()
+                .unwrap()
+                .is_none());
         })
     }
 }

--- a/extension/src/nmost/max_int.rs
+++ b/extension/src/nmost/max_int.rs
@@ -102,9 +102,12 @@ pub fn max_n_int_deserialize(bytes: bytea, _internal: Internal) -> Option<Intern
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn max_n_int_final(state: Internal) -> MaxInts<'static> {
-    let mut state = unsafe { state.to_inner::<MaxIntTransType>().unwrap() };
-    (&mut *state).into()
+pub fn max_n_int_final(state: Internal) -> Option<MaxInts<'static>> {
+    let mut state = unsafe { state.to_inner::<MaxIntTransType>() };
+    match state {
+        Some(mut state) => Some((&mut *state).into()),
+        None => None,
+    }
 }
 
 #[pg_extern(name = "into_array", immutable, parallel_safe)]

--- a/extension/src/nmost/max_time.rs
+++ b/extension/src/nmost/max_time.rs
@@ -311,44 +311,45 @@ mod tests {
     #[pg_test]
     fn max_time_final_returns_null_on_empty_input() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(val TIMESTAMPTZ);",
-                None,
-                &[],
-            ).unwrap();
+            client
+                .update("CREATE TABLE data(val TIMESTAMPTZ);", None, &[])
+                .unwrap();
 
-            let mut result = client.update(
-                "SELECT max_n(val, 1) FROM data",
-                None,
-                &[],
-            ).unwrap();
+            let mut result = client
+                .update("SELECT max_n(val, 1) FROM data", None, &[])
+                .unwrap();
 
-            assert!(result.next().unwrap()[1].value::<String>().unwrap().is_none());
+            assert!(result.next().unwrap()[1]
+                .value::<String>()
+                .unwrap()
+                .is_none());
         })
     }
 
     #[pg_test]
     fn max_time_empty_returns_null() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
-                None,
-                &[],
-            ).unwrap();
+            client
+                .update(
+                    "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
+                    None,
+                    &[],
+                )
+                .unwrap();
 
-            let mut result = client.update(
-                "SELECT max_n(val, 1)->into_array() FROM data",
-                None,
-                &[],
-            ).unwrap();
+            let mut result = client
+                .update("SELECT max_n(val, 1)->into_array() FROM data", None, &[])
+                .unwrap();
 
             assert!(result.next().unwrap()[1].value::<&str>().unwrap().is_none());
 
-            let mut result = client.update(
-                "SELECT (max_n(val, 1)->into_values())::TEXT FROM data",
-                None,
-                &[],
-            ).unwrap();
+            let mut result = client
+                .update(
+                    "SELECT (max_n(val, 1)->into_values())::TEXT FROM data",
+                    None,
+                    &[],
+                )
+                .unwrap();
 
             assert!(result.next().is_none());
         })
@@ -357,17 +358,21 @@ mod tests {
     #[pg_test]
     fn max_time_into_values_empty_returns_no_rows() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
-                None,
-                &[],
-            ).unwrap();
+            client
+                .update(
+                    "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
+                    None,
+                    &[],
+                )
+                .unwrap();
 
-            let mut result = client.update(
-                "SELECT into_values(max_n(val, 1))::TEXT FROM data",
-                None,
-                &[],
-            ).unwrap();
+            let mut result = client
+                .update(
+                    "SELECT into_values(max_n(val, 1))::TEXT FROM data",
+                    None,
+                    &[],
+                )
+                .unwrap();
 
             assert!(result.next().is_none());
         })
@@ -376,19 +381,22 @@ mod tests {
     #[pg_test]
     fn max_time_into_array_empty_returns_no_rows() {
         Spi::connect_mut(|client| {
-            client.update(
-                "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
-                None,
-                &[],
-            ).unwrap();
+            client
+                .update(
+                    "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
+                    None,
+                    &[],
+                )
+                .unwrap();
 
-            let mut result = client.update(
-                "SELECT into_array(max_n(val, 1)) FROM data",
-                None,
-                &[],
-            ).unwrap();
+            let mut result = client
+                .update("SELECT into_array(max_n(val, 1)) FROM data", None, &[])
+                .unwrap();
 
-            assert!(result.next().unwrap()[1].value::<Vec<f64>>().unwrap().is_none());
+            assert!(result.next().unwrap()[1]
+                .value::<Vec<f64>>()
+                .unwrap()
+                .is_none());
         })
     }
 }

--- a/extension/src/nmost/max_time.rs
+++ b/extension/src/nmost/max_time.rs
@@ -322,10 +322,12 @@ mod tests {
                 .update("SELECT max_n(val, 1) FROM data", None, &[])
                 .unwrap();
 
-            assert!(result.next().unwrap()[1]
-                .value::<String>()
-                .unwrap()
-                .is_none());
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<String>()
+                    .unwrap()
+                    .is_none()
+            );
         })
     }
 
@@ -396,10 +398,12 @@ mod tests {
                 .update("SELECT into_array(max_n(val, 1)) FROM data", None, &[])
                 .unwrap();
 
-            assert!(result.next().unwrap()[1]
-                .value::<Vec<f64>>()
-                .unwrap()
-                .is_none());
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<Vec<f64>>()
+                    .unwrap()
+                    .is_none()
+            );
         })
     }
 }

--- a/extension/src/nmost/max_time.rs
+++ b/extension/src/nmost/max_time.rs
@@ -103,9 +103,12 @@ pub fn max_n_time_deserialize(bytes: bytea, _internal: Internal) -> Option<Inter
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn max_n_time_final(state: Internal) -> MaxTimes<'static> {
-    let mut state = unsafe { state.to_inner::<MaxTimeTransType>().unwrap() };
-    (&mut *state).into()
+pub fn max_n_time_final(state: Internal) -> Option<MaxTimes<'static>> {
+    let mut state = unsafe { state.to_inner::<MaxTimeTransType>() };
+    match state {
+        Some(mut state) => Some((&mut *state).into()),
+        None => None,
+    }
 }
 
 #[pg_extern(name = "into_array", immutable, parallel_safe)]

--- a/extension/src/nmost/max_time.rs
+++ b/extension/src/nmost/max_time.rs
@@ -104,11 +104,8 @@ pub fn max_n_time_deserialize(bytes: bytea, _internal: Internal) -> Option<Inter
 
 #[pg_extern(immutable, parallel_safe)]
 pub fn max_n_time_final(state: Internal) -> Option<MaxTimes<'static>> {
-    let mut state = unsafe { state.to_inner::<MaxTimeTransType>() };
-    match state {
-        Some(mut state) => Some((&mut *state).into()),
-        None => None,
-    }
+    let state = unsafe { state.to_inner::<MaxTimeTransType>() };
+    state.map(|mut state| (&mut *state).into())
 }
 
 #[pg_extern(name = "into_array", immutable, parallel_safe)]

--- a/extension/src/nmost/max_time.rs
+++ b/extension/src/nmost/max_time.rs
@@ -307,4 +307,88 @@ mod tests {
             );
         })
     }
+
+    #[pg_test]
+    fn max_time_final_returns_null_on_empty_input() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(val TIMESTAMPTZ);",
+                None,
+                &[],
+            ).unwrap();
+
+            let mut result = client.update(
+                "SELECT max_n(val, 1) FROM data",
+                None,
+                &[],
+            ).unwrap();
+
+            assert!(result.next().unwrap()[1].value::<String>().unwrap().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn max_time_empty_returns_null() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
+                None,
+                &[],
+            ).unwrap();
+
+            let mut result = client.update(
+                "SELECT max_n(val, 1)->into_array() FROM data",
+                None,
+                &[],
+            ).unwrap();
+
+            assert!(result.next().unwrap()[1].value::<&str>().unwrap().is_none());
+
+            let mut result = client.update(
+                "SELECT (max_n(val, 1)->into_values())::TEXT FROM data",
+                None,
+                &[],
+            ).unwrap();
+
+            assert!(result.next().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn max_time_into_values_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
+                None,
+                &[],
+            ).unwrap();
+
+            let mut result = client.update(
+                "SELECT into_values(max_n(val, 1))::TEXT FROM data",
+                None,
+                &[],
+            ).unwrap();
+
+            assert!(result.next().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn max_time_into_array_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client.update(
+                "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
+                None,
+                &[],
+            ).unwrap();
+
+            let mut result = client.update(
+                "SELECT into_array(max_n(val, 1)) FROM data",
+                None,
+                &[],
+            ).unwrap();
+
+            assert!(result.next().unwrap()[1].value::<Vec<f64>>().unwrap().is_none());
+        })
+    }
 }


### PR DESCRIPTION
Fix #860

This only fixes max_n and max_n_by aggregates. I intend to fix min_n and min_n_by aggregates as soon as possible, since they leak the same Option::unwrap() on a `None` value error.