### PR TITLE
Fix upgrade tests

### DIFF
--- a/tools/build
+++ b/tools/build
@@ -26,7 +26,7 @@ require_pg_version() {
 find_pg_config() {
     if [ -z "$pg_config" ]; then
         require_pg_version
-        pg_config=`which $(sed -ne 's/"//g' -e "s/^pg$pg_version *= *//p" ~/.pgrx/config.toml)`
+        pg_config=`command -v $(sed -ne 's/"//g' -e "s/^pg$pg_version *= *//p" ~/.pgrx/config.toml)`
     fi
     [ -x "$pg_config" ] || die "$pg_config not executable"
 }

--- a/tools/testbin
+++ b/tools/testbin
@@ -224,10 +224,7 @@ cmp_version() {
 }
 
 print_upgradeable_from() {
-    # TODO We never shipped a 1.4 deb and the 1.5 deb is called 1.5.0
-    #  Let's draw the line there and remove those from upgradeable_from.
-    #  Someone who needs to upgrade from 1.4 or 1.5 can upgrade to 1.10.1 and then beyond.
-    sed -n "s/'//g; s/,//g; s/^# upgradeable_from = 1\.4 1\.5 //p" $CONTROL
+    sed -n "s/'//g; s/,//g; s/^# upgradeable_from = //p" $CONTROL
 }
 
 cleanup() {
@@ -245,8 +242,11 @@ run() {
     [ -d "$BINDIR" ] || die '-bindir required'
     [ -n "$TOOLKIT_VERSION" ] || die '-version required'
 
+    FROM_VERSIONS=`print_upgradeable_from`
+    [ -n "$FROM_VERSIONS" ] || die "no versions parsed from upgradeable_from in $CONTROL"
+
     trap cleanup 0
-    test_$1 `print_upgradeable_from`
+    test_$1 $FROM_VERSIONS
     trap - 0
 
     echo DONE

--- a/tools/testbin
+++ b/tools/testbin
@@ -96,6 +96,9 @@ skip_from_version() {
     [ $FROM_VERSION = 1.10.0-dev ] && return
     [ $OS_NAME = debian ] && [ $OS_VERSION = 10 ] && [ `cmp_version $FROM_VERSION` -lt 011100 ] && return
     [ $OS_NAME = ubuntu ] && [ $OS_VERSION = 22.04 ] && [ `cmp_version $FROM_VERSION` -lt 010600 ] && return
+    [ $OS_NAME = debian ] && [ $OS_VERSION = 13 ] && [ `cmp_version $FROM_VERSION` -lt 012100 ] && return
+    [ $OS_NAME = ubuntu ] && [ $OS_VERSION = 26.04 ] && [ `cmp_version $FROM_VERSION` -lt 012300 ] && return
+    [ $OS_NAME = rockylinux ] && [ $OS_VERSION = 10 ] && [ `cmp_version $FROM_VERSION` -lt 012300 ] && return
 }
 
 # Requires:
@@ -105,6 +108,7 @@ skip_from_version_pg_version() {
     # skip versions without binaries for this PostgreSQL version
     [ $PG_VERSION -gt 14 ] && [ `cmp_version $FROM_VERSION` -lt 011301 ] && return
     [ $PG_VERSION -gt 15 ] && [ `cmp_version $FROM_VERSION` -lt 011801 ] && return
+    [ $PG_VERSION -gt 17 ] && [ `cmp_version $FROM_VERSION` -lt 012200 ] && return
 }
 
 # Requires:

--- a/tools/update-tester/src/main.rs
+++ b/tools/update-tester/src/main.rs
@@ -150,11 +150,15 @@ fn main() {
                     .num_args(1)
             )
 	)
-// Mutates help, removing the short flag (-h) so that it can be used by HOST
-	.mut_arg("help", |_h| {
-      Arg::new("help")
-          .long("help")
-  })
+        // Mutates help, removing the short flag (-h) so that it can be used by HOST
+        .disable_help_flag(true)
+        .arg(
+            Arg::new("help")
+                .long("help")
+                .action(clap::ArgAction::Help)
+                .global(true)
+                .help("Print help")
+        )
 	.get_matches();
 
     match matches.subcommand() {

--- a/tools/update-tester/src/testrunner.rs
+++ b/tools/update-tester/src/testrunner.rs
@@ -458,6 +458,7 @@ fn get_values(query_results: Vec<SimpleQueryMessage>) -> QueryValues {
                 }
                 Some(values)
             }
+            SimpleQueryMessage::RowDescription(_) => None,
             _ => unreachable!(),
         })
         .collect()
@@ -479,6 +480,7 @@ pub fn validate_output(output: Vec<SimpleQueryMessage>, test: &Test) -> Result<(
                 rows.push(row);
             }
             CommandComplete(_) => {}
+            RowDescription(_) => {}
             _ => unreachable!(),
         }
     }

--- a/tools/update-tester/src/testrunner.rs
+++ b/tools/update-tester/src/testrunner.rs
@@ -245,23 +245,7 @@ impl TestClient {
                 db_creation_client
                     .simple_query(&drop)
                     .unwrap_or_else(|e| panic!("could not drop db {test_db_name} due to {e}"));
-                let locale_flags = {
-                    match std::process::Command::new("locale").arg("-a").output() {
-                        Ok(cmd)
-                            if String::from_utf8_lossy(&cmd.stdout)
-                                .lines()
-                                .any(|l| l == "C.UTF-8") =>
-                        {
-                            "LC_COLLATE 'C.UTF-8' LC_CTYPE 'C.UTF-8'"
-                        }
-                        _ => "LC_COLLATE 'C' LC_CTYPE 'C'",
-                    }
-                };
-                // template0 is required when the requested collation differs
-                // from the collation of the default template database.
-                let create = format!(
-                    r#"CREATE DATABASE "{test_db_name}" {locale_flags} TEMPLATE template0"#,
-                );
+                let create = format!(r#"CREATE DATABASE "{test_db_name}""#,);
                 db_creation_client
                     .simple_query(&create)
                     .unwrap_or_else(|e| panic!("could not create db {test_db_name} due to {e}"));

--- a/tools/update-tester/src/testrunner.rs
+++ b/tools/update-tester/src/testrunner.rs
@@ -257,7 +257,11 @@ impl TestClient {
                         _ => "LC_COLLATE 'C' LC_CTYPE 'C'",
                     }
                 };
-                let create = format!(r#"CREATE DATABASE "{test_db_name}" {locale_flags}"#,);
+                // template0 is required when the requested collation differs
+                // from the collation of the default template database.
+                let create = format!(
+                    r#"CREATE DATABASE "{test_db_name}" {locale_flags} TEMPLATE template0"#,
+                );
                 db_creation_client
                     .simple_query(&create)
                     .unwrap_or_else(|e| panic!("could not create db {test_db_name} due to {e}"));


### PR DESCRIPTION
Looks like it was broken more than 3 years ago, because we removed the support for the old versions we're using as a cutoff for something we can upgrade from.

Broken after this change: https://github.com/timescale/timescaledb-toolkit/pull/743

Additionally, the update tester code needs a fix to support this dependencies update: https://github.com/timescale/timescaledb-toolkit/pull/935