### PR TITLE
Fix huge memory allocation from integer overflows

### DIFF
--- a/crates/asap/src/lib.rs
+++ b/crates/asap/src/lib.rs
@@ -29,12 +29,20 @@ mod fft;
 pub fn asap_smooth(data: &[f64], resolution: u32) -> Vec<f64> {
     use std::borrow::Cow;
 
+    if resolution == 0 || data.is_empty() {
+        return Vec::new();
+    }
+
     let data = if data.len() > 2 * resolution as usize {
         let period = (data.len() as f64 / resolution as f64) as u32;
         Cow::Owned(sma(data, period, period))
     } else {
         Cow::Borrowed(data)
     };
+
+    if data.len() <= 1 {
+        return data.into_owned();
+    }
 
     let mut acf = Acf::new(&data, (data.len() as f64 / 10.0).round() as u32);
     let peaks = acf.find_peaks();
@@ -264,7 +272,7 @@ impl Metrics<'_> {
     }
 
     fn diffs(&self) -> Vec<f64> {
-        let mut diff = vec![0.0; (self.len - 1) as usize];
+        let mut diff = vec![0.0; self.len.saturating_sub(1) as usize];
         for i in 1..self.len as usize {
             diff[i - 1] = self.values[i] - self.values[i - 1];
         }
@@ -342,6 +350,18 @@ mod tests {
         let test = Metrics::new(&series_c);
         assert_eq!(test.roughness(), 0.0);
         assert!((test.kurtosis() - 1.7).abs() < 0.000000000001); // == 1.7
+    }
+
+    #[test]
+    fn zero_resolution_returns_no_points() {
+        let test = asap_smooth(&[0.0, 40.0, 16.0], 0);
+        assert!(test.is_empty());
+    }
+
+    #[test]
+    fn single_point_downsample_does_not_underflow() {
+        let test = asap_smooth(&[0.0, 40.0, 16.0], 1);
+        assert_eq!(test, vec![56.0 / 3.0]);
     }
 
     #[test]

--- a/extension/src/asap.rs
+++ b/extension/src/asap.rs
@@ -44,6 +44,10 @@ pub fn asap_trans_internal(
                 (Some(ts), Some(val)) => TSPoint { ts: ts.into(), val },
             };
 
+            if resolution <= 0 {
+                error!("resolution must be greater than 0")
+            }
+
             match state {
                 None => Some(
                     ASAPTransState {
@@ -137,6 +141,10 @@ pub fn asap_on_timevector(
     mut series: Timevector_TSTZ_F64<'static>,
     resolution: i32,
 ) -> Option<Timevector_TSTZ_F64<'static>> {
+    if resolution <= 0 {
+        error!("resolution must be greater than 0")
+    }
+
     // TODO: implement this using zero copy (requires sort, find_downsample_interval, and downsample_and_gapfill on Timevector)
     if !series.is_sorted() {
         series.points.as_owned().sort_by_key(|p| p.ts);
@@ -322,6 +330,45 @@ mod tests {
             }
             assert!(value_result.next().is_none());
             assert!(tvec_result.next().is_none());
+        })
+    }
+
+    #[pg_test(error = "resolution must be greater than 0")]
+    fn test_asap_aggregate_rejects_zero_resolution() {
+        Spi::connect_mut(|client| {
+            client
+                .update(
+                    "
+                    CREATE TEMP TABLE temp_series(id int4);
+                    INSERT INTO temp_series VALUES (0), (40), (16);
+                    SELECT public.asap_smooth(now(), 1.0, t1.id)
+                    FROM temp_series AS t1;
+                    ",
+                    None,
+                    &[],
+                )
+                .unwrap();
+        })
+    }
+
+    #[pg_test(error = "resolution must be greater than 0")]
+    fn test_asap_timevector_rejects_zero_resolution() {
+        Spi::connect_mut(|client| {
+            client
+                .update(
+                    "
+                    SELECT asap_smooth(
+                        (
+                            SELECT timevector('2020-1-1'::timestamptz + i * '1d'::interval, val)
+                            FROM (VALUES (1, 0.0), (2, 40.0), (3, 16.0)) AS v(i, val)
+                        ),
+                        0
+                    );
+                    ",
+                    None,
+                    &[],
+                )
+                .unwrap();
         })
     }
 }


### PR DESCRIPTION
The bug is kinda cool. 

In `asap_smooth` when resolution is `0`, like `asap_smooth(&[1.0, 1.0, 1.0], 0)`

It will try to downsample the data. First it will calculate the period:

 `let period = data.len() as f64 / resolution as f64) as u32` 

But it's dividing by 0, resulting in `3.0/0.0` which is infinity, when cast to u32 it reaches `u32::MAX` 

```rust
fn main() {
    let t = (3 as f64 / 0 as f64) as u32;
    println!("{}", t);
}
// 4294967295
```

Then the `sma` downsampling algorithm is called: 
`let data = sma(data, period, period)`,  now  the periods are huge (4294967295), 
so it freezes for a few seconds while calculating before just returning an empty array since it doesn't have enough data to fill the big periods.

After that, there is this line:

```let mut diff = vec![0.0; (self.len - 1) as usize];```

Where `self.len` is `0`, it's the len of the smoothed data, which `sma` returned as an empty vector.

`(self.len-1) as usize` causes an overflow, because self.len is unsigned, and of course unsigned integers don't have negative values,  that might not be caught in some release profiles so
it can wrap to `0_u32 - 1 == 4294967295_u32`, then `4294967295_u32 as usize` is just `4294967295_usize` (usize is just an unsigned integer with architecture dependent size)

So, we end up with `vec![0.0; 4294967295_usize]`, `vec!` is a Rust macro to construct vectors (arrays), in this case it's saying initialize a vector that contains f64 values, (type inferred from `0.0`),  of length `4294967295_usize`.

A vector of that size is `4294967295 elements * 8 bytes per f64 = 32GiB` roughly.. and if you don't have that kind of memory, out of memory panic!

Then postgres SIGABRTs


