### PR TITLE
Relax `stats_agg::tests::pg_stats_agg_fuzz` flakiness

### DIFF
--- a/extension/src/stats_agg.rs
+++ b/extension/src/stats_agg.rs
@@ -2002,6 +2002,7 @@ mod tests {
             const EPS1: f64 = f64::EPSILON; // Generally enough to handle float rounding
             const EPS2: f64 = 2. * f64::EPSILON; // stddev is sqrt(variance), so a bit looser bound
             const EPS3: f64 = 3. * f64::EPSILON; // Sum of squares in variance agg accumulates a bit more error
+            const EPS4: f64 = 4. * f64::EPSILON;
             const BILLIONTH: f64 = 1e-9; // Higher order moments exponentially compound the error
 
             check_agg_equivalence(
@@ -2235,7 +2236,7 @@ mod tests {
                 client,
                 &pg2d_agg("regr_intercept"),
                 &tk2d_agg("intercept"),
-                EPS1,
+                EPS4,
                 true,
             );
 

--- a/extension/src/stats_agg.rs
+++ b/extension/src/stats_agg.rs
@@ -2002,7 +2002,7 @@ mod tests {
             const EPS1: f64 = f64::EPSILON; // Generally enough to handle float rounding
             const EPS2: f64 = 2. * f64::EPSILON; // stddev is sqrt(variance), so a bit looser bound
             const EPS3: f64 = 3. * f64::EPSILON; // Sum of squares in variance agg accumulates a bit more error
-            const EPS4: f64 = 4. * f64::EPSILON;
+            const EPS4: f64 = 5. * f64::EPSILON; // Handle 'regr_intercept' float rounding 
             const BILLIONTH: f64 = 1e-9; // Higher order moments exponentially compound the error
 
             check_agg_equivalence(
@@ -2236,7 +2236,7 @@ mod tests {
                 client,
                 &pg2d_agg("regr_intercept"),
                 &tk2d_agg("intercept"),
-                EPS4,
+                EPS5,
                 true,
             );
 

--- a/extension/src/stats_agg.rs
+++ b/extension/src/stats_agg.rs
@@ -2002,7 +2002,8 @@ mod tests {
             const EPS1: f64 = f64::EPSILON; // Generally enough to handle float rounding
             const EPS2: f64 = 2. * f64::EPSILON; // stddev is sqrt(variance), so a bit looser bound
             const EPS3: f64 = 3. * f64::EPSILON; // Sum of squares in variance agg accumulates a bit more error
-            const EPS4: f64 = 5. * f64::EPSILON; // Handle 'regr_intercept' float rounding 
+            const EPS4: f64 = 4. * f64::EPSILON; // Handle 'variance_y' float rounding
+            const EPS5: f64 = 5. * f64::EPSILON; // Handle 'regr_intercept' float rounding 
             const BILLIONTH: f64 = 1e-9; // Higher order moments exponentially compound the error
 
             check_agg_equivalence(
@@ -2171,7 +2172,7 @@ mod tests {
                 client,
                 &pg1d_aggy("variance"),
                 &tk2d_agg("variance_y"),
-                EPS3,
+                EPS4,
                 true,
             );
             check_agg_equivalence(


### PR DESCRIPTION
Fixes #912

This PR fixes an intermittent test failure caused by an overly strict floating point tolerance during fuzz testing of the regression functions.

The test suite previously enforced an `EPS1` (`f64::EPSILON`) tolerance of approximately `2.22e-16`. In some cases, the relative difference exceeded this value, causing the test to panic.

As a workaround, this PR introduces a `5. * f64::EPSILON` tolerance of approximately `1.11e-15` for `regr_intercept`. This should be sufficient to accommodate the relative difference observed by @surister in #912. 

I suspect there may be a better solution that avoids introducing a new constant or relaxing the tolerance, but this change should address the intermittent failure for now.