### PR TITLE
Add negative check in mcv_agg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This changelog should be updated as part of a PR if the work is worth noting (mo
 
 #### Bug fixes
 - Handle `stats_agg` overflow in the experimental timevector pipeline by @darkgl06 in https://github.com/timescale/timescaledb-toolkit/issues/947
+- Fix `mcv_agg` in `frequency` for negative values, making function to overlow due to i32 cast @darkgl06 in https://github.com/timescale/timescaledb-toolkit/pull/959
 #### Other notable changes
 
 #### Shout-outs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ This changelog should be updated as part of a PR if the work is worth noting (mo
 
 #### Bug fixes
 - Handle `stats_agg` overflow in the experimental timevector pipeline by @darkgl06 in https://github.com/timescale/timescaledb-toolkit/issues/947
-- Fix `mcv_agg` in `frequency` for negative values, making function to overlow due to i32 cast @darkgl06 in https://github.com/timescale/timescaledb-toolkit/pull/959
+- Add negative check in `mcv_agg` by @darkgl06 in https://github.com/timescale/timescaledb-toolkit/pull/959
+
 #### Other notable changes
 
 #### Shout-outs

--- a/extension/src/frequency.rs
+++ b/extension/src/frequency.rs
@@ -631,6 +631,17 @@ impl<'input> From<(&SpaceSavingTextAggregate<'input>, &pg_sys::FunctionCallInfo)
 
 ron_inout_funcs!(SpaceSavingTextAggregate<'input>);
 
+fn validate_mcv_n(n: i32) -> u32 {
+    if n <= 0 {
+        pgrx::ereport!(
+            ERROR,
+            PgSqlErrorCode::ERRCODE_INVALID_PARAMETER_VALUE,
+            "mcv aggregate requires an n value > 0"
+        );
+    }
+    n as u32
+}
+
 #[pg_extern(immutable, parallel_safe)]
 pub fn mcv_agg_trans(
     state: Internal,
@@ -669,12 +680,13 @@ pub fn mcv_agg_with_skew_trans(
     value: Option<AnyElement>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Internal> {
+    let validated_n = validate_mcv_n(n);
     space_saving_trans(
         unsafe { state.to_inner() },
         value,
         fcinfo,
         |typ, collation| {
-            SpaceSavingTransState::mcv_agg_from_type_id(skew, n as u32, typ, collation)
+            SpaceSavingTransState::mcv_agg_from_type_id(skew, validated_n, typ, collation)
         },
     )
     .internal()
@@ -688,6 +700,7 @@ pub fn mcv_agg_with_skew_bigint_trans(
     value: Option<i64>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Internal> {
+    let validated_n = validate_mcv_n(n);
     let value = match value {
         None => None,
         Some(val) => unsafe {
@@ -700,7 +713,7 @@ pub fn mcv_agg_with_skew_bigint_trans(
         value,
         fcinfo,
         |typ, collation| {
-            SpaceSavingTransState::mcv_agg_from_type_id(skew, n as u32, typ, collation)
+            SpaceSavingTransState::mcv_agg_from_type_id(skew, validated_n, typ, collation)
         },
     )
     .internal()
@@ -714,6 +727,7 @@ pub fn mcv_agg_with_skew_text_trans(
     value: Option<crate::raw::text>,
     fcinfo: pg_sys::FunctionCallInfo,
 ) -> Option<Internal> {
+    let validated_n = validate_mcv_n(n);
     let txt = value.map(|v| unsafe { pg_sys::pg_detoast_datum_copy(v.0.cast_mut_ptr()) });
     let value = match txt {
         None => None,
@@ -727,7 +741,7 @@ pub fn mcv_agg_with_skew_text_trans(
         value,
         fcinfo,
         |typ, collation| {
-            SpaceSavingTransState::mcv_agg_from_type_id(skew, n as u32, typ, collation)
+            SpaceSavingTransState::mcv_agg_from_type_id(skew, validated_n, typ, collation)
         },
     )
     .internal()
@@ -1697,6 +1711,25 @@ mod tests {
     use pgrx_macros::pg_test;
     use rand::{distr::Uniform, prelude::*};
     use rand_distr::Zeta;
+
+    #[pg_test]
+    fn test_mcv_agg_rejects_non_positive_n() {
+        for query in [
+            "SELECT mcv_agg(-1, value) FROM (VALUES (1), (2)) AS input(value)",
+            "SELECT mcv_agg(-1, value) FROM (VALUES (1::bigint), (2)) AS input(value)",
+            "SELECT mcv_agg(-1, value) FROM (VALUES ('one'::text), ('two')) AS input(value)",
+            "SELECT mcv_agg(0, value) FROM (VALUES (1), (2)) AS input(value)",
+        ] {
+            let result = pg_sys::PgTryBuilder::new(|| {
+                Spi::run(query).unwrap();
+                false
+            })
+            .catch_when(PgSqlErrorCode::ERRCODE_INVALID_PARAMETER_VALUE, |_| true)
+            .execute();
+
+            assert!(result, "query did not return SQLSTATE 22023: {query}");
+        }
+    }
 
     #[pg_test]
     fn test_freq_aggregate() {


### PR DESCRIPTION
Described in https://github.com/timescale/timescaledb-toolkit/issues/958

Reject non-positive n values in mcv_agg before converting the parameter from i32 to u32.

  Previously, negative values were converted directly using n as u32. For example, -1 became 4294967295. Since the internal validation only rejected zero, this value reached the zeta-distribution sizing calculation, causing excessive computation and eventually an integer-overflow
  error.

  The validation now immediately returns PostgreSQL SQLSTATE 22023 (invalid_parameter_value):

  ERROR: mcv aggregate requires an n value > 0

  The validation applies consistently to the polymorphic, bigint, and text transition functions.

  ## Reproduction

  Before this change:

```SQL
  SELECT mcv_agg(-1, value)
  FROM (VALUES (1), (2)) AS input(value);
```

  The query could perform a long-running calculation before failing with:

  **`ERROR: attempt to add with overflow`**

  After this change, it fails immediately with SQLSTATE 22023:

`ERROR: mcv aggregate requires an n value > 0`

  ## Testing

  Added a PostgreSQL regression test covering:

  - Negative n with polymorphic/integer input
  - Negative n with bigint input
  - Negative n with text input
  - Zero n

  Validation performed with:

```sh
cargo check -p timescaledb_toolkit && cargo pgrx test pg18 test_mcv_agg_rejects_non_positive_n
```
Results:
`1 passed; 0 failed`