### PR TITLE
Fix `min_n` and `min_n_by` when used on empty tables

### DIFF
--- a/extension/src/nmost/min_by_float.rs
+++ b/extension/src/nmost/min_by_float.rs
@@ -85,22 +85,29 @@ pub fn min_n_by_float_rollup_trans(
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn min_n_by_float_final(state: Internal) -> MinByFloats<'static> {
-    unsafe { state.to_inner::<MinByFloatTransType>().unwrap().clone() }.into()
+pub fn min_n_by_float_final(state: Internal) -> Option<MinByFloats<'static>> {
+    unsafe {
+        state
+            .to_inner::<MinByFloatTransType>()
+            .map(|state| state.clone().into())
+    }
 }
 
 #[pg_extern(name = "into_values", immutable, parallel_safe)]
 pub fn min_n_by_float_to_values(
-    agg: MinByFloats<'static>,
+    agg: Option<MinByFloats<'static>>,
     _dummy: Option<AnyElement>,
 ) -> TableIterator<'static, (name!(value, f64), name!(data, AnyElement))> {
-    TableIterator::new(
-        agg.values
-            .values
-            .clone()
-            .into_iter()
-            .zip(agg.data.clone().into_anyelement_iter()),
-    )
+    match agg {
+        Some(agg) => TableIterator::new(
+            agg.values
+                .values
+                .clone()
+                .into_iter()
+                .zip(agg.data.clone().into_anyelement_iter()),
+        ),
+        None => TableIterator::empty(),
+    }
 }
 
 extension_sql!(
@@ -210,6 +217,56 @@ mod tests {
                 result.next().unwrap()[1].value().unwrap(),
                 Some("(0.03125,\"(0.03125,0)\")")
             );
+            assert!(result.next().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn min_by_float_empty_input_returns_null() {
+        Spi::connect_mut(|client| {
+            client
+                .update(
+                    "CREATE TABLE data(ts TIMESTAMPTZ, value DOUBLE PRECISION);",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            let mut result = client
+                .update("SELECT min_n_by(value, ts, 1)::TEXT FROM data", None, &[])
+                .unwrap();
+
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<String>()
+                    .unwrap()
+                    .is_none()
+            );
+        })
+    }
+
+    #[pg_test]
+    fn min_by_float_into_values_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client
+                .update(
+                    "CREATE TABLE data(ts TIMESTAMPTZ, value DOUBLE PRECISION);",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            let mut result = client
+                .update(
+                    "SELECT * FROM into_values((
+                    SELECT min_n_by(value, ts, 1)
+                    FROM data
+                ), NULL::timestamptz)",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
             assert!(result.next().is_none());
         })
     }

--- a/extension/src/nmost/min_by_int.rs
+++ b/extension/src/nmost/min_by_int.rs
@@ -72,22 +72,29 @@ pub fn min_n_by_int_rollup_trans(
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn min_n_by_int_final(state: Internal) -> MinByInts<'static> {
-    unsafe { state.to_inner::<MinByIntTransType>().unwrap().clone() }.into()
+pub fn min_n_by_int_final(state: Internal) -> Option<MinByInts<'static>> {
+    unsafe {
+        state
+            .to_inner::<MinByIntTransType>()
+            .map(|state| state.clone().into())
+    }
 }
 
 #[pg_extern(name = "into_values", immutable, parallel_safe)]
 pub fn min_n_by_int_to_values(
-    agg: MinByInts<'static>,
+    agg: Option<MinByInts<'static>>,
     _dummy: Option<AnyElement>,
 ) -> TableIterator<'static, (name!(value, i64), name!(data, AnyElement))> {
-    TableIterator::new(
-        agg.values
-            .values
-            .clone()
-            .into_iter()
-            .zip(agg.data.clone().into_anyelement_iter()),
-    )
+    match agg {
+        Some(agg) => TableIterator::new(
+            agg.values
+                .values
+                .clone()
+                .into_iter()
+                .zip(agg.data.clone().into_anyelement_iter()),
+        ),
+        None => TableIterator::empty(),
+    }
 }
 
 extension_sql!(
@@ -193,6 +200,47 @@ mod tests {
                 result.next().unwrap()[1].value().unwrap(),
                 Some("(4,\"(4,0)\")")
             );
+            assert!(result.next().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn min_by_int_empty_input_returns_null() {
+        Spi::connect_mut(|client| {
+            client
+                .update("CREATE TABLE data(val INT8, category INT)", None, &[])
+                .unwrap();
+
+            let mut result = client
+                .update("SELECT min_n_by(val, data, 1)::TEXT FROM data", None, &[])
+                .unwrap();
+
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<String>()
+                    .unwrap()
+                    .is_none()
+            );
+        })
+    }
+
+    #[pg_test]
+    fn min_by_int_into_values_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client
+                .update("CREATE TABLE data(val INT8, category INT)", None, &[])
+                .unwrap();
+
+            let mut result = client
+                .update(
+                    "SELECT into_values(
+                    min_n_by(val, data, 1),
+                    NULL::DATA)::TEXT FROM data",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
             assert!(result.next().is_none());
         })
     }

--- a/extension/src/nmost/min_by_time.rs
+++ b/extension/src/nmost/min_by_time.rs
@@ -72,13 +72,17 @@ pub fn min_n_by_time_rollup_trans(
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn min_n_by_time_final(state: Internal) -> MinByTimes<'static> {
-    unsafe { state.to_inner::<MinByTimeTransType>().unwrap().clone() }.into()
+pub fn min_n_by_time_final(state: Internal) -> Option<MinByTimes<'static>> {
+    unsafe {
+        state
+            .to_inner::<MinByTimeTransType>()
+            .map(|state| state.clone().into())
+    }
 }
 
 #[pg_extern(name = "into_values", immutable, parallel_safe)]
 pub fn min_n_by_time_to_values(
-    agg: MinByTimes<'static>,
+    agg: Option<MinByTimes<'static>>,
     _dummy: Option<AnyElement>,
 ) -> TableIterator<
     'static,
@@ -87,14 +91,17 @@ pub fn min_n_by_time_to_values(
         name!(data, AnyElement),
     ),
 > {
-    TableIterator::new(
-        agg.values
-            .values
-            .clone()
-            .into_iter()
-            .map(crate::raw::TimestampTz::from)
-            .zip(agg.data.clone().into_anyelement_iter()),
-    )
+    match agg {
+        Some(agg) => TableIterator::new(
+            agg.values
+                .values
+                .clone()
+                .into_iter()
+                .map(crate::raw::TimestampTz::from)
+                .zip(agg.data.clone().into_anyelement_iter()),
+        ),
+        None => TableIterator::empty(),
+    }
 }
 
 extension_sql!(
@@ -202,6 +209,54 @@ mod tests {
                 result.next().unwrap()[1].value().unwrap(),
                 Some("(\"2020-01-05 00:00:00+00\",\"(\"\"2020-01-05 00:00:00+00\"\",0)\")")
             );
+            assert!(result.next().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn min_by_time_empty_input_return_null() {
+        Spi::connect_mut(|client| {
+            client
+                .update(
+                    "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            let mut result = client
+                .update("SELECT min_n_by(val, data, 1)::TEXT FROM data", None, &[])
+                .unwrap();
+
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<String>()
+                    .unwrap()
+                    .is_none()
+            );
+        })
+    }
+
+    #[pg_test]
+    fn min_by_time_into_values_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client
+                .update(
+                    "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            let mut result = client
+                .update(
+                    "SELECT into_values(min_n_by(val, data, 1),
+                NULL::data)::TEXT FROM data",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
             assert!(result.next().is_none());
         })
     }

--- a/extension/src/nmost/min_float.rs
+++ b/extension/src/nmost/min_float.rs
@@ -107,9 +107,9 @@ pub fn min_n_float_deserialize(bytes: bytea, _internal: Internal) -> Option<Inte
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn min_n_float_final(state: Internal) -> MinFloats<'static> {
-    let mut state = unsafe { state.to_inner::<MinFloatTransType>().unwrap() };
-    (&mut *state).into()
+pub fn min_n_float_final(state: Internal) -> Option<MinFloats<'static>> {
+    let state = unsafe { state.to_inner::<MinFloatTransType>() };
+    state.map(|mut state| (&mut *state).into())
 }
 
 #[pg_extern(name = "into_array", immutable, parallel_safe)]
@@ -279,6 +279,107 @@ mod tests {
             assert_eq!(
                 result.unwrap().unwrap(),
                 vec![0. / 128., 1. / 128., 2. / 128., 3. / 128., 4. / 128.]
+            );
+        })
+    }
+
+    #[pg_test]
+    fn min_float_final_returns_null_on_empty_input() {
+        Spi::connect_mut(|client| {
+            client
+                .update("CREATE TABLE data(val DOUBLE PRECISION);", None, &[])
+                .unwrap();
+
+            let mut result = client
+                .update("SELECT min_n(val, 1) FROM data", None, &[])
+                .unwrap();
+
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<String>()
+                    .unwrap()
+                    .is_none()
+            );
+        })
+    }
+
+    #[pg_test]
+    fn min_float_empty_input_returns_null() {
+        Spi::connect_mut(|client| {
+            client
+                .update(
+                    "CREATE TABLE data(val DOUBLE PRECISION, category INT);",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            let mut result = client
+                .update("SELECT min_n(val, 1)->into_array() FROM data", None, &[])
+                .unwrap();
+
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<Vec<f64>>()
+                    .unwrap()
+                    .is_none()
+            );
+
+            let mut result = client
+                .update(
+                    "SELECT (min_n(val, 1)->into_values())::TEXT FROM data",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            assert!(result.next().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn min_float_into_values_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client
+                .update(
+                    "CREATE TABLE data(val DOUBLE PRECISION, category INT);",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            let mut result = client
+                .update(
+                    "SELECT into_values(min_n(val, 1))::TEXT FROM data",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            assert!(result.next().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn min_float_into_array_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client
+                .update(
+                    "CREATE TABLE data(val DOUBLE PRECISION, category INT);",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            let mut result = client
+                .update("SELECT into_array(min_n(val, 1)) FROM data", None, &[])
+                .unwrap();
+
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<Vec<f64>>()
+                    .unwrap()
+                    .is_none()
             );
         })
     }

--- a/extension/src/nmost/min_int.rs
+++ b/extension/src/nmost/min_int.rs
@@ -94,9 +94,9 @@ pub fn min_n_int_deserialize(bytes: bytea, _internal: Internal) -> Option<Intern
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn min_n_int_final(state: Internal) -> MinInts<'static> {
-    let mut state = unsafe { state.to_inner::<MinIntTransType>().unwrap() };
-    (&mut *state).into()
+pub fn min_n_int_final(state: Internal) -> Option<MinInts<'static>> {
+    let state = unsafe { state.to_inner::<MinIntTransType>() };
+    state.map(|mut state| (&mut *state).into())
 }
 
 #[pg_extern(name = "into_array", immutable, parallel_safe)]
@@ -245,6 +245,95 @@ mod tests {
                         None, &[],
                     ).unwrap().first().get_one::<Vec<i64>>().unwrap();
             assert_eq!(result.unwrap(), vec![0, 1, 2, 3, 4]);
+        })
+    }
+
+    #[pg_test]
+    fn min_int_final_returns_null_on_empty_input() {
+        Spi::connect_mut(|client| {
+            client
+                .update("CREATE TABLE data(val INT8);", None, &[])
+                .unwrap();
+
+            let mut result = client
+                .update("SELECT min_n(val, 1) FROM data", None, &[])
+                .unwrap();
+
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<String>()
+                    .unwrap()
+                    .is_none()
+            );
+        })
+    }
+
+    #[pg_test]
+    fn min_int_empty_returns_null() {
+        Spi::connect_mut(|client| {
+            client
+                .update("CREATE TABLE data(val INT8, category INT);", None, &[])
+                .unwrap();
+
+            let mut result = client
+                .update("SELECT min_n(val, 1)->into_array() FROM data", None, &[])
+                .unwrap();
+
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<Vec<i64>>()
+                    .unwrap()
+                    .is_none()
+            );
+
+            let mut result = client
+                .update(
+                    "SELECT (min_n(val, 1)->into_values())::TEXT FROM data",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            assert!(result.next().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn min_int_into_values_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client
+                .update("CREATE TABLE data(val INT8, category INT);", None, &[])
+                .unwrap();
+
+            let mut result = client
+                .update(
+                    "SELECT into_values(min_n(val, 1))::TEXT FROM data",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            assert!(result.next().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn min_int_into_array_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client
+                .update("CREATE TABLE data(val INT8, category INT);", None, &[])
+                .unwrap();
+
+            let mut result = client
+                .update("SELECT into_array(min_n(val, 1)) FROM data", None, &[])
+                .unwrap();
+
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<Vec<f64>>()
+                    .unwrap()
+                    .is_none()
+            );
         })
     }
 }

--- a/extension/src/nmost/min_time.rs
+++ b/extension/src/nmost/min_time.rs
@@ -94,9 +94,9 @@ pub fn min_n_time_deserialize(bytes: bytea, _internal: Internal) -> Option<Inter
 }
 
 #[pg_extern(immutable, parallel_safe)]
-pub fn min_n_time_final(state: Internal) -> MinTimes<'static> {
-    let mut state = unsafe { state.to_inner::<MinTimeTransType>().unwrap() };
-    (&mut *state).into()
+pub fn min_n_time_final(state: Internal) -> Option<MinTimes<'static>> {
+    let state = unsafe { state.to_inner::<MinTimeTransType>() };
+    state.map(|mut state| (&mut *state).into())
 }
 
 #[pg_extern(name = "into_array", immutable, parallel_safe)]
@@ -295,6 +295,102 @@ mod tests {
             assert_eq!(
                 result.unwrap(),
                 "{\"2020-01-01 00:00:00+00\",\"2020-01-02 00:00:00+00\",\"2020-01-03 00:00:00+00\",\"2020-01-04 00:00:00+00\",\"2020-01-05 00:00:00+00\"}"
+            );
+        })
+    }
+
+    #[pg_test]
+    fn min_time_final_returns_null_on_empty_input() {
+        Spi::connect_mut(|client| {
+            client
+                .update("CREATE TABLE data(val TIMESTAMPTZ);", None, &[])
+                .unwrap();
+
+            let mut result = client
+                .update("SELECT min_n(val, 1) FROM data", None, &[])
+                .unwrap();
+
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<String>()
+                    .unwrap()
+                    .is_none()
+            );
+        })
+    }
+
+    #[pg_test]
+    fn min_time_empty_returns_null() {
+        Spi::connect_mut(|client| {
+            client
+                .update(
+                    "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            let mut result = client
+                .update("SELECT min_n(val, 1)->into_array() FROM data", None, &[])
+                .unwrap();
+
+            assert!(result.next().unwrap()[1].value::<&str>().unwrap().is_none());
+
+            let mut result = client
+                .update(
+                    "SELECT (min_n(val, 1)->into_values())::TEXT FROM data",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            assert!(result.next().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn min_time_into_values_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client
+                .update(
+                    "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            let mut result = client
+                .update(
+                    "SELECT into_values(min_n(val, 1))::TEXT FROM data",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            assert!(result.next().is_none());
+        })
+    }
+
+    #[pg_test]
+    fn min_time_into_array_empty_returns_no_rows() {
+        Spi::connect_mut(|client| {
+            client
+                .update(
+                    "CREATE TABLE data(val TIMESTAMPTZ, category INT);",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            let mut result = client
+                .update("SELECT into_array(min_n(val, 1)) FROM data", None, &[])
+                .unwrap();
+
+            assert!(
+                result.next().unwrap()[1]
+                    .value::<Vec<f64>>()
+                    .unwrap()
+                    .is_none()
             );
         })
     }


### PR DESCRIPTION
Fix #860

This PR applies the same bug fixes from #915 to the `min_n` and `min_n_by` aggregates.