### PR TITLE
Fix CI workflow by adding ICU package and CMake support

### DIFF
--- a/docker/ci/setup.sh
+++ b/docker/ci/setup.sh
@@ -130,6 +130,7 @@ if $privileged; then
                 git \
                 make \
                 openssl-devel \
+                cmake \
                 pkg-config \
                 rpm-build \
                 sudo
@@ -200,6 +201,7 @@ EOF
                     gnupg \
                     libkrb5-dev \
                     libssl-dev \
+                    libicu-dev \
                     make \
                     pkg-config \
                     postgresql-common \


### PR DESCRIPTION
Fix #936.

Adds the ICU development package on Debian/Ubuntu and the CMake package on Rocky Linux.

I expect these package additions to resolve the CI workflow issues.