### PR TITLE
fix: raise PostgreSQL ERROR on OOM instead of unwinding out of the allocator

### DIFF
--- a/extension/src/lib.rs
+++ b/extension/src/lib.rs
@@ -60,7 +60,7 @@ pgrx::pg_module_magic!();
 
 #[pg_guard]
 pub extern "C-unwind" fn _PG_init() {
-    // Nothing to do here
+    crate::palloc::record_pg_main_thread();
 }
 
 extension_sql!(

--- a/extension/src/palloc.rs
+++ b/extension/src/palloc.rs
@@ -124,17 +124,110 @@ unsafe impl<T> ToInternal for *const T {
 // likelihood of aborts.
 //
 // [1] `oom=panic` tracking issue: https://github.com/rust-lang/rust/issues/43596
+//
+// Update (2026): on rustc >= 1.93, the panic!() approach aborts the whole
+// backend. The second out-of-memory panic that unwinds out of the global
+// allocator in one backend fails with "fatal runtime error: failed to
+// initiate panic" (bisected: 1.92 unwinds correctly, 1.93 aborts). An
+// unwind out of GlobalAlloc is documented undefined behavior, `-Zoom=panic`
+// was removed in 1.94, and `set_alloc_error_hook` is still nightly-only, so
+// no stable panic-based design exists. Instead, on the backend main thread
+// (recorded in _PG_init) we now report the error the way PostgreSQL C code
+// does: errstart/errfinish longjmp to the error handler and abort the
+// transaction without unwinding Rust frames. The skipped frames leak their
+// allocations on this path, which is acceptable. Other threads keep the
+// panic fallback. PostgreSQL's ErrorContext has a preallocated reserve, so
+// the report also works under genuine memory exhaustion.
 struct PanickingAllocator;
 
 #[global_allocator]
 static ALLOCATOR: PanickingAllocator = PanickingAllocator;
+
+// pgrx does not expose these in pg_sys (it routes errors through its
+// panic-based ereport! macro, which is exactly what we cannot use here).
+// Resolve them at runtime with dlsym: a link-time reference would make
+// the `cargo pgrx test` harness executable fail to link, because unlike
+// the extension cdylib it cannot have undefined symbols.
+unsafe extern "C" {
+    fn dlsym(
+        handle: *mut ::core::ffi::c_void,
+        symbol: *const ::core::ffi::c_char,
+    ) -> *mut ::core::ffi::c_void;
+}
+
+#[cfg(target_os = "macos")]
+const RTLD_DEFAULT: *mut ::core::ffi::c_void = -2isize as *mut ::core::ffi::c_void;
+#[cfg(not(target_os = "macos"))]
+const RTLD_DEFAULT: *mut ::core::ffi::c_void = std::ptr::null_mut();
+
+type Errstart = unsafe extern "C" fn(::core::ffi::c_int, *const ::core::ffi::c_char) -> bool;
+type Errcode = unsafe extern "C" fn(::core::ffi::c_int) -> ::core::ffi::c_int;
+type Errmsg = unsafe extern "C" fn(*const ::core::ffi::c_char, ...) -> ::core::ffi::c_int;
+type Errfinish = unsafe extern "C" fn(
+    *const ::core::ffi::c_char,
+    ::core::ffi::c_int,
+    *const ::core::ffi::c_char,
+);
+
+/// The PostgreSQL backend's main thread, recorded in _PG_init.
+static PG_MAIN_THREAD: std::sync::OnceLock<std::thread::ThreadId> = std::sync::OnceLock::new();
+
+/// Record the current thread as the PostgreSQL main thread.
+/// Call from _PG_init, which PostgreSQL runs on the backend's thread.
+pub fn record_pg_main_thread() {
+    let _ = PG_MAIN_THREAD.set(std::thread::current().id());
+}
+
+fn on_pg_main_thread() -> bool {
+    PG_MAIN_THREAD.get() == Some(&std::thread::current().id())
+}
+
+/// Raise a PostgreSQL "Out of memory" ERROR, which longjmps to the active
+/// error handler and aborts the transaction. Never unwinds Rust frames, so
+/// it is safe to call from inside the global allocator.
+unsafe fn pg_oom_error() -> ! {
+    unsafe {
+        let errstart = dlsym(RTLD_DEFAULT, c"errstart".as_ptr());
+        let errcode = dlsym(RTLD_DEFAULT, c"errcode".as_ptr());
+        let errmsg = dlsym(RTLD_DEFAULT, c"errmsg".as_ptr());
+        let errfinish = dlsym(RTLD_DEFAULT, c"errfinish".as_ptr());
+        if !errstart.is_null() && !errcode.is_null() && !errmsg.is_null() && !errfinish.is_null() {
+            let errstart: Errstart = std::mem::transmute(errstart);
+            let errcode: Errcode = std::mem::transmute(errcode);
+            let errmsg: Errmsg = std::mem::transmute(errmsg);
+            let errfinish: Errfinish = std::mem::transmute(errfinish);
+            if errstart(
+                pg_sys::elog::PgLogLevel::ERROR as ::core::ffi::c_int,
+                std::ptr::null(),
+            ) {
+                errcode(
+                    pg_sys::errcodes::PgSqlErrorCode::ERRCODE_OUT_OF_MEMORY as ::core::ffi::c_int,
+                );
+                errmsg(c"Out of memory".as_ptr());
+                errfinish(c"palloc.rs".as_ptr(), 0, std::ptr::null());
+            }
+        }
+    }
+    // errfinish never returns for ERROR; only reachable outside a real
+    // PostgreSQL backend or if errstart refused the report.
+    std::process::abort()
+}
+
+/// Handle an allocation failure: PostgreSQL ERROR on the main thread,
+/// Rust panic elsewhere.
+unsafe fn oom() -> ! {
+    if on_pg_main_thread() {
+        unsafe { pg_oom_error() }
+    }
+    panic!("Out of memory")
+}
 
 unsafe impl GlobalAlloc for PanickingAllocator {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         unsafe {
             let p = System.alloc(layout);
             if p.is_null() {
-                panic!("Out of memory")
+                oom()
             }
             p
         }
@@ -148,7 +241,7 @@ unsafe impl GlobalAlloc for PanickingAllocator {
         unsafe {
             let p = System.alloc_zeroed(layout);
             if p.is_null() {
-                panic!("Out of memory")
+                oom()
             }
             p
         }
@@ -158,7 +251,7 @@ unsafe impl GlobalAlloc for PanickingAllocator {
         unsafe {
             let p = System.realloc(ptr, layout, new_size);
             if p.is_null() {
-                panic!("Out of memory")
+                oom()
             }
             p
         }


### PR DESCRIPTION
## Problem

`palloc.rs` turns a failed allocation into a Rust `panic!` from inside `GlobalAlloc`. On rustc 1.93 and later, this design aborts the whole backend: the first OOM panic unwinds and becomes a clean transaction abort, but the second one in the same backend fails with `fatal runtime error: failed to initiate panic`, and PostgreSQL restarts. A toolchain bisect shows 1.92 unwinds correctly and 1.93 aborts (the suspected trigger is the allocator/TLS rework in rust-lang/rust#144465). This repo pins rust 1.96.0 (`tools/dependencies.sh`), so the abort is reachable today.

There is no stable panic-based replacement: an unwind out of `GlobalAlloc` is [documented undefined behavior](https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html), `-Zoom=panic` was removed in Rust 1.94, and `set_alloc_error_hook` (rust-lang/rust#51245) is still nightly-only.

## Change

On the backend main thread (recorded in `_PG_init`), the allocator now reports OOM the way PostgreSQL C code does. It calls `errstart`/`errcode`/`errmsg`/`errfinish`, which longjmp to the active PostgreSQL error handler and abort the transaction. No Rust frames unwind, so the rustc limitation does not apply. PostgreSQL keeps a preallocated reserve in its ErrorContext, so the report also works under genuine memory exhaustion.

Trade-offs and edges:

- The longjmp skips Rust frames without running their destructors, so allocations owned by those frames leak. On the OOM path this is acceptable, and it is strictly better than a backend abort plus a PostgreSQL restart.
- Threads other than the backend main thread keep the previous `panic!` fallback.
- The `err*` symbols are declared locally because pgrx does not expose them in `pg_sys` (pgrx routes errors through its panic-based `ereport!` macro, which is exactly the mechanism that cannot be used inside the allocator).
