### PR TITLE
Fix type handling in timevector pipelines and space-saving aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This changelog should be updated as part of a PR if the work is worth noting (mo
 #### Bug fixes
 - Handle `stats_agg` overflow in the experimental timevector pipeline by @darkgl06 in https://github.com/timescale/timescaledb-toolkit/issues/947
 - Add negative check in `mcv_agg` by @darkgl06 in https://github.com/timescale/timescaledb-toolkit/pull/959
+- Fix a type confusion in timevector `map_data`/`map_series`: revalidate the mapping function's signature at execution time so a pipeline built from its text representation cannot invoke a function with a mismatched signature
+- Fix a type confusion in the space-saving (`freq_agg`/`mcv_agg`) aggregates: reject a value built from its text representation whose recorded element type disagrees with the type of its stored values
 
 #### Other notable changes
 

--- a/extension/src/datum_utils.rs
+++ b/extension/src/datum_utils.rs
@@ -497,6 +497,11 @@ impl<'a, 'b> Iterator for DatumStoreIterator<'a, 'b> {
 }
 
 impl<'a> DatumStore<'a> {
+    /// The type OID the stored datums were parsed with.
+    pub fn type_oid(&self) -> Oid {
+        self.type_oid.into()
+    }
+
     pub fn iter<'b>(&'b self) -> DatumStoreIterator<'a, 'b> {
         unsafe {
             let tentry = pg_sys::lookup_type_cache(self.type_oid.into(), 0_i32);

--- a/extension/src/frequency.rs
+++ b/extension/src/frequency.rs
@@ -483,7 +483,19 @@ impl<'input> From<(&SpaceSavingAggregate<'input>, &pg_sys::FunctionCallInfo)>
     }
 }
 
-ron_inout_funcs!(SpaceSavingAggregate<'input>);
+impl<'input> SpaceSavingAggregate<'input> {
+    /// Require `type_oid` and the datum count to match the stored `datums`.
+    fn validate(&self) {
+        if Oid::from(self.type_oid) != self.datums.type_oid() {
+            pgrx::error!("invalid frequency aggregate: element type does not match stored values")
+        }
+        if self.datums.iter().count() != self.num_values as usize {
+            pgrx::error!("invalid frequency aggregate: value count does not match stored data")
+        }
+    }
+}
+
+ron_inout_funcs!(SpaceSavingAggregate<'input>, validated);
 
 pg_type! {
     #[derive(Debug)]
@@ -629,7 +641,19 @@ impl<'input> From<(&SpaceSavingTextAggregate<'input>, &pg_sys::FunctionCallInfo)
     }
 }
 
-ron_inout_funcs!(SpaceSavingTextAggregate<'input>);
+impl<'input> SpaceSavingTextAggregate<'input> {
+    /// `datums` are read as varlena; require type `text` and a matching count.
+    fn validate(&self) {
+        if self.datums.type_oid() != pg_sys::TEXTOID {
+            pgrx::error!("invalid frequency aggregate: element type does not match stored values")
+        }
+        if self.datums.iter().count() != self.num_values as usize {
+            pgrx::error!("invalid frequency aggregate: value count does not match stored data")
+        }
+    }
+}
+
+ron_inout_funcs!(SpaceSavingTextAggregate<'input>, validated);
 
 fn validate_mcv_n(n: i32) -> u32 {
     if n <= 0 {
@@ -2199,6 +2223,62 @@ mod tests {
                     .unwrap()
                     .count(),
             );
+        });
+    }
+
+    // Mismatched element type must be rejected.
+    #[pg_test]
+    #[should_panic = "element type does not match stored values"]
+    fn test_mcv_agg_type_oid_confusion() {
+        Spi::connect_mut(|client| {
+            // type_oid 25 (text), datums 701 (float8)
+            client
+                .update(
+                    "SELECT into_values(\
+                     '(version:1,type_oid:25,num_values:1,values_seen:1,freq_param:1.1,\
+                     topn:1,counts:[1],overcounts:[0],datums:[701,\"3.14\"])'\
+                     ::spacesavingaggregate, 'x'::text)",
+                    None,
+                    &[],
+                )
+                .unwrap();
+        });
+    }
+
+    #[pg_test]
+    #[should_panic = "element type does not match stored values"]
+    fn test_mcv_text_agg_type_oid_confusion() {
+        Spi::connect_mut(|client| {
+            // datums claim 701 (float8), not text
+            client
+                .update(
+                    "SELECT into_values(\
+                     '(version:1,num_values:1,topn:1,values_seen:1,freq_param:1.1,\
+                     counts:[1],overcounts:[0],datums:[701,\"3.14\"])'\
+                     ::spacesavingtextaggregate)",
+                    None,
+                    &[],
+                )
+                .unwrap();
+        });
+    }
+
+    // Too many datums would index counts/overcounts out of bounds.
+    #[pg_test]
+    #[should_panic = "value count does not match stored data"]
+    fn test_mcv_agg_value_count_mismatch() {
+        Spi::connect_mut(|client| {
+            // num_values 1, two datums
+            client
+                .update(
+                    "SELECT into_values(\
+                     '(version:1,type_oid:701,num_values:1,values_seen:2,freq_param:1.1,\
+                     topn:1,counts:[1],overcounts:[0],datums:[701,\"3.14\",\"2.71\"])'\
+                     ::spacesavingaggregate, 3.14::float8)",
+                    None,
+                    &[],
+                )
+                .unwrap();
         });
     }
 

--- a/extension/src/time_vector/pipeline/map.rs
+++ b/extension/src/time_vector/pipeline/map.rs
@@ -106,31 +106,54 @@ pub fn map_series_element<'a>(function: crate::raw::regproc) -> Element<'a> {
     }
 }
 
-pub fn check_user_function_type(function: pg_sys::regproc) {
+// `function` must be `fn(expected) RETURNS expected`; `signature` names it in
+// the error messages.
+fn check_user_function_signature(
+    function: pg_sys::regproc,
+    expected: pg_sys::Oid,
+    signature: &str,
+) {
     let mut argtypes: *mut pg_sys::Oid = ptr::null_mut();
     let mut nargs: ::std::os::raw::c_int = 0;
     let rettype = unsafe { pg_sys::get_func_signature(function, &mut argtypes, &mut nargs) };
 
     if nargs != 1 {
-        error!(
-            "invalid number of mapping function arguments, expected fn(timevector) RETURNS timevector"
-        )
+        error!("invalid number of mapping function arguments, expected {signature}")
     }
 
     assert!(!argtypes.is_null());
-    if unsafe { *argtypes } != *crate::time_vector::TIMEVECTOR_OID {
-        error!("invalid argument type, expected fn(timevector) RETURNS timevector")
+    if unsafe { *argtypes } != expected {
+        error!("invalid argument type, expected {signature}")
     }
 
-    if rettype != *crate::time_vector::TIMEVECTOR_OID {
-        error!("invalid return type, expected fn(timevector) RETURNS timevector")
+    if rettype != expected {
+        error!("invalid return type, expected {signature}")
     }
+}
+
+pub fn check_user_function_type(function: pg_sys::regproc) {
+    check_user_function_signature(
+        function,
+        *crate::time_vector::TIMEVECTOR_OID,
+        "fn(timevector) RETURNS timevector",
+    )
+}
+
+pub fn check_user_function_data_type(function: pg_sys::regproc) {
+    check_user_function_signature(
+        function,
+        pgrx::PgBuiltInOids::FLOAT8OID.value(),
+        "fn(double precision) RETURNS double precision",
+    )
 }
 
 pub fn apply_to_series(
     mut series: Timevector_TSTZ_F64<'_>,
     func: pg_sys::RegProcedure,
 ) -> Timevector_TSTZ_F64<'_> {
+    // Mapping function must be `fn(timevector) RETURNS timevector`.
+    check_user_function_type(func);
+
     let mut flinfo: pg_sys::FmgrInfo = unsafe { MaybeUninit::zeroed().assume_init() };
     unsafe {
         pg_sys::fmgr_info(func, &mut flinfo);
@@ -160,32 +183,12 @@ pub fn apply_to_series(
 pub fn map_data_pipeline_element(
     function: crate::raw::regproc,
 ) -> toolkit_experimental::UnstableTimevectorPipeline<'static> {
-    let mut argtypes: *mut pg_sys::Oid = ptr::null_mut();
-    let mut nargs: ::std::os::raw::c_int = 0;
-    let rettype = unsafe {
-        pg_sys::get_func_signature(
-            pg_sys::Oid::from(function.0.value() as u32),
-            &mut argtypes,
-            &mut nargs,
-        )
-    };
-
-    if nargs != 1 {
-        error!(
-            "invalid number of mapping function arguments, expected fn(double precision) RETURNS double precision"
-        )
-    }
-
-    if unsafe { *argtypes } != pgrx::PgBuiltInOids::FLOAT8OID.value() {
-        error!("invalid argument type, expected fn(double precision) RETURNS double precision")
-    }
-
-    if rettype != pgrx::PgBuiltInOids::FLOAT8OID.value() {
-        error!("invalid return type, expected fn(double precision) RETURNS double precision")
-    }
-
+    let function: pg_sys::regproc = pg_sys::Oid::from(function.0.value() as u32)
+        .try_into()
+        .unwrap();
+    check_user_function_data_type(function);
     Element::MapData {
-        function: PgProcId(pg_sys::Oid::from(function.0.value() as u32)),
+        function: PgProcId(function),
     }
     .flatten()
 }
@@ -194,6 +197,9 @@ pub fn apply_to(
     mut series: Timevector_TSTZ_F64<'_>,
     func: pg_sys::RegProcedure,
 ) -> Timevector_TSTZ_F64<'_> {
+    // Mapping function must be `fn(double precision) RETURNS double precision`.
+    check_user_function_data_type(func);
+
     let mut flinfo: pg_sys::FmgrInfo = unsafe { MaybeUninit::zeroed().assume_init() };
 
     let fn_addr: unsafe extern "C-unwind" fn(
@@ -874,6 +880,75 @@ mod tests {
                 .get_two::<String, String>()
                 .unwrap();
             assert_eq!((&*a.unwrap(), &*b.unwrap()), (one, two));
+        });
+    }
+
+    // Text-built pipeline with a mismatched-signature function must be rejected.
+    #[pg_test]
+    #[should_panic = "invalid argument type"]
+    fn test_pipeline_map_data_signature_bypass() {
+        Spi::connect_mut(|client| {
+            client
+                .update(
+                    "CREATE FUNCTION bypass_target(text) RETURNS text \
+                     AS $$ SELECT $1 $$ LANGUAGE SQL",
+                    None,
+                    &[],
+                )
+                .unwrap();
+            client
+                .update(
+                    "SELECT timevector('2021-01-01'::timestamptz, 1.0) \
+                     -> '(version:1,num_elements:1,elements:\
+                     [MapData(function:\"public.bypass_target(text)\")])'\
+                     ::toolkit_experimental.unstabletimevectorpipeline",
+                    None,
+                    &[],
+                )
+                .unwrap();
+        });
+    }
+
+    #[pg_test]
+    #[should_panic = "invalid argument type"]
+    fn test_pipeline_map_series_signature_bypass() {
+        Spi::connect_mut(|client| {
+            client
+                .update(
+                    "CREATE FUNCTION bypass_series_target(text) RETURNS text \
+                     AS $$ SELECT $1 $$ LANGUAGE SQL",
+                    None,
+                    &[],
+                )
+                .unwrap();
+            client
+                .update(
+                    "SELECT timevector('2021-01-01'::timestamptz, 1.0) \
+                     -> '(version:1,num_elements:1,elements:\
+                     [MapSeries(function:\"public.bypass_series_target(text)\")])'\
+                     ::toolkit_experimental.unstabletimevectorpipeline",
+                    None,
+                    &[],
+                )
+                .unwrap();
+        });
+    }
+
+    // MapData targeting `textout(text)` on an `f64` must be rejected.
+    #[pg_test]
+    #[should_panic = "invalid argument type"]
+    fn test_pipeline_map_data_textout_poc() {
+        Spi::connect_mut(|client| {
+            client
+                .update(
+                    "SELECT timevector('2021-01-01'::timestamptz, 3.14) \
+                     -> '(version:1,num_elements:1,elements:\
+                     [MapData(function:\"pg_catalog.textout(text)\")])'\
+                     ::toolkit_experimental.unstabletimevectorpipeline",
+                    None,
+                    &[],
+                )
+                .unwrap();
         });
     }
 }

--- a/extension/src/type_builder.rs
+++ b/extension/src/type_builder.rs
@@ -612,6 +612,11 @@ macro_rules! ron_inout_funcs {
         $crate::ron_inout_funcs_impl!($name);
     };
 
+    // Pattern 1b: `validated` runs the type's `validate(&self)` on text input.
+    ($name:ident<$lifetime:lifetime>, validated) => {
+        $crate::ron_inout_funcs_validated_impl!($name);
+    };
+
     // Pattern 2: No lifetime parameter → route to ron_inout_funcs_no_lifetime_impl!
     ($name:ident) => {
         $crate::ron_inout_funcs_no_lifetime_impl!($name);
@@ -671,6 +676,38 @@ macro_rules! ron_inout_funcs_impl {
                 let input = str_from_db_encoding(input);
                 let val = ron::from_str(input).unwrap();
                 unsafe { Self(val, $crate::type_builder::CachedDatum::None).flatten() }
+            }
+        }
+    };
+}
+
+// Like `ron_inout_funcs_impl!`, but runs the type's `validate(&self)` on each
+// value parsed from text.
+#[macro_export]
+macro_rules! ron_inout_funcs_validated_impl {
+    ($name:ident) => {
+        impl<'input> InOutFuncs for $name<'input> {
+            fn output(&self, buffer: &mut StringInfo) {
+                use $crate::serialization::{EncodedStr::*, str_to_db_encoding};
+
+                let stringified = ron::to_string(&**self).unwrap();
+                match str_to_db_encoding(&stringified) {
+                    Utf8(s) => buffer.push_str(s),
+                    Other(s) => buffer.push_bytes(s.to_bytes()),
+                }
+            }
+
+            fn input(input: &std::ffi::CStr) -> $name<'input>
+            where
+                Self: Sized,
+            {
+                use $crate::serialization::str_from_db_encoding;
+
+                let input = str_from_db_encoding(input);
+                let val = ron::from_str(input).unwrap();
+                let value = unsafe { Self(val, $crate::type_builder::CachedDatum::None).flatten() };
+                value.validate();
+                value
             }
         }
     };


### PR DESCRIPTION
Both the timevector `map` pipeline elements and the space-saving
(`freq_agg`/`mcv_agg`) aggregates can be built from their text
representation, which let untrusted input diverge from the invariants the
readers rely on, reinterpreting a stored datum as the wrong type.
