### PR TITLE
Change pgrx::* imports to pgrx::prelude::*

### DIFF
--- a/extension/src/accessors.rs
+++ b/extension/src/accessors.rs
@@ -1,4 +1,5 @@
-use pgrx::*;
+use pgrx::prelude::*;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use counter_agg::range::I64Range;
 

--- a/extension/src/accessors.rs
+++ b/extension/src/accessors.rs
@@ -1,4 +1,4 @@
-use pgrx::prelude::*;
+use pgrx::prelude::{InOutFuncs, default, error, pg_extern, pg_sys};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use counter_agg::range::I64Range;

--- a/extension/src/aggregate_builder_tests.rs
+++ b/extension/src/aggregate_builder_tests.rs
@@ -3,7 +3,8 @@
 // function
 use aggregate_builder::aggregate;
 
-use pgrx::*;
+use pgrx::datum::Internal;
+use pgrx::prelude::*;
 
 use crate::{palloc::Inner, raw::bytea};
 

--- a/extension/src/aggregate_builder_tests.rs
+++ b/extension/src/aggregate_builder_tests.rs
@@ -4,7 +4,7 @@
 use aggregate_builder::aggregate;
 
 use pgrx::datum::Internal;
-use pgrx::prelude::*;
+use pgrx::prelude::{pg_schema, pg_sys};
 
 use crate::{palloc::Inner, raw::bytea};
 
@@ -83,7 +83,7 @@ impl toolkit_experimental::parallel_anything {
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {
-    use pgrx::*;
+    use pgrx::{Spi, spi};
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/asap.rs
+++ b/extension/src/asap.rs
@@ -1,5 +1,5 @@
 use asap::*;
-use pgrx::*;
+use pgrx::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/extension/src/asap.rs
+++ b/extension/src/asap.rs
@@ -1,5 +1,5 @@
-use asap::*;
-use pgrx::prelude::*;
+use asap::asap_smooth_with_metadata;
+use pgrx::prelude::{error, extension_sql, pg_extern, pg_sys};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -177,10 +177,10 @@ extension_sql!(
 );
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
     use approx::assert_relative_eq;
-    use pgrx::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/candlestick.rs
+++ b/extension/src/candlestick.rs
@@ -1,4 +1,5 @@
-use pgrx::*;
+use pgrx::prelude::*;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 use serde::{Deserialize, Serialize};
 
 use crate::accessors::{

--- a/extension/src/candlestick.rs
+++ b/extension/src/candlestick.rs
@@ -1,4 +1,4 @@
-use pgrx::prelude::*;
+use pgrx::prelude::{InOutFuncs, error, extension_sql, opname, pg_extern, pg_operator, pg_sys};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 use serde::{Deserialize, Serialize};
 
@@ -512,11 +512,12 @@ pub fn vwap(candlestick: Option<Candlestick>) -> Option<f64> {
 }
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
     use std::ptr;
 
     use super::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     macro_rules! select_one {

--- a/extension/src/counter_agg.rs
+++ b/extension/src/counter_agg.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-use pgrx::*;
+use pgrx::prelude::*;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::{
     accessors::{

--- a/extension/src/counter_agg.rs
+++ b/extension/src/counter_agg.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use pgrx::prelude::*;
+use pgrx::prelude::{InOutFuncs, error, extension_sql, opname, pg_extern, pg_operator, pg_sys};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::{
@@ -15,7 +15,7 @@ use crate::{
     flatten,
     palloc::{Inner, Internal, InternalAsValue, ToInternal},
     pg_type,
-    range::*,
+    range::{I64RangeWrapper, get_range},
     ron_inout_funcs,
 };
 
@@ -24,7 +24,7 @@ use tspoint::TSPoint;
 use counter_agg::{CounterSummaryBuilder, MetricSummary, range::I64Range};
 use stats_agg::stats2d::StatsSummary2D;
 
-use self::Method::*;
+use self::Method::Prometheus;
 
 use crate::raw::tstzrange;
 
@@ -875,12 +875,13 @@ pub fn as_method(method: &str) -> Option<Method> {
 }
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
 
     use super::testing::*;
     use super::*;
     use approx::assert_relative_eq;
+    use pgrx::{Spi, pg_test};
 
     macro_rules! select_one {
         ($client:expr, $stmt:expr, $type:ty) => {

--- a/extension/src/counter_agg/accessors.rs
+++ b/extension/src/counter_agg/accessors.rs
@@ -1,4 +1,5 @@
-use pgrx::*;
+use pgrx::prelude::*;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::{
     counter_agg::{CounterSummary, CounterSummaryData, MetricSummary},

--- a/extension/src/counter_agg/accessors.rs
+++ b/extension/src/counter_agg/accessors.rs
@@ -1,4 +1,4 @@
-use pgrx::prelude::*;
+use pgrx::prelude::{InOutFuncs, error, pg_extern, pg_sys};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::{

--- a/extension/src/countminsketch.rs
+++ b/extension/src/countminsketch.rs
@@ -1,4 +1,5 @@
-use pgrx::*;
+use pgrx::prelude::*;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use aggregate_builder::aggregate;
 use countminsketch::{CountMinHashFn, CountMinSketch as CountMinSketchInternal};

--- a/extension/src/countminsketch.rs
+++ b/extension/src/countminsketch.rs
@@ -1,8 +1,10 @@
-use pgrx::prelude::*;
+use pgrx::prelude::{pg_extern, pg_schema, pg_sys};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use aggregate_builder::aggregate;
 use countminsketch::{CountMinHashFn, CountMinSketch as CountMinSketchInternal};
+
+use toolkit_experimental::CountMinSketch;
 
 use crate::{
     flatten,
@@ -74,8 +76,6 @@ pub mod toolkit_experimental {
     ron_inout_funcs!(CountMinSketch<'input>);
 }
 
-use toolkit_experimental::CountMinSketch;
-
 #[aggregate]
 impl toolkit_experimental::count_min_sketch {
     type State = CountMinSketchInternal;
@@ -135,7 +135,7 @@ pub fn approx_count<'a>(item: String, aggregate: Option<CountMinSketch<'a>>) -> 
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {
-    use super::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/datum_utils.rs
+++ b/extension/src/datum_utils.rs
@@ -12,7 +12,8 @@ use serde::{
 };
 
 use pg_sys::{Datum, Oid};
-use pgrx::*;
+use pgrx::prelude::*;
+use pgrx::{AnyElement, varsize_any};
 
 use crate::serialization::{PgCollationId, ShortTypeId};
 
@@ -661,6 +662,8 @@ mod tests {
     #[pg_schema]
     pub mod toolkit_experimental {
         use super::*;
+        use pgrx::datum::Internal;
+        use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
         pg_type! {
             #[derive(Debug)]
             struct DatumStoreTester<'input> {

--- a/extension/src/datum_utils.rs
+++ b/extension/src/datum_utils.rs
@@ -11,9 +11,11 @@ use serde::{
     ser::SerializeSeq,
 };
 
-use pg_sys::{Datum, Oid};
-use pgrx::prelude::*;
-use pgrx::{AnyElement, varsize_any};
+use pgrx::{
+    AnyElement, FromDatum,
+    pg_sys::{self, Datum, Oid},
+    varsize_any,
+};
 
 use crate::serialization::{PgCollationId, ShortTypeId};
 
@@ -652,14 +654,15 @@ impl<'a> IntoIterator for DatumStore<'a> {
 }
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
     use super::*;
     use crate::{build, palloc::Inner, pg_type, ron_inout_funcs};
-    use aggregate_builder::*;
+    use aggregate_builder::aggregate;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
-    #[pg_schema]
+    #[pgrx::pg_schema]
     pub mod toolkit_experimental {
         use super::*;
         use pgrx::datum::Internal;

--- a/extension/src/frequency.rs
+++ b/extension/src/frequency.rs
@@ -2,10 +2,9 @@
 
 use std::fmt;
 
-use pgrx::{
-    iter::{SetOfIterator, TableIterator},
-    *,
-};
+use pgrx::iter::{SetOfIterator, TableIterator};
+use pgrx::prelude::*;
+use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein, varlena_to_byte_slice};
 
 use pg_sys::{Datum, Oid};
 
@@ -1732,6 +1731,7 @@ unsafe fn varlena_to_string(vl: *const pg_sys::varlena) -> String {
 #[pg_schema]
 mod tests {
     use super::*;
+    use pgrx::{vardata_any, varsize_any_exhdr};
     use pgrx_macros::pg_test;
     use rand::{distr::Uniform, prelude::*};
     use rand_distr::Zeta;

--- a/extension/src/frequency.rs
+++ b/extension/src/frequency.rs
@@ -2,11 +2,15 @@
 
 use std::fmt;
 
-use pgrx::iter::{SetOfIterator, TableIterator};
-use pgrx::prelude::*;
-use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein, varlena_to_byte_slice};
-
-use pg_sys::{Datum, Oid};
+use pgrx::prelude::{
+    FromDatum, InOutFuncs, PgSqlErrorCode, extension_sql, name, opname, pg_extern, pg_operator,
+    pg_sys::{self, Datum, Oid},
+};
+use pgrx::{
+    AnyElement, StringInfo, callconv,
+    iter::{SetOfIterator, TableIterator},
+    nullable, rust_regtypein, varlena_to_byte_slice,
+};
 
 use serde::{
     Deserialize, Serialize,
@@ -1728,10 +1732,10 @@ unsafe fn varlena_to_string(vl: *const pg_sys::varlena) -> String {
 }
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
     use super::*;
-    use pgrx::{vardata_any, varsize_any_exhdr};
+    use pgrx::{Spi, vardata_any, varsize_any_exhdr};
     use pgrx_macros::pg_test;
     use rand::{distr::Uniform, prelude::*};
     use rand_distr::Zeta;

--- a/extension/src/gauge_agg.rs
+++ b/extension/src/gauge_agg.rs
@@ -1,4 +1,5 @@
-use pgrx::*;
+use pgrx::prelude::*;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use serde::{Deserialize, Serialize};
 

--- a/extension/src/gauge_agg.rs
+++ b/extension/src/gauge_agg.rs
@@ -1,4 +1,4 @@
-use pgrx::prelude::*;
+use pgrx::prelude::{InOutFuncs, error, extension_sql, opname, pg_extern, pg_operator, pg_sys};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use serde::{Deserialize, Serialize};
@@ -673,13 +673,14 @@ impl From<MetricSummary> for GaugeSummary {
 }
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
     use pgrx_macros::pg_test;
 
     use crate::counter_agg::testing::*;
 
     use super::*;
+    use pgrx::Spi;
 
     macro_rules! select_one {
         ($client:expr, $stmt:expr, $type:ty) => {

--- a/extension/src/heartbeat_agg.rs
+++ b/extension/src/heartbeat_agg.rs
@@ -1,5 +1,7 @@
+use pgrx::datum::Internal;
 use pgrx::iter::TableIterator;
-use pgrx::*;
+use pgrx::prelude::*;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::{
     accessors::{

--- a/extension/src/heartbeat_agg.rs
+++ b/extension/src/heartbeat_agg.rs
@@ -1,7 +1,8 @@
-use pgrx::datum::Internal;
-use pgrx::iter::TableIterator;
-use pgrx::prelude::*;
-use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
+use pgrx::prelude::{
+    commutator, default, error, extension_sql, name, negator, opname, pg_extern, pg_operator,
+    pg_sys,
+};
+use pgrx::{StringInfo, callconv, datum::Internal, iter::TableIterator, nullable, rust_regtypein};
 
 use crate::{
     accessors::{
@@ -766,9 +767,10 @@ extension_sql!(
 );
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
     use super::*;
+    use pgrx::{Spi, pg_test};
 
     #[pg_test]
     pub fn test_heartbeat_trans_state() {

--- a/extension/src/heartbeat_agg/accessors.rs
+++ b/extension/src/heartbeat_agg/accessors.rs
@@ -1,4 +1,5 @@
-use pgrx::*;
+use pgrx::prelude::*;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::{
     flatten,

--- a/extension/src/heartbeat_agg/accessors.rs
+++ b/extension/src/heartbeat_agg/accessors.rs
@@ -1,4 +1,4 @@
-use pgrx::prelude::*;
+use pgrx::prelude::{InOutFuncs, default, error, pg_extern, pg_sys};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::{

--- a/extension/src/hyperloglog.rs
+++ b/extension/src/hyperloglog.rs
@@ -8,7 +8,8 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use pg_sys::{Datum, Oid};
-use pgrx::*;
+use pgrx::prelude::*;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::{
     accessors::{AccessorDistinctCount, AccessorStderror},
@@ -480,6 +481,7 @@ fn unflatten_log(hyperloglog: HyperLogLog) -> HLL<HashableDatum, DatumHashBuilde
 mod tests {
     use super::*;
 
+    use pgrx::rust_str_to_text_p;
     use pgrx_macros::pg_test;
     use rand::distr::{Distribution, Uniform};
 

--- a/extension/src/hyperloglog.rs
+++ b/extension/src/hyperloglog.rs
@@ -7,8 +7,10 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use pg_sys::{Datum, Oid};
-use pgrx::prelude::*;
+use pgrx::prelude::{
+    error, extension_sql, opname, pg_extern, pg_operator,
+    pg_sys::{self, Datum, Oid},
+};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::{
@@ -477,11 +479,11 @@ fn unflatten_log(hyperloglog: HyperLogLog) -> HLL<HashableDatum, DatumHashBuilde
 }
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
     use super::*;
 
-    use pgrx::rust_str_to_text_p;
+    use pgrx::{IntoDatum, Spi, rust_str_to_text_p};
     use pgrx_macros::pg_test;
     use rand::distr::{Distribution, Uniform};
 

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -54,7 +54,7 @@ mod type_builder;
 #[cfg(any(test, feature = "pg_test"))]
 mod aggregate_builder_tests;
 
-use pgrx::*;
+use pgrx::prelude::*;
 
 pgrx::pg_module_magic!();
 

--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -54,7 +54,7 @@ mod type_builder;
 #[cfg(any(test, feature = "pg_test"))]
 mod aggregate_builder_tests;
 
-use pgrx::prelude::*;
+use pgrx::prelude::{extension_sql, pg_guard, pg_sys};
 
 pgrx::pg_module_magic!();
 

--- a/extension/src/lttb.rs
+++ b/extension/src/lttb.rs
@@ -1,4 +1,4 @@
-use pgrx::*;
+use pgrx::prelude::*;
 use std::borrow::Cow;
 
 use crate::{

--- a/extension/src/lttb.rs
+++ b/extension/src/lttb.rs
@@ -1,4 +1,4 @@
-use pgrx::prelude::*;
+use pgrx::prelude::{error, extension_sql, pg_extern, pg_sys};
 use std::borrow::Cow;
 
 use crate::{
@@ -431,9 +431,9 @@ pub fn lttb_ts(data: Timevector_TSTZ_F64, threshold: usize) -> Timevector_TSTZ_F
 }
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
-    use pgrx::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/nmost.rs
+++ b/extension/src/nmost.rs
@@ -1,4 +1,4 @@
-use pgrx::*;
+use pgrx::prelude::*;
 
 use serde::{Deserialize, Serialize};
 

--- a/extension/src/nmost.rs
+++ b/extension/src/nmost.rs
@@ -1,4 +1,4 @@
-use pgrx::prelude::*;
+use pgrx::prelude::pg_sys;
 
 use serde::{Deserialize, Serialize};
 

--- a/extension/src/nmost/max_by_float.rs
+++ b/extension/src/nmost/max_by_float.rs
@@ -1,4 +1,5 @@
-use pgrx::{iter::TableIterator, *};
+use pgrx::iter::TableIterator;
+use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::max_float::*;
 use crate::nmost::*;

--- a/extension/src/nmost/max_by_float.rs
+++ b/extension/src/nmost/max_by_float.rs
@@ -1,4 +1,5 @@
 use pgrx::iter::TableIterator;
+use pgrx::prelude::*;
 use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::max_float::*;

--- a/extension/src/nmost/max_by_float.rs
+++ b/extension/src/nmost/max_by_float.rs
@@ -1,9 +1,12 @@
 use pgrx::iter::TableIterator;
-use pgrx::prelude::*;
+use pgrx::prelude::{InOutFuncs, extension_sql, name, pg_extern, pg_sys};
 use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
-use crate::nmost::max_float::*;
-use crate::nmost::*;
+use crate::nmost::max_float::{MaxFloats, MaxFloatsData};
+use crate::nmost::{
+    DatumStore, NMostByTransState, nmost_by_rollup_trans_function, nmost_by_trans_function,
+    validate_nmost_by_dummy_type, validate_nmost_by_parts,
+};
 
 use crate::{
     build, flatten,
@@ -157,9 +160,9 @@ extension_sql!(
 );
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
-    use super::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/nmost/max_by_int.rs
+++ b/extension/src/nmost/max_by_int.rs
@@ -1,4 +1,5 @@
-use pgrx::{iter::TableIterator, *};
+use pgrx::iter::TableIterator;
+use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::max_int::*;
 use crate::nmost::*;

--- a/extension/src/nmost/max_by_int.rs
+++ b/extension/src/nmost/max_by_int.rs
@@ -1,4 +1,5 @@
 use pgrx::iter::TableIterator;
+use pgrx::prelude::*;
 use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::max_int::*;

--- a/extension/src/nmost/max_by_int.rs
+++ b/extension/src/nmost/max_by_int.rs
@@ -1,9 +1,12 @@
 use pgrx::iter::TableIterator;
-use pgrx::prelude::*;
+use pgrx::prelude::{InOutFuncs, extension_sql, name, pg_extern, pg_sys};
 use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
-use crate::nmost::max_int::*;
-use crate::nmost::*;
+use crate::nmost::max_int::{MaxInts, MaxIntsData};
+use crate::nmost::{
+    DatumStore, NMostByTransState, nmost_by_rollup_trans_function, nmost_by_trans_function,
+    validate_nmost_by_dummy_type, validate_nmost_by_parts,
+};
 
 use crate::{
     build, flatten,
@@ -156,9 +159,9 @@ extension_sql!(
 );
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
-    use super::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/nmost/max_by_time.rs
+++ b/extension/src/nmost/max_by_time.rs
@@ -1,4 +1,5 @@
 use pgrx::iter::TableIterator;
+use pgrx::prelude::*;
 use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::max_time::*;

--- a/extension/src/nmost/max_by_time.rs
+++ b/extension/src/nmost/max_by_time.rs
@@ -1,4 +1,5 @@
-use pgrx::{iter::TableIterator, *};
+use pgrx::iter::TableIterator;
+use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::max_time::*;
 use crate::nmost::*;

--- a/extension/src/nmost/max_by_time.rs
+++ b/extension/src/nmost/max_by_time.rs
@@ -1,9 +1,12 @@
 use pgrx::iter::TableIterator;
-use pgrx::prelude::*;
+use pgrx::prelude::{InOutFuncs, extension_sql, name, pg_extern, pg_sys};
 use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
-use crate::nmost::max_time::*;
-use crate::nmost::*;
+use crate::nmost::max_time::{MaxTimes, MaxTimesData};
+use crate::nmost::{
+    DatumStore, NMostByTransState, nmost_by_rollup_trans_function, nmost_by_trans_function,
+    validate_nmost_by_dummy_type, validate_nmost_by_parts,
+};
 
 use crate::{
     build, flatten,
@@ -163,9 +166,9 @@ extension_sql!(
 );
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
-    use super::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/nmost/max_float.rs
+++ b/extension/src/nmost/max_float.rs
@@ -1,4 +1,5 @@
-use pgrx::{iter::SetOfIterator, *};
+use pgrx::iter::SetOfIterator;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::*;
 

--- a/extension/src/nmost/max_float.rs
+++ b/extension/src/nmost/max_float.rs
@@ -1,4 +1,5 @@
 use pgrx::iter::SetOfIterator;
+use pgrx::prelude::*;
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::*;

--- a/extension/src/nmost/max_float.rs
+++ b/extension/src/nmost/max_float.rs
@@ -1,8 +1,10 @@
 use pgrx::iter::SetOfIterator;
-use pgrx::prelude::*;
+use pgrx::prelude::{extension_sql, opname, pg_extern, pg_operator, pg_sys};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
-use crate::nmost::*;
+use crate::nmost::{
+    NMostTransState, nmost_rollup_trans_function, nmost_trans_combine, nmost_trans_function,
+};
 
 use crate::{
     accessors::{AccessorIntoArray, AccessorIntoValues},
@@ -191,9 +193,9 @@ extension_sql!(
 );
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
-    use super::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/nmost/max_int.rs
+++ b/extension/src/nmost/max_int.rs
@@ -1,4 +1,5 @@
-use pgrx::{iter::SetOfIterator, *};
+use pgrx::iter::SetOfIterator;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::*;
 

--- a/extension/src/nmost/max_int.rs
+++ b/extension/src/nmost/max_int.rs
@@ -1,4 +1,5 @@
 use pgrx::iter::SetOfIterator;
+use pgrx::prelude::*;
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::*;

--- a/extension/src/nmost/max_int.rs
+++ b/extension/src/nmost/max_int.rs
@@ -1,8 +1,10 @@
 use pgrx::iter::SetOfIterator;
-use pgrx::prelude::*;
+use pgrx::prelude::{extension_sql, opname, pg_extern, pg_operator, pg_sys};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
-use crate::nmost::*;
+use crate::nmost::{
+    NMostTransState, nmost_rollup_trans_function, nmost_trans_combine, nmost_trans_function,
+};
 
 use crate::{
     accessors::{AccessorIntoArray, AccessorIntoValues},
@@ -182,9 +184,9 @@ extension_sql!(
 );
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
-    use super::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/nmost/max_time.rs
+++ b/extension/src/nmost/max_time.rs
@@ -1,4 +1,5 @@
-use pgrx::{iter::SetOfIterator, *};
+use pgrx::iter::SetOfIterator;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::*;
 

--- a/extension/src/nmost/max_time.rs
+++ b/extension/src/nmost/max_time.rs
@@ -1,4 +1,5 @@
 use pgrx::iter::SetOfIterator;
+use pgrx::prelude::*;
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::*;

--- a/extension/src/nmost/max_time.rs
+++ b/extension/src/nmost/max_time.rs
@@ -1,8 +1,10 @@
 use pgrx::iter::SetOfIterator;
-use pgrx::prelude::*;
+use pgrx::prelude::{extension_sql, opname, pg_extern, pg_operator, pg_sys};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
-use crate::nmost::*;
+use crate::nmost::{
+    NMostTransState, nmost_rollup_trans_function, nmost_trans_combine, nmost_trans_function,
+};
 
 use crate::{
     accessors::{AccessorIntoArray, AccessorIntoValues},
@@ -197,9 +199,9 @@ extension_sql!(
 );
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
-    use super::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/nmost/min_by_float.rs
+++ b/extension/src/nmost/min_by_float.rs
@@ -1,4 +1,5 @@
-use pgrx::{iter::TableIterator, *};
+use pgrx::iter::TableIterator;
+use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::min_float::*;
 use crate::nmost::*;

--- a/extension/src/nmost/min_by_float.rs
+++ b/extension/src/nmost/min_by_float.rs
@@ -1,4 +1,5 @@
 use pgrx::iter::TableIterator;
+use pgrx::prelude::*;
 use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::min_float::*;

--- a/extension/src/nmost/min_by_float.rs
+++ b/extension/src/nmost/min_by_float.rs
@@ -1,9 +1,12 @@
 use pgrx::iter::TableIterator;
-use pgrx::prelude::*;
+use pgrx::prelude::{InOutFuncs, extension_sql, name, pg_extern, pg_sys};
 use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
-use crate::nmost::min_float::*;
-use crate::nmost::*;
+use crate::nmost::min_float::{MinFloats, MinFloatsData};
+use crate::nmost::{
+    DatumStore, NMostByTransState, nmost_by_rollup_trans_function, nmost_by_trans_function,
+    validate_nmost_by_dummy_type, validate_nmost_by_parts,
+};
 
 use crate::{
     build, flatten,
@@ -156,9 +159,9 @@ extension_sql!(
 );
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
-    use super::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/nmost/min_by_int.rs
+++ b/extension/src/nmost/min_by_int.rs
@@ -1,4 +1,5 @@
 use pgrx::iter::TableIterator;
+use pgrx::prelude::*;
 use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::min_int::*;

--- a/extension/src/nmost/min_by_int.rs
+++ b/extension/src/nmost/min_by_int.rs
@@ -1,4 +1,5 @@
-use pgrx::{iter::TableIterator, *};
+use pgrx::iter::TableIterator;
+use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::min_int::*;
 use crate::nmost::*;

--- a/extension/src/nmost/min_by_int.rs
+++ b/extension/src/nmost/min_by_int.rs
@@ -1,9 +1,12 @@
 use pgrx::iter::TableIterator;
-use pgrx::prelude::*;
+use pgrx::prelude::{InOutFuncs, extension_sql, name, pg_extern, pg_sys};
 use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
-use crate::nmost::min_int::*;
-use crate::nmost::*;
+use crate::nmost::min_int::{MinInts, MinIntsData};
+use crate::nmost::{
+    DatumStore, NMostByTransState, nmost_by_rollup_trans_function, nmost_by_trans_function,
+    validate_nmost_by_dummy_type, validate_nmost_by_parts,
+};
 
 use crate::{
     build, flatten,
@@ -143,9 +146,9 @@ extension_sql!(
 );
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
-    use super::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/nmost/min_by_time.rs
+++ b/extension/src/nmost/min_by_time.rs
@@ -1,4 +1,5 @@
-use pgrx::{iter::TableIterator, *};
+use pgrx::iter::TableIterator;
+use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::min_time::*;
 use crate::nmost::*;

--- a/extension/src/nmost/min_by_time.rs
+++ b/extension/src/nmost/min_by_time.rs
@@ -1,4 +1,5 @@
 use pgrx::iter::TableIterator;
+use pgrx::prelude::*;
 use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::min_time::*;

--- a/extension/src/nmost/min_by_time.rs
+++ b/extension/src/nmost/min_by_time.rs
@@ -1,9 +1,12 @@
 use pgrx::iter::TableIterator;
-use pgrx::prelude::*;
+use pgrx::prelude::{InOutFuncs, extension_sql, name, pg_extern, pg_sys};
 use pgrx::{AnyElement, StringInfo, callconv, nullable, rust_regtypein};
 
-use crate::nmost::min_time::*;
-use crate::nmost::*;
+use crate::nmost::min_time::{MinTimes, MinTimesData};
+use crate::nmost::{
+    DatumStore, NMostByTransState, nmost_by_rollup_trans_function, nmost_by_trans_function,
+    validate_nmost_by_dummy_type, validate_nmost_by_parts,
+};
 
 use crate::{
     build, flatten,
@@ -150,9 +153,9 @@ extension_sql!(
 );
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
-    use super::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/nmost/min_float.rs
+++ b/extension/src/nmost/min_float.rs
@@ -1,4 +1,5 @@
-use pgrx::{iter::SetOfIterator, *};
+use pgrx::iter::SetOfIterator;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::*;
 

--- a/extension/src/nmost/min_float.rs
+++ b/extension/src/nmost/min_float.rs
@@ -1,4 +1,5 @@
 use pgrx::iter::SetOfIterator;
+use pgrx::prelude::*;
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::*;

--- a/extension/src/nmost/min_float.rs
+++ b/extension/src/nmost/min_float.rs
@@ -1,8 +1,10 @@
 use pgrx::iter::SetOfIterator;
-use pgrx::prelude::*;
+use pgrx::prelude::{extension_sql, opname, pg_extern, pg_operator, pg_sys};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
-use crate::nmost::*;
+use crate::nmost::{
+    NMostTransState, nmost_rollup_trans_function, nmost_trans_combine, nmost_trans_function,
+};
 
 use crate::{
     accessors::{AccessorIntoArray, AccessorIntoValues},
@@ -190,9 +192,9 @@ extension_sql!(
 );
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
-    use super::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/nmost/min_int.rs
+++ b/extension/src/nmost/min_int.rs
@@ -1,4 +1,5 @@
-use pgrx::{iter::SetOfIterator, *};
+use pgrx::iter::SetOfIterator;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::*;
 

--- a/extension/src/nmost/min_int.rs
+++ b/extension/src/nmost/min_int.rs
@@ -1,4 +1,5 @@
 use pgrx::iter::SetOfIterator;
+use pgrx::prelude::*;
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::*;

--- a/extension/src/nmost/min_int.rs
+++ b/extension/src/nmost/min_int.rs
@@ -1,8 +1,10 @@
 use pgrx::iter::SetOfIterator;
-use pgrx::prelude::*;
+use pgrx::prelude::{extension_sql, opname, pg_extern, pg_operator, pg_sys};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
-use crate::nmost::*;
+use crate::nmost::{
+    NMostTransState, nmost_rollup_trans_function, nmost_trans_combine, nmost_trans_function,
+};
 
 use crate::{
     accessors::{AccessorIntoArray, AccessorIntoValues},
@@ -174,9 +176,9 @@ extension_sql!(
 );
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
-    use super::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/nmost/min_time.rs
+++ b/extension/src/nmost/min_time.rs
@@ -1,4 +1,5 @@
-use pgrx::{iter::SetOfIterator, *};
+use pgrx::iter::SetOfIterator;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::*;
 

--- a/extension/src/nmost/min_time.rs
+++ b/extension/src/nmost/min_time.rs
@@ -1,4 +1,5 @@
 use pgrx::iter::SetOfIterator;
+use pgrx::prelude::*;
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::nmost::*;

--- a/extension/src/nmost/min_time.rs
+++ b/extension/src/nmost/min_time.rs
@@ -1,8 +1,10 @@
 use pgrx::iter::SetOfIterator;
-use pgrx::prelude::*;
+use pgrx::prelude::{extension_sql, opname, pg_extern, pg_operator, pg_sys};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
-use crate::nmost::*;
+use crate::nmost::{
+    NMostTransState, nmost_rollup_trans_function, nmost_trans_combine, nmost_trans_function,
+};
 
 use crate::{
     accessors::{AccessorIntoArray, AccessorIntoValues},
@@ -188,9 +190,9 @@ extension_sql!(
 );
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
-    use super::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/palloc.rs
+++ b/extension/src/palloc.rs
@@ -4,7 +4,7 @@ use std::{
     ptr::NonNull,
 };
 
-use pgrx::*;
+use pgrx::prelude::*;
 
 pub unsafe fn in_memory_context<T, F: FnOnce() -> T>(mctx: pg_sys::MemoryContext, f: F) -> T {
     let prev_ctx = unsafe { pg_sys::CurrentMemoryContext };

--- a/extension/src/palloc.rs
+++ b/extension/src/palloc.rs
@@ -4,7 +4,7 @@ use std::{
     ptr::NonNull,
 };
 
-use pgrx::prelude::*;
+use pgrx::prelude::pg_sys;
 
 pub unsafe fn in_memory_context<T, F: FnOnce() -> T>(mctx: pg_sys::MemoryContext, f: F) -> T {
     let prev_ctx = unsafe { pg_sys::CurrentMemoryContext };

--- a/extension/src/pg_any_element.rs
+++ b/extension/src/pg_any_element.rs
@@ -4,7 +4,8 @@ use std::{
     mem::size_of,
 };
 
-use pgrx::*;
+use pgrx::AnyElement;
+use pgrx::prelude::*;
 
 use pg_sys::{Datum, Oid};
 

--- a/extension/src/pg_any_element.rs
+++ b/extension/src/pg_any_element.rs
@@ -5,9 +5,7 @@ use std::{
 };
 
 use pgrx::AnyElement;
-use pgrx::prelude::*;
-
-use pg_sys::{Datum, Oid};
+use pgrx::prelude::pg_sys::{self, Datum, Oid};
 
 use crate::datum_utils::{DatumHashBuilder, deep_copy_datum};
 

--- a/extension/src/raw.rs
+++ b/extension/src/raw.rs
@@ -1,6 +1,7 @@
 #![allow(non_camel_case_types)]
 
-use pgrx::*;
+use pgrx::prelude::*;
+use pgrx::{callconv, nullable};
 use pgrx_sql_entity_graph::metadata::{
     ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable, TypeOrigin,
 };

--- a/extension/src/raw.rs
+++ b/extension/src/raw.rs
@@ -1,6 +1,6 @@
 #![allow(non_camel_case_types)]
 
-use pgrx::prelude::*;
+use pgrx::prelude::{FromDatum, IntoDatum, extension_sql, pg_sys};
 use pgrx::{callconv, nullable};
 use pgrx_sql_entity_graph::metadata::{
     ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable, TypeOrigin,

--- a/extension/src/saturation.rs
+++ b/extension/src/saturation.rs
@@ -1,6 +1,6 @@
 //! Saturating Math for Integers
 
-use pgrx::*;
+use pgrx::prelude::*;
 
 /// Computes x+y, saturating at the numeric bounds instead of overflowing
 #[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]

--- a/extension/src/saturation.rs
+++ b/extension/src/saturation.rs
@@ -1,6 +1,6 @@
 //! Saturating Math for Integers
 
-use pgrx::prelude::*;
+use pgrx::prelude::pg_extern;
 
 /// Computes x+y, saturating at the numeric bounds instead of overflowing
 #[pg_extern(schema = "toolkit_experimental", immutable, parallel_safe)]
@@ -35,7 +35,7 @@ fn saturating_mul(x: i32, y: i32) -> i32 {
 }
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
     use super::*;
     use pgrx_macros::pg_test;

--- a/extension/src/serialization.rs
+++ b/extension/src/serialization.rs
@@ -6,7 +6,7 @@ use std::{
     os::raw::{c_char, c_int},
 };
 
-use pgrx::pg_sys::{self};
+use pgrx::pg_sys;
 
 use std::ffi::CStr;
 

--- a/extension/src/serialization/collations.rs
+++ b/extension/src/serialization/collations.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use once_cell::sync::Lazy;
 
 use pg_sys::Oid;
-use pgrx::*;
+use pgrx::prelude::*;
 
 // TODO short collation serializer?
 

--- a/extension/src/serialization/collations.rs
+++ b/extension/src/serialization/collations.rs
@@ -11,8 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use once_cell::sync::Lazy;
 
-use pg_sys::Oid;
-use pgrx::prelude::*;
+use pgrx::prelude::pg_sys::{self, Oid};
 
 // TODO short collation serializer?
 
@@ -255,7 +254,7 @@ unsafe fn get_struct<T>(tuple: pg_sys::HeapTuple) -> *mut T {
 }
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
 
     use super::PgCollationId;

--- a/extension/src/serialization/functions.rs
+++ b/extension/src/serialization/functions.rs
@@ -10,7 +10,7 @@ use flat_serialize::{FlatSerializable, WrapErr, impl_flat_serializable};
 use serde::{Deserialize, Serialize};
 
 use pg_sys::{Datum, Oid};
-use pgrx::*;
+use pgrx::prelude::*;
 
 /// `PgProcId` provides provides the ability to serialize and deserialize
 /// regprocedures as `namespace.name(args)`

--- a/extension/src/serialization/functions.rs
+++ b/extension/src/serialization/functions.rs
@@ -9,8 +9,7 @@ use flat_serialize::{FlatSerializable, WrapErr, impl_flat_serializable};
 
 use serde::{Deserialize, Serialize};
 
-use pg_sys::{Datum, Oid};
-use pgrx::prelude::*;
+use pgrx::pg_sys::{self, Datum, Oid};
 
 /// `PgProcId` provides provides the ability to serialize and deserialize
 /// regprocedures as `namespace.name(args)`

--- a/extension/src/serialization/types.rs
+++ b/extension/src/serialization/types.rs
@@ -9,7 +9,7 @@ use flat_serialize::{FlatSerializable, WrapErr, impl_flat_serializable};
 use serde::{Deserialize, Serialize};
 
 use pg_sys::Oid;
-use pgrx::*;
+use pgrx::prelude::*;
 
 /// Possibly a premature optimization, `ShortTypId` provides the ability to
 /// serialize and deserialize type Oids as `(namespace, name)` pairs, special

--- a/extension/src/serialization/types.rs
+++ b/extension/src/serialization/types.rs
@@ -8,8 +8,7 @@ use flat_serialize::{FlatSerializable, WrapErr, impl_flat_serializable};
 
 use serde::{Deserialize, Serialize};
 
-use pg_sys::Oid;
-use pgrx::prelude::*;
+use pgrx::pg_sys::{self, Oid};
 
 /// Possibly a premature optimization, `ShortTypId` provides the ability to
 /// serialize and deserialize type Oids as `(namespace, name)` pairs, special
@@ -317,7 +316,7 @@ unsafe fn get_struct<T>(tuple: pg_sys::HeapTuple) -> *mut T {
 }
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
 
     use super::{PgTypId, ShortTypeId};

--- a/extension/src/stabilization_tests.rs
+++ b/extension/src/stabilization_tests.rs
@@ -1,5 +1,5 @@
 #[cfg(any(test, feature = "pg_test"))]
-use pgrx::*;
+use pgrx::prelude::*;
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]

--- a/extension/src/stabilization_tests.rs
+++ b/extension/src/stabilization_tests.rs
@@ -1,12 +1,12 @@
 #[cfg(any(test, feature = "pg_test"))]
-use pgrx::prelude::*;
+use pgrx::prelude::pg_schema;
 
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {
     use std::collections::HashSet;
 
-    use pgrx::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     // Test that any new features are added to the the experimental schema

--- a/extension/src/state_aggregate.rs
+++ b/extension/src/state_aggregate.rs
@@ -6,7 +6,9 @@
 
 #![allow(non_camel_case_types)]
 
-use pgrx::{iter::TableIterator, *};
+use pgrx::iter::TableIterator;
+use pgrx::prelude::*;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 

--- a/extension/src/state_aggregate.rs
+++ b/extension/src/state_aggregate.rs
@@ -6,9 +6,8 @@
 
 #![allow(non_camel_case_types)]
 
-use pgrx::iter::TableIterator;
-use pgrx::prelude::*;
-use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
+use pgrx::prelude::{default, extension_sql, opname, pg_extern, pg_operator, pg_schema, pg_sys};
+use pgrx::{StringInfo, callconv, iter::TableIterator, nullable, rust_regtypein};
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 
@@ -30,7 +29,13 @@ use crate::{
 use toolkit_experimental::{CompactStateAgg, CompactStateAggData};
 
 mod accessors;
-use accessors::*;
+use accessors::{
+    AccessorDurationIn, AccessorDurationInInt, AccessorDurationInRange, AccessorDurationInRangeInt,
+    AccessorInterpolatedDurationIn, AccessorInterpolatedDurationInInt,
+    AccessorInterpolatedStateIntTimeline, AccessorInterpolatedStatePeriods,
+    AccessorInterpolatedStatePeriodsInt, AccessorInterpolatedStateTimeline, AccessorStateAt,
+    AccessorStateAtInt, AccessorStatePeriods, AccessorStatePeriodsInt,
+};
 pub mod rollup;
 
 /// The data of a state.
@@ -1852,6 +1857,7 @@ mod tests {
     use std::sync::atomic::Ordering::Relaxed;
 
     use super::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     macro_rules! select_one {

--- a/extension/src/state_aggregate/accessors.rs
+++ b/extension/src/state_aggregate/accessors.rs
@@ -3,8 +3,11 @@ use crate::{
     pg_type,
     raw::{Interval, TimestampTz},
     ron_inout_funcs,
-    state_aggregate::*,
+    state_aggregate::{NO_INTERVAL_MARKER, StateAgg, StateAggData},
 };
+
+use pgrx::prelude::{InOutFuncs, default, error, pg_extern, pg_sys};
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 pg_type! {
     struct AccessorInterpolatedStateTimeline<'input> {

--- a/extension/src/stats_agg.rs
+++ b/extension/src/stats_agg.rs
@@ -1,4 +1,5 @@
-use pgrx::*;
+use pgrx::prelude::*;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::{
     accessors::{
@@ -1489,6 +1490,7 @@ pub fn as_method(method: &str) -> Option<Method> {
 mod tests {
     use super::*;
     use approx::relative_eq;
+    use pgrx::varlena_to_byte_slice;
 
     use pgrx_macros::pg_test;
     use rand::prelude::*;

--- a/extension/src/stats_agg.rs
+++ b/extension/src/stats_agg.rs
@@ -1,4 +1,7 @@
-use pgrx::prelude::*;
+use pgrx::prelude::{
+    InOutFuncs, PgSqlErrorCode, default, error, extension_sql, opname, pg_extern, pg_operator,
+    pg_sys,
+};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::{
@@ -19,7 +22,7 @@ pub use stats_agg::stats1d::StatsSummary1D as InternalStatsSummary1D;
 pub use stats_agg::stats2d::StatsSummary2D as InternalStatsSummary2D;
 use stats_agg::{StatsError, XYPair};
 
-use crate::stats_agg::Method::*;
+use crate::stats_agg::Method::{Population, Sample};
 use stats_agg::TwoFloat;
 
 use crate::raw::bytea;
@@ -1486,11 +1489,11 @@ pub fn as_method(method: &str) -> Option<Method> {
 // }
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
     use super::*;
     use approx::relative_eq;
-    use pgrx::varlena_to_byte_slice;
+    use pgrx::{Spi, varlena_to_byte_slice, warning};
 
     use pgrx_macros::pg_test;
     use rand::prelude::*;

--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -1,6 +1,7 @@
 use std::{convert::TryInto, ops::Deref};
 
-use pgrx::*;
+use pgrx::prelude::*;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::{
     accessors::{

--- a/extension/src/tdigest.rs
+++ b/extension/src/tdigest.rs
@@ -1,6 +1,6 @@
 use std::{convert::TryInto, ops::Deref};
 
-use pgrx::prelude::*;
+use pgrx::prelude::{InOutFuncs, extension_sql, opname, pg_extern, pg_operator, pg_sys};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::{
@@ -427,10 +427,10 @@ pub fn tdigest_sum(digest: TDigest<'_>) -> f64 {
 }
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
     use super::*;
-
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     // Assert equality between two floats, within some fixed error range.

--- a/extension/src/time_vector.rs
+++ b/extension/src/time_vector.rs
@@ -2,7 +2,9 @@
 
 use crate::pg_sys::timestamptz_to_str;
 use core::str::Utf8Error;
-use pgrx::{iter::TableIterator, *};
+use pgrx::iter::TableIterator;
+use pgrx::prelude::*;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 use std::ffi::CStr;
 use tera::{Context, Tera};
 

--- a/extension/src/time_vector.rs
+++ b/extension/src/time_vector.rs
@@ -2,9 +2,11 @@
 
 use crate::pg_sys::timestamptz_to_str;
 use core::str::Utf8Error;
-use pgrx::iter::TableIterator;
-use pgrx::prelude::*;
-use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
+use pgrx::prelude::{
+    FromDatum, InOutFuncs, IntoDatum, PgBuiltInOids, error, extension_sql, name, opname, pg_extern,
+    pg_operator, pg_schema, pg_sys,
+};
+use pgrx::{StringInfo, callconv, iter::TableIterator, nullable, rust_regtypein};
 use std::ffi::CStr;
 use tera::{Context, Tera};
 
@@ -19,7 +21,7 @@ use tspoint::TSPoint;
 
 pub use iter::Iter;
 
-use flat_serialize::*;
+use flat_serialize::FlatSerializable;
 
 mod iter;
 mod pipeline;
@@ -526,7 +528,7 @@ pub fn arrow_timevector_asof<'a>(
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {
-    use pgrx::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/time_vector/iter.rs
+++ b/extension/src/time_vector/iter.rs
@@ -1,6 +1,6 @@
 use tspoint::TSPoint;
 
-use Iter::*;
+use Iter::Slice;
 
 pub enum Iter<'a> {
     Slice {

--- a/extension/src/time_vector/pipeline.rs
+++ b/extension/src/time_vector/pipeline.rs
@@ -10,7 +10,8 @@ mod sort;
 
 use std::convert::TryInto;
 
-use pgrx::*;
+use pgrx::prelude::*;
+use pgrx::{PgList, is_a};
 
 use super::*;
 

--- a/extension/src/time_vector/pipeline.rs
+++ b/extension/src/time_vector/pipeline.rs
@@ -10,7 +10,6 @@ mod sort;
 
 use std::convert::TryInto;
 
-use pgrx::prelude::*;
 use pgrx::{PgList, is_a};
 
 use super::*;
@@ -325,7 +324,7 @@ pub fn lttb_pipeline_element(
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {
-    use pgrx::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/time_vector/pipeline/aggregation.rs
+++ b/extension/src/time_vector/pipeline/aggregation.rs
@@ -1,6 +1,6 @@
 use std::mem::take;
 
-use pgrx::*;
+use pgrx::prelude::*;
 
 use counter_agg::CounterSummaryBuilder;
 

--- a/extension/src/time_vector/pipeline/aggregation.rs
+++ b/extension/src/time_vector/pipeline/aggregation.rs
@@ -1,7 +1,5 @@
 use std::mem::take;
 
-use pgrx::prelude::*;
-
 use counter_agg::CounterSummaryBuilder;
 
 use super::*;
@@ -752,7 +750,7 @@ ALTER FUNCTION "arrow_run_pipeline_then_percentile_agg" SUPPORT toolkit_experime
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {
-    use pgrx::*;
+    use pgrx::{PgSqlErrorCode, Spi, pg_sys};
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/time_vector/pipeline/arithmetic.rs
+++ b/extension/src/time_vector/pipeline/arithmetic.rs
@@ -1,4 +1,4 @@
-use pgrx::*;
+use pgrx::prelude::*;
 
 use super::*;
 

--- a/extension/src/time_vector/pipeline/arithmetic.rs
+++ b/extension/src/time_vector/pipeline/arithmetic.rs
@@ -1,9 +1,10 @@
-use pgrx::prelude::*;
-
 use super::*;
 
 use super::Element::Arithmetic;
-use Function::*;
+use Function::{
+    Abs, Add, Cbrt, Ceil, Div, Floor, Ln, Log10, LogN, Mod, Mul, Power, Round, Sign, Sqrt, Sub,
+    Trunc,
+};
 
 #[derive(
     Debug, Copy, Clone, flat_serialize_macro::FlatSerializable, serde::Serialize, serde::Deserialize,
@@ -288,7 +289,7 @@ pub fn pipeline_trunc() -> toolkit_experimental::UnstableTimevectorPipeline<'sta
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {
-    use pgrx::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/time_vector/pipeline/delta.rs
+++ b/extension/src/time_vector/pipeline/delta.rs
@@ -1,4 +1,4 @@
-use pgrx::*;
+use pgrx::prelude::*;
 
 use super::*;
 

--- a/extension/src/time_vector/pipeline/delta.rs
+++ b/extension/src/time_vector/pipeline/delta.rs
@@ -1,5 +1,3 @@
-use pgrx::prelude::*;
-
 use super::*;
 
 use crate::accessors::AccessorDelta;
@@ -62,7 +60,7 @@ pub fn timevector_delta<'s>(series: &Timevector_TSTZ_F64<'s>) -> Timevector_TSTZ
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {
-    use pgrx::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/time_vector/pipeline/expansion.rs
+++ b/extension/src/time_vector/pipeline/expansion.rs
@@ -1,6 +1,7 @@
 use std::mem::take;
 
-use pgrx::{iter::TableIterator, *};
+use pgrx::iter::TableIterator;
+use pgrx::prelude::*;
 
 use super::*;
 

--- a/extension/src/time_vector/pipeline/expansion.rs
+++ b/extension/src/time_vector/pipeline/expansion.rs
@@ -1,7 +1,6 @@
 use std::mem::take;
 
 use pgrx::iter::TableIterator;
-use pgrx::prelude::*;
 
 use super::*;
 
@@ -175,7 +174,7 @@ ALTER FUNCTION "arrow_run_pipeline_then_materialize" SUPPORT toolkit_experimenta
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {
-    use pgrx::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/time_vector/pipeline/fill_to.rs
+++ b/extension/src/time_vector/pipeline/fill_to.rs
@@ -1,4 +1,4 @@
-use pgrx::*;
+use pgrx::prelude::*;
 
 use flat_serialize_macro::FlatSerializable;
 

--- a/extension/src/time_vector/pipeline/fill_to.rs
+++ b/extension/src/time_vector/pipeline/fill_to.rs
@@ -1,5 +1,3 @@
-use pgrx::prelude::*;
-
 use flat_serialize_macro::FlatSerializable;
 
 use serde::{Deserialize, Serialize};
@@ -141,7 +139,7 @@ pub fn fill_to<'s>(
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {
-    use pgrx::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/time_vector/pipeline/filter.rs
+++ b/extension/src/time_vector/pipeline/filter.rs
@@ -1,4 +1,4 @@
-use pgrx::*;
+use pgrx::prelude::*;
 
 use super::*;
 

--- a/extension/src/time_vector/pipeline/filter.rs
+++ b/extension/src/time_vector/pipeline/filter.rs
@@ -1,5 +1,3 @@
-use pgrx::prelude::*;
-
 use super::*;
 
 // TODO is (stable, parallel_safe) correct?
@@ -59,7 +57,7 @@ pub fn filter_lambda_over_series(
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {
-    use pgrx::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/time_vector/pipeline/lambda.rs
+++ b/extension/src/time_vector/pipeline/lambda.rs
@@ -1,9 +1,7 @@
 use std::borrow::Cow;
 
-use pgrx::{
-    iter::{SetOfIterator, TableIterator},
-    *,
-};
+use pgrx::iter::{SetOfIterator, TableIterator};
+use pgrx::prelude::*;
 
 use super::*;
 

--- a/extension/src/time_vector/pipeline/lambda.rs
+++ b/extension/src/time_vector/pipeline/lambda.rs
@@ -1,7 +1,8 @@
 use std::borrow::Cow;
 
+use Value::{Bool, Double, Time, Tuple};
 use pgrx::iter::{SetOfIterator, TableIterator};
-use pgrx::prelude::*;
+use std::mem::discriminant;
 
 use super::*;
 
@@ -352,9 +353,6 @@ impl Value {
 
 impl PartialOrd for Value {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        use Value::*;
-        use std::mem::discriminant;
-
         // XXX `NodeTag` somewhere inside `pg_sys::FunctionCallInfo` triggers
         // `improper_ctypes` lint. The `pgrx` author explains the issue in
         // details here:
@@ -376,7 +374,7 @@ impl PartialOrd for Value {
             (Double(l0), Double(r0)) => l0.partial_cmp(r0),
             (Time(l0), Time(r0)) => l0.partial_cmp(r0),
             (Tuple(l0), Tuple(r0)) => l0.partial_cmp(r0),
-            (Interval(l0), Interval(r0)) => unsafe {
+            (Value::Interval(l0), Value::Interval(r0)) => unsafe {
                 let res = pg_sys::DirectFunctionCall2Coll(
                     Some(interval_cmp),
                     pg_sys::InvalidOid,
@@ -408,7 +406,7 @@ impl PartialEq for Value {
             (Double(l0), Double(r0)) => l0 == r0,
             (Time(l0), Time(r0)) => l0 == r0,
             (Tuple(l0), Tuple(r0)) => l0 == r0,
-            (Interval(l0), Interval(r0)) => unsafe {
+            (Value::Interval(l0), Value::Interval(r0)) => unsafe {
                 let res = pg_sys::DirectFunctionCall2Coll(
                     Some(interval_eq),
                     pg_sys::InvalidOid,

--- a/extension/src/time_vector/pipeline/lambda/executor.rs
+++ b/extension/src/time_vector/pipeline/lambda/executor.rs
@@ -1,4 +1,4 @@
-use pgrx::*;
+use pgrx::prelude::*;
 
 use super::*;
 

--- a/extension/src/time_vector/pipeline/lambda/executor.rs
+++ b/extension/src/time_vector/pipeline/lambda/executor.rs
@@ -1,6 +1,17 @@
-use pgrx::prelude::*;
-
 use super::*;
+
+use BinOp::{And, Div, Eq, Ge, Gt, Le, Lt, Minus, Mul, Neq, Or, Plus, Pow};
+use ExpressionSegment::{
+    Binary, BuildTuple, DoubleConstant, FunctionCall, IntervalConstant, TimeConstant, TimeVar,
+    Unary, UserVar, ValueVar,
+};
+use Function::{
+    Abs, Acos, Acosh, Asin, Asinh, Atan, Atan2, Atanh, Cbrt, Ceil, Cos, Cosh, Floor, Ln, Log,
+    Log10, Pi, Round, Sign, Sin, Sinh, Sqrt, Tan, Tanh, Trunc,
+};
+use Type::Double;
+use Type::{Interval, Time};
+use UnaryOp::{Negative, Not};
 
 pub struct ExpressionExecutor<'e, T> {
     exprs: &'e Expression,
@@ -50,7 +61,6 @@ where
         time: i64,
         // trace_function: impl FnMut(&ExpressionSegment, &Value),
     ) -> Value {
-        use ExpressionSegment::*;
         let res = match expr {
             ValueVar => Value::Double(value),
             TimeVar => Value::Time(time),
@@ -94,7 +104,6 @@ where
         value: f64,
         time: i64,
     ) -> Value {
-        use Function::*;
         macro_rules! unary_function {
             ($func:ident ( )) => {{
                 let then = self.exec_expression(&args[0], value, time).float();
@@ -150,8 +159,6 @@ where
         value: f64,
         time: i64,
     ) -> Value {
-        use Type::*;
-        use UnaryOp::*;
         match op {
             Not => {
                 let val = self.exec_expression(expr, value, time).bool();
@@ -179,9 +186,6 @@ where
         value: f64,
         time: i64,
     ) -> Value {
-        use BinOp::*;
-        use Type::*;
-
         // FIXME pgrx wraps all functions in rust wrappers, which makes them
         //       uncallable with DirectFunctionCall(). Is there a way to
         //       export both?

--- a/extension/src/time_vector/pipeline/lambda/parser.rs
+++ b/extension/src/time_vector/pipeline/lambda/parser.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashMap, ffi::CString};
 
-use pgrx::*;
+use pgrx::prelude::*;
 
 use super::*;
 

--- a/extension/src/time_vector/pipeline/lambda/parser.rs
+++ b/extension/src/time_vector/pipeline/lambda/parser.rs
@@ -2,8 +2,6 @@
 
 use std::{collections::HashMap, ffi::CString};
 
-use pgrx::prelude::*;
-
 use super::*;
 
 use pest::{
@@ -12,10 +10,22 @@ use pest::{
     prec_climber::{Assoc, Operator, PrecClimber},
 };
 
-use ExpressionSegment::*;
-use Rule::*;
-use Type::*;
-use UnaryOp::*;
+use Assoc::{Left, Right};
+use ExpressionSegment::{
+    Binary, BuildTuple, DoubleConstant, FunctionCall, IntervalConstant, TimeConstant, TimeVar,
+    Unary, UserVar, ValueVar,
+};
+use Function::{
+    Abs, Acos, Acosh, Asin, Asinh, Atan, Atan2, Atanh, Cbrt, Ceil, Cos, Cosh, Floor, Ln, Log,
+    Log10, Pi, Round, Sign, Sin, Sinh, Sqrt, Tan, Tanh, Trunc,
+};
+use Rule::{
+    EOI, WHITESPACE, add, and, binops, calculation, divide, eq, function, function_name, ge, gt,
+    int, interval, le, let_expr, lt, multiply, neg, neq, not, num, operation, or, power, string,
+    subtract, term, time, time_var, tuple, unary, val_var, var,
+};
+use Type::{Bool, Double, Tuple};
+use UnaryOp::{Negative, Not};
 
 // Idealized expression grammar ignoring precedence
 // ```
@@ -411,8 +421,6 @@ fn parse_interval(val: &str) -> *mut pg_sys::Interval {
 
 // This static determines the precedence of infix operators
 static PREC_CLIMBER: once_cell::sync::Lazy<PrecClimber<Rule>> = once_cell::sync::Lazy::new(|| {
-    use Assoc::*;
-
     // operators according to their precedence, ordered in a vector
     // from lowest to highest. Multiple operators with the same precedence are
     // joined with `|`
@@ -435,7 +443,6 @@ static PREC_CLIMBER: once_cell::sync::Lazy<PrecClimber<Rule>> = once_cell::sync:
 // Maps function name to a tuple (num arguments, function identifier)
 static BUILTIN_FUNCTION: once_cell::sync::Lazy<HashMap<&str, (usize, Function)>> =
     once_cell::sync::Lazy::new(|| {
-        use Function::*;
         [
             ("abs", (1, Abs)),
             ("cbrt", (1, Cbrt)),

--- a/extension/src/time_vector/pipeline/map.rs
+++ b/extension/src/time_vector/pipeline/map.rs
@@ -3,7 +3,7 @@ use std::{
     ptr,
 };
 
-use pgrx::*;
+use pgrx::prelude::*;
 
 use super::*;
 

--- a/extension/src/time_vector/pipeline/map.rs
+++ b/extension/src/time_vector/pipeline/map.rs
@@ -1,9 +1,9 @@
+use lambda::Value::{Double, Time, Tuple};
+use std::panic::AssertUnwindSafe;
 use std::{
     mem::{self, ManuallyDrop, MaybeUninit},
     ptr,
 };
-
-use pgrx::prelude::*;
 
 use super::*;
 
@@ -47,7 +47,6 @@ pub fn apply_lambda_to<'a>(
     let mut executor = lambda::ExpressionExecutor::new(&expression);
 
     let invoke = |time: i64, value: f64| {
-        use lambda::Value::*;
         executor.reset();
         let result = executor.exec(value, time);
         match result {
@@ -242,8 +241,6 @@ pub fn apply_to(
 }
 
 pub fn map_series(series: &mut Timevector_TSTZ_F64<'_>, mut func: impl FnMut(f64) -> f64) {
-    use std::panic::AssertUnwindSafe;
-
     let points = series.points.as_owned().iter_mut();
     // setjump guard around the loop to reduce the amount we have to
     // call it
@@ -263,7 +260,7 @@ pub fn map_series(series: &mut Timevector_TSTZ_F64<'_>, mut func: impl FnMut(f64
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {
-    use pgrx::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/time_vector/pipeline/sort.rs
+++ b/extension/src/time_vector/pipeline/sort.rs
@@ -1,4 +1,4 @@
-use pgrx::*;
+use pgrx::prelude::*;
 
 use super::*;
 

--- a/extension/src/time_vector/pipeline/sort.rs
+++ b/extension/src/time_vector/pipeline/sort.rs
@@ -1,5 +1,3 @@
-use pgrx::prelude::*;
-
 use super::*;
 
 // TODO is (immutable, parallel_safe) correct?
@@ -60,7 +58,7 @@ pub fn sort_timevector(mut series: Timevector_TSTZ_F64<'_>) -> Timevector_TSTZ_F
 #[cfg(any(test, feature = "pg_test"))]
 #[pg_schema]
 mod tests {
-    use pgrx::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]

--- a/extension/src/time_weighted_average.rs
+++ b/extension/src/time_weighted_average.rs
@@ -1,6 +1,7 @@
 #![allow(non_camel_case_types)]
 
-use pgrx::*;
+use pgrx::prelude::*;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/extension/src/time_weighted_average.rs
+++ b/extension/src/time_weighted_average.rs
@@ -1,6 +1,8 @@
 #![allow(non_camel_case_types)]
 
-use pgrx::prelude::*;
+use pgrx::prelude::{
+    InOutFuncs, default, error, extension_sql, opname, pg_extern, pg_operator, pg_sys,
+};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 use serde::{Deserialize, Serialize};
 
@@ -580,9 +582,10 @@ pub fn arrow_time_weighted_average_interpolated_integral(
 }
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
     use super::*;
+    use pgrx::Spi;
 
     use pgrx_macros::pg_test;
     macro_rules! select_one {

--- a/extension/src/time_weighted_average/accessors.rs
+++ b/extension/src/time_weighted_average/accessors.rs
@@ -1,4 +1,5 @@
-use pgrx::*;
+use pgrx::prelude::*;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::time_weighted_average::DurationUnit;
 use crate::{

--- a/extension/src/time_weighted_average/accessors.rs
+++ b/extension/src/time_weighted_average/accessors.rs
@@ -1,4 +1,4 @@
-use pgrx::prelude::*;
+use pgrx::prelude::{InOutFuncs, default, error, pg_extern, pg_sys};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use crate::time_weighted_average::DurationUnit;

--- a/extension/src/type_builder.rs
+++ b/extension/src/type_builder.rs
@@ -339,7 +339,7 @@ macro_rules! pg_type_impl {
                     };
                     let (data, _) = match unsafe { [<$name Data>]::try_ref(bytes) } {
                         Ok(wrapped) => wrapped,
-                        Err(e) => error!(concat!("invalid ", stringify!($name), " {:?}, got len {}"), e, bytes.len()),
+                        Err(e) => pgrx::error!(concat!("invalid ", stringify!($name), " {:?}, got len {}"), e, bytes.len()),
                     };
 
                     $name(data, $crate::type_builder::CachedDatum::FromInput(bytes)).into()
@@ -656,7 +656,7 @@ macro_rules! ron_inout_funcs_no_lifetime_impl {
 #[macro_export]
 macro_rules! ron_inout_funcs_impl {
     ($name:ident) => {
-        impl<'input> InOutFuncs for $name<'input> {
+        impl<'input> pgrx::InOutFuncs for $name<'input> {
             fn output(&self, buffer: &mut StringInfo) {
                 use $crate::serialization::{EncodedStr::*, str_to_db_encoding};
 

--- a/extension/src/uddsketch.rs
+++ b/extension/src/uddsketch.rs
@@ -1,4 +1,5 @@
-use pgrx::*;
+use pgrx::prelude::*;
+use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use encodings::{delta, prefix_varint};
 

--- a/extension/src/uddsketch.rs
+++ b/extension/src/uddsketch.rs
@@ -1,4 +1,4 @@
-use pgrx::prelude::*;
+use pgrx::prelude::{InOutFuncs, extension_sql, opname, pg_extern, pg_operator, pg_sys};
 use pgrx::{StringInfo, callconv, nullable, rust_regtypein};
 
 use encodings::{delta, prefix_varint};
@@ -691,9 +691,10 @@ pub fn uddsketch_error<'a>(sketch: UddSketch<'a>) -> f64 {
 }
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
     use super::*;
+    use pgrx::Spi;
 
     use pgrx_macros::pg_test;
 

--- a/extension/src/utilities.rs
+++ b/extension/src/utilities.rs
@@ -1,5 +1,5 @@
 use crate::raw::TimestampTz;
-use pgrx::prelude::*;
+use pgrx::prelude::{TableIterator, extension_sql, name, pg_extern};
 
 #[pg_extern(
     name = "generate_periodic_normal_series",
@@ -124,9 +124,9 @@ $$;
 );
 
 #[cfg(any(test, feature = "pg_test"))]
-#[pg_schema]
+#[pgrx::pg_schema]
 mod tests {
-    use pgrx::*;
+    use pgrx::Spi;
     use pgrx_macros::pg_test;
 
     #[pg_test]


### PR DESCRIPTION
Following #586, this PR changes `pgrx::*` to `pgrx::prelude::*`, avoiding scope pollution for the importer and making it clearer where items come from.