### PR TITLE
Remove CI workaround for pgrx v0.18.0 bug as v0.18.1 landed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,13 +182,7 @@ jobs:
           set -e
         fi
 
-        cat > /tmp/keep-pgrxsc.ld <<'EOF'
-        SECTIONS {
-          .pgrxsc : { KEEP(*(.pgrxsc)) }
-        } INSERT AFTER .rodata;
-        EOF
-
-        su postgres -c 'RUSTFLAGS="-Awarnings -C link-arg=-Wl,-T,/tmp/keep-pgrxsc.ld" sh tools/build -pg${{ matrix.pgversion }} test-extension 2>&1'
+        su postgres -c 'sh tools/build -pg${{ matrix.pgversion }} test-extension 2>&1'
 
     - name: Run doc tests
       # depends on TSDB, which requires PG >=13

--- a/Readme.md
+++ b/Readme.md
@@ -52,7 +52,7 @@ sudo apt-get install make gcc pkg-config clang postgresql-server-dev-18 libssl-d
 Next you need [cargo-pgrx](https://github.com/tcdi/pgrx), which can be installed with
 
 ```bash
-cargo install cargo-pgrx --version 0.18.0 --locked --force
+cargo install cargo-pgrx --version 0.18.1 --locked --force
 ```
 
 You must reinstall cargo-pgrx whenever you update your Rust compiler, since cargo-pgrx needs to be built with the same compiler as Toolkit.

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -20,14 +20,6 @@ ENV CARGO_HOME=/usr/local/cargo
 ENV RUSTUP_HOME=/usr/local/rustup
 ENV PATH="${CARGO_HOME}/bin:/sbin:/usr/sbin:/bin:/usr/bin:/usr/local/bin"
 
-# TODO: Remove once pgrx v1.18.1 is released.
-RUN printf '%s\n' \
-        'SECTIONS {' \
-        '  .pgrxsc : { KEEP(*(.pgrxsc)) }' \
-        '} INSERT AFTER .rodata;' \
-        > /usr/local/share/keep-pgrxsc.ld
-ENV RUSTFLAGS="-C link-arg=-Wl,-T,/usr/local/share/keep-pgrxsc.ld"
-
 COPY docker/ci/setup.sh /
 COPY tools/dependencies.sh /
 # TODO simple option processing a la build and testbin would make this less error-prone


### PR DESCRIPTION
As mentioned in #913, pgrx was updated to version 0.18.1 in #935, so the changes made in #910 to circumvent a bug in version 0.18.0 are no longer needed.