### PR TITLE
Add `heartbeat_agg` equality operator

### DIFF
--- a/extension/src/heartbeat_agg.rs
+++ b/extension/src/heartbeat_agg.rs
@@ -327,6 +327,20 @@ impl HeartbeatAgg<'_> {
     }
 }
 
+impl PartialEq for HeartbeatAgg<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.start_time == other.start_time
+            && self.end_time == other.end_time
+            && self.last_seen == other.last_seen
+            && self.interval_len == other.interval_len
+            && self.num_intervals == other.num_intervals
+            && self.interval_starts.as_slice() == other.interval_starts.as_slice()
+            && self.interval_ends.as_slice() == other.interval_ends.as_slice()
+    }
+}
+
+impl Eq for HeartbeatAgg<'_> {}
+
 #[pg_extern]
 pub fn live_ranges(
     agg: HeartbeatAgg<'static>,
@@ -581,6 +595,11 @@ pub fn arrow_heartbeat_agg_trim_to(
         Some(accessor.end)
     };
     agg.trim_to(Some(accessor.start), end)
+}
+
+#[pg_extern]
+pub fn equal(left: HeartbeatAgg<'static>, right: HeartbeatAgg<'static>) -> bool {
+    left == right
 }
 
 #[pg_operator(immutable, parallel_safe)]

--- a/extension/src/heartbeat_agg.rs
+++ b/extension/src/heartbeat_agg.rs
@@ -583,6 +583,12 @@ pub fn arrow_heartbeat_agg_trim_to(
     agg.trim_to(Some(accessor.start), end)
 }
 
+#[pg_operator(immutable, parallel_safe)]
+#[opname(=)]
+pub fn eq_op_hearbeat_agg(left: HeartbeatAgg<'static>, right: HeartbeatAgg<'static>) -> bool {
+    left == right
+}
+
 impl From<HeartbeatAgg<'static>> for HeartbeatTransState {
     fn from(agg: HeartbeatAgg<'static>) -> Self {
         HeartbeatTransState {

--- a/extension/src/heartbeat_agg.rs
+++ b/extension/src/heartbeat_agg.rs
@@ -597,15 +597,20 @@ pub fn arrow_heartbeat_agg_trim_to(
     agg.trim_to(Some(accessor.start), end)
 }
 
-#[pg_extern]
-pub fn equal(left: HeartbeatAgg<'static>, right: HeartbeatAgg<'static>) -> bool {
+#[pg_operator(immutable, parallel_safe)]
+#[opname(=)]
+#[negator(<>)]
+#[commutator(=)]
+pub fn eq_op_heartbeat_agg(left: HeartbeatAgg<'static>, right: HeartbeatAgg<'static>) -> bool {
     left == right
 }
 
 #[pg_operator(immutable, parallel_safe)]
-#[opname(=)]
-pub fn eq_op_hearbeat_agg(left: HeartbeatAgg<'static>, right: HeartbeatAgg<'static>) -> bool {
-    left == right
+#[opname(<>)]
+#[negator(=)]
+#[commutator(<>)]
+pub fn neq_op_heartbeat_agg(left: HeartbeatAgg<'static>, right: HeartbeatAgg<'static>) -> bool {
+    left != right
 }
 
 impl From<HeartbeatAgg<'static>> for HeartbeatTransState {
@@ -1882,6 +1887,57 @@ mod tests {
             let expected = "(\"2020-01-01 00:50:00+00\",\"2020-01-01 01:30:00+00\")";
 
             assert_eq!(output, Some(expected.into()));
+        });
+    }
+
+    #[pg_test]
+    fn test_eq_operator() {
+        Spi::connect_mut(|client| {
+            client.update("SET TIMEZONE to UTC", None, &[]).unwrap();
+
+            client
+                .update(
+                    "CREATE TABLE poc(ts TIMESTAMPTZ, batch TIMESTAMPTZ)",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            client
+                .update(
+                    "INSERT INTO poc VALUES
+                    ('1-1-2020 0:50 UTC', '1-1-2020 0:00 UTC'),
+                    ('1-1-2020 1:00 UTC', '1-1-2020 0:00 UTC'),
+                    ('1-1-2020 1:00 UTC', '1-1-2020 0:00 UTC')",
+                    None,
+                    &[],
+                )
+                .unwrap();
+
+            let output = client
+                .select(
+                    "WITH aggs AS (
+                        SELECT
+                            heartbeat_agg(ts, batch, '2h', '20m') AS all_agg,
+                            heartbeat_agg(ts, batch, '2h', '20m')
+                                FILTER (WHERE ts < '1-1-2020 1:00 UTC') AS subset_agg
+                        FROM poc
+                    )
+                    SELECT
+                        all_agg = all_agg
+                        AND NOT all_agg <> all_agg
+                        AND NOT all_agg = subset_agg
+                        AND all_agg <> subset_agg
+                    FROM aggs",
+                    None,
+                    &[],
+                )
+                .unwrap()
+                .first()
+                .get_one::<bool>()
+                .unwrap();
+
+            assert_eq!(output, Some(true));
         });
     }
 }

--- a/extension/src/stabilization_info.rs
+++ b/extension/src/stabilization_info.rs
@@ -11,6 +11,10 @@
 
 crate::functions_stabilized_at! {
     STABLE_FUNCTIONS
+    "1.24.0" => {
+        eq_op_heartbeat_agg(heartbeatagg, heartbeatagg),
+        neq_op_heartbeat_agg(heartbeatagg, heartbeatagg),
+    }
     "1.23.0" => {
         stats_agg(bigint),
         stats1d_i64_tf_inv_trans(internal,bigint),
@@ -1054,6 +1058,10 @@ crate::types_stabilized_at! {
 
 crate::operators_stabilized_at! {
     STABLE_OPERATORS
+    "1.24.0" => {
+        "="(heartbeatagg, heartbeatagg),
+        "<>"(heartbeatagg, heartbeatagg),
+    }
     "1.16.0" => {
         "->"(heartbeatagg,accessornumgaps),
         "->"(heartbeatagg,accessornumliveranges),


### PR DESCRIPTION
Add equality operators for `heartbeat_agg` to prevent errors when comparing values of this aggregate. This addresses the issue reported in #875 and lays the groundwork for supporting equality comparisons on other custom aggregate that may be affected by the same limitation.

This change implements `Eq` and `PartialEq` for `HeartbeatAgg`, allowing `pg_operator` to successfully define equality operators for the type.

As a result, the following query:

```sql
WITH aggs AS (
  SELECT
    heartbeat_agg(ts, batch, '2h', '20m') AS a,
    heartbeat_agg(ts, batch, '2h', '20m') FILTER (WHERE ts < '2020-01-01 01:00 UTC') AS b
  FROM poc
)
SELECT a = a, a <> a, a = b, a <> b
FROM aggs;
```

now returns:

```sql
 ?column? | ?column? | ?column? | ?column?
----------+----------+----------+----------
 t        | f        | f        | t
(1 row)
```