### PR TITLE
Fix Clippy warnings

### DIFF
--- a/crates/flat_serialize/flat_serialize_macro/src/lib.rs
+++ b/crates/flat_serialize/flat_serialize_macro/src/lib.rs
@@ -1391,12 +1391,8 @@ pub fn flat_serializable_derive(input: TokenStream) -> TokenStream {
                 .iter()
                 .flat_map(|attr| {
                     if attr.path().is_ident("repr") {
-                        attr.parse_args().ok().and_then(|ident: Ident| {
-                            if ident == "u8" || ident == "u16" || ident == "u32" || ident == "u64" {
-                                Some(ident)
-                            } else {
-                                None
-                            }
+                        attr.parse_args().ok().filter(|ident: &Ident| {
+                            ident == "u8" || ident == "u16" || ident == "u32" || ident == "u64"
                         })
                     } else {
                         None
@@ -1497,13 +1493,7 @@ pub fn flat_serializable_derive(input: TokenStream) -> TokenStream {
         .iter()
         .flat_map(|attr| {
             if attr.path().is_ident("repr") {
-                attr.parse_args::<Ident>().ok().and_then(|ident| {
-                    if ident == "C" {
-                        Some(ident)
-                    } else {
-                        None
-                    }
-                })
+                attr.parse_args::<Ident>().ok().filter(|ident| ident == "C")
             } else {
                 None
             }

--- a/extension/src/time_vector/pipeline.rs
+++ b/extension/src/time_vector/pipeline.rs
@@ -27,7 +27,6 @@ use crate::serialization::PgProcId;
 #[pg_schema]
 pub mod toolkit_experimental {
     use super::*;
-    pub use crate::time_vector::Timevector_TSTZ_F64;
     pub(crate) use lambda::toolkit_experimental::{Lambda, LambdaData};
     // TODO once we start stabilizing elements, create a type TimevectorPipeline
     //      stable elements will create a stable pipeline, but adding an unstable


### PR DESCRIPTION
Changes:
- Remove the unused `Timevector_TSTZ_F64` import from `time_vector/pipeline`.
- Replace `Option::and_then` with `Option::filter` in `flat_serialize_macro/src/lib.rs`.