### PR TITLE
Fix inverted is_sorted check in ASAP timevector smoothing

### DIFF
--- a/extension/src/asap.rs
+++ b/extension/src/asap.rs
@@ -138,9 +138,7 @@ pub fn asap_on_timevector(
     resolution: i32,
 ) -> Option<Timevector_TSTZ_F64<'static>> {
     // TODO: implement this using zero copy (requires sort, find_downsample_interval, and downsample_and_gapfill on Timevector)
-    let needs_sort = series.is_sorted();
-
-    if needs_sort {
+    if !series.is_sorted() {
         series.points.as_owned().sort_by_key(|p| p.ts);
     }
     let start_ts = series.points.as_slice().first().unwrap().ts;


### PR DESCRIPTION
Fix #844 

Fix an inverted sorting condition in `asap_on_timevector`.

`Timevector_TSTZ_F64::is_sorted()` returns `true` when the `FLAG_IS_SORTED` flag is set, but the current implementation sorts the series only when `is_sorted()` is `true` ans skips sorting otherwise.

This change updates the condition so that sorting is performed only for unsorted timevectors, matching the behavior used in `asap_final_inner`.