### PR TITLE
Handle overflows in timevector pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This changelog should be updated as part of a PR if the work is worth noting (mo
 #### New experimental features
 
 #### Bug fixes
-
+- Handle `stats_agg` overflow in the experimental timevector pipeline by @darkgl06 in https://github.com/timescale/timescaledb-toolkit/issues/947
 #### Other notable changes
 
 #### Shout-outs

--- a/extension/src/stats_agg.rs
+++ b/extension/src/stats_agg.rs
@@ -110,7 +110,7 @@ impl StatsSummary2D {
     }
 }
 
-fn unwrap_stats_result<T>(result: Result<T, StatsError>) -> T {
+pub(crate) fn unwrap_stats_result<T>(result: Result<T, StatsError>) -> T {
     result.unwrap_or_else(|StatsError::DoubleOverflow| {
         pgrx::ereport!(
             ERROR,

--- a/extension/src/time_vector/pipeline/aggregation.rs
+++ b/extension/src/time_vector/pipeline/aggregation.rs
@@ -113,7 +113,7 @@ pub fn arrow_run_pipeline_then_stats_agg<'a>(
     timevector = run_pipeline_elements(timevector, pipeline.elements.iter());
     let mut stats = InternalStatsSummary1D::new();
     for TSPoint { val, .. } in timevector.iter() {
-        stats.accum(val).expect("error while running stats_agg");
+        stats_agg::unwrap_stats_result(stats.accum(val));
     }
     StatsSummary1D::from_internal(stats)
 }
@@ -799,6 +799,44 @@ mod tests {
                 "(version:1,n:5,sx:100.0,sx2:250.0,sx3:0.0,sx4:21250.0)"
             );
         });
+    }
+
+    #[pg_test]
+    fn test_stats_agg_pipeline_overflow_uses_numeric_out_of_range_sqlstate() {
+        let result = pg_sys::PgTryBuilder::new(|| {
+            Spi::connect_mut(|client| {
+                client
+                    .update(
+                        "SET LOCAL search_path TO public, toolkit_experimental",
+                        None,
+                        &[],
+                    )
+                    .unwrap();
+                client
+                    .select(
+                        "WITH input(ts, val) AS (
+                            VALUES
+                                ('2020-01-01 UTC'::timestamptz, 1e308::float8),
+                                ('2020-01-02 UTC'::timestamptz, 1e308::float8),
+                                ('2020-01-03 UTC'::timestamptz, 1e308::float8)
+                        ),
+                        series AS (
+                            SELECT timevector(ts, val) AS tv
+                            FROM input
+                        )
+                        SELECT (tv -> stats_agg())::text
+                        FROM series;",
+                        None,
+                        &[],
+                    )
+                    .unwrap();
+            });
+            false
+        })
+        .catch_when(PgSqlErrorCode::ERRCODE_NUMERIC_VALUE_OUT_OF_RANGE, |_| true)
+        .execute();
+
+        assert!(result);
     }
 
     #[pg_test]


### PR DESCRIPTION
Following https://github.com/timescale/timescaledb-toolkit/issues/947

Made `unwrap_stats_result` public to be reused in `stats_agg`

## PoL
```sql
SET search_path TO public, toolkit_experimental;

WITH input(ts, val) AS (
    VALUES
        ('2020-01-01 UTC'::timestamptz, 1e308::float8),
        ('2020-01-02 UTC'::timestamptz, 1e308::float8),
        ('2020-01-03 UTC'::timestamptz, 1e308::float8)
),
series AS (
    SELECT timevector(ts, val) AS tv
    FROM input
)
SELECT (tv -> stats_agg())::text
FROM series;
-- SET ERROR:  SQLSTATE [22003] stats_agg overflowed
```