### PR TITLE
Apply Rustc and Clippy fixes

### DIFF
--- a/crates/encodings/src/lib.rs
+++ b/crates/encodings/src/lib.rs
@@ -91,7 +91,7 @@ pub mod zigzag {
 
     #[inline(always)]
     pub fn decode(n: u64) -> i64 {
-        if n % 2 == 0 {
+        if n.is_multiple_of(2) {
             // positive number
             (n / 2) as i64
         } else {

--- a/crates/flat_serialize/flat_serialize/src/lib.rs
+++ b/crates/flat_serialize/flat_serialize/src/lib.rs
@@ -686,7 +686,7 @@ fn len_of_iterable<'i, T: FlatSerializable<'i>, V: ValOrRef<T>, I: Iterator<Item
 #[inline(always)]
 fn aligning_len(ptr: *const MaybeUninit<u8>, align: usize) -> usize {
     let current_ptr = ptr as usize;
-    if current_ptr % align == 0 {
+    if current_ptr.is_multiple_of(align) {
         return 0;
     }
     align - (current_ptr % align)

--- a/crates/hyperloglogplusplus/src/dense.rs
+++ b/crates/hyperloglogplusplus/src/dense.rs
@@ -62,7 +62,7 @@ impl<'s> Storage<'s> {
     fn idx_count_from_hash(&self, hash: u64) -> (usize, u8) {
         let idx = hash.extract(63, self.precision);
         // w in the paper
-        let hash_bits = hash.extract_bits(63 - self.precision, 0);
+        let hash_bits = Extractable::extract_bits(&hash, 63 - self.precision, 0);
         let count = hash_bits.q() - self.precision;
         (idx as usize, count)
     }

--- a/crates/hyperloglogplusplus/src/sparse.rs
+++ b/crates/hyperloglogplusplus/src/sparse.rs
@@ -198,10 +198,10 @@ impl Encoded {
         //
         // *`count` is only present when `tag` is `1`
         let idx = hash.extract(63, NUM_HIGH_BITS) as u32;
-        let diff = hash.extract_bits(63 - precision, 64 - NUM_HIGH_BITS);
+        let diff = Extractable::extract_bits(&hash, 63 - precision, 64 - NUM_HIGH_BITS);
         if diff == 0 {
             // TODO is this right?
-            let count = hash.extract_bits(63 - NUM_HIGH_BITS, 0).q() as u32 - NUM_HIGH_BITS as u32;
+            let count = Extractable::extract_bits(&hash, 63 - NUM_HIGH_BITS, 0).q() as u32 - NUM_HIGH_BITS as u32;
             Encoded((idx << 7) | (count << 1) | 1)
         } else {
             Encoded(idx << 1)
@@ -222,7 +222,7 @@ impl Encoded {
             self.extract_count() + extra_bits
         } else {
             let new_hash = (self.idx() as u64) << (64 - NUM_HIGH_BITS);
-            let hash_bits = new_hash.extract_bits(63 - p, 0);
+            let hash_bits = Extractable::extract_bits(&new_hash, 63 - p, 0);
             hash_bits.q() - p
         }
     }
@@ -234,7 +234,7 @@ impl Encoded {
 
     #[inline]
     fn extract_count(&self) -> u8 {
-        self.0.extract_bits(6, 1) as u8
+        Extractable::extract_bits(&self.0, 6, 1) as u8
     }
 }
 

--- a/crates/hyperloglogplusplus/src/sparse.rs
+++ b/crates/hyperloglogplusplus/src/sparse.rs
@@ -201,7 +201,8 @@ impl Encoded {
         let diff = Extractable::extract_bits(&hash, 63 - precision, 64 - NUM_HIGH_BITS);
         if diff == 0 {
             // TODO is this right?
-            let count = Extractable::extract_bits(&hash, 63 - NUM_HIGH_BITS, 0).q() as u32 - NUM_HIGH_BITS as u32;
+            let count = Extractable::extract_bits(&hash, 63 - NUM_HIGH_BITS, 0).q() as u32
+                - NUM_HIGH_BITS as u32;
             Encoded((idx << 7) | (count << 1) | 1)
         } else {
             Encoded(idx << 1)

--- a/extension/Cargo.toml
+++ b/extension/Cargo.toml
@@ -2,7 +2,6 @@
 name = "timescaledb_toolkit"
 version = "1.22.0-dev"
 edition = "2024"
-resolver = "3"
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/extension/src/time_vector/pipeline.rs
+++ b/extension/src/time_vector/pipeline.rs
@@ -232,7 +232,7 @@ pub(crate) unsafe fn pipeline_support_helper(
                 //       instead of
                 //       `unsafe extern "C" fn(fcinfo: pg_sys::FunctionCallInfo) -> pg_sys::Datum`
                 //       we'll fix this upstream
-                let expected_executor = arrow_run_pipeline_wrapper as usize;
+                let expected_executor = arrow_run_pipeline_wrapper as *const () as usize;
                 match executor_fn {
                     None => return no_change(),
                     // FIXME the direct comparison should work

--- a/extension/src/time_vector/pipeline/sort.rs
+++ b/extension/src/time_vector/pipeline/sort.rs
@@ -21,7 +21,7 @@ pub fn sort_timevector(mut series: Timevector_TSTZ_F64<'_>) -> Timevector_TSTZ_F
     let (points, null_val) = if !series.has_nulls() {
         // easy case
         let mut points = std::mem::take(series.points.as_owned());
-        points.sort_by(|a, b| a.ts.cmp(&b.ts));
+        points.sort_by_key(|a| a.ts);
         let nulls_len = points.len().div_ceil(8);
         (points, std::vec::from_elem(0_u8, nulls_len))
     } else {
@@ -29,7 +29,7 @@ pub fn sort_timevector(mut series: Timevector_TSTZ_F64<'_>) -> Timevector_TSTZ_F
             .into_iter()
             .enumerate()
             .collect();
-        points.sort_by(|(_, a), (_, b)| a.ts.cmp(&b.ts));
+        points.sort_by_key(|(_, a)| a.ts);
         let mut null_val = std::vec::from_elem(0_u8, points.len().div_ceil(8));
         let points = points
             .into_iter()


### PR DESCRIPTION
This PR applies automated fixes recommended by rustc compiler suggestions and clippy lints across the codebase.

It updates calls to `extract_bits` to use fully qualified syntax via the `Extractable` trait. The change removes `unstable_name_collisions` warnings caused by potential conflicts with methods that may be added to the Rust standard library.

It moves the workspace resolver configuration to the root `Cargo.toml`, since resolver settings defined in non-root packages are ignored by Cargo workspaces. The resolver remains set to version `2` to preserve the current workspace behavior, although it could be migrated to resolver `3` in the future. 